### PR TITLE
asm_templates: bug fixes, projection_T_asm, tests, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,15 @@
 *.dir
 
 __pycache__
+
+# Generated assembly / machine-code artifacts from codegen tests and runs
+generated_*.asm
+generated_*.mem
+*.asm
+*.mem
+
+# Allow hand-authored assembly templates / fixtures that live inside source dirs
+!asm_templates/**/*.asm
+!asm_templates/**/*.mem
+!**/tests/**/*.asm
+!**/tests/**/*.mem

--- a/asm_templates/__init__.py
+++ b/asm_templates/__init__.py
@@ -7,7 +7,7 @@ from .gelu_asm import gelu_asm
 from .normalization_asm import layer_norm_asm, rms_norm_asm
 from .preload_act import preload_act_asm
 from .preload_addr_reg import preload_addr_reg_asm
-from .projection_asm import projection_asm
+from .projection_asm import projection_asm, projection_T_asm
 from .reset_reg_asm import reset_fpreg_asm, reset_reg_asm
 from .silu_asm import silu_asm
 from .gemv_asm import gemv_asm
@@ -26,6 +26,7 @@ __all__ = [
     "preload_act_asm",
     "preload_addr_reg_asm",
     "projection_asm",
+    "projection_T_asm",
     "reset_fpreg_asm",
     "reset_reg_asm",
     "rms_norm_asm",

--- a/asm_templates/_imm.py
+++ b/asm_templates/_imm.py
@@ -1,0 +1,54 @@
+"""Helpers for loading large integer immediates into GP registers.
+
+S_ADDI_INT only encodes 18-bit immediates (0..2^18-1). Anything larger needs
+S_LUI_INT (which writes `imm << 12` into the destination) optionally followed
+by an S_ADDI_INT for the lower 12 bits.
+
+These helpers were previously duplicated in projection_asm, ffn_asm and
+preload_act with subtly different signatures and thresholds; this module is
+the single source of truth.
+"""
+
+from __future__ import annotations
+
+IMM2_BOUND = 1 << 18  # S_ADDI_INT supports values 0..2^18-1
+
+
+def load_large_int(reg: int, value: int) -> list[str]:
+    """Return ASM lines that load `value` into gp{reg}.
+
+    For values < 2^18, emits a single S_ADDI_INT from gp0.
+    For values >= 2^18, emits S_LUI_INT (sets gp{reg} = imm << 12) followed
+    by an S_ADDI_INT for the low 12 bits when non-zero.
+    """
+    if value < IMM2_BOUND:
+        return [f"S_ADDI_INT gp{reg}, gp0, {value}"]
+    upper = value >> 12
+    lower = value & 0xFFF
+    lines = [f"S_LUI_INT gp{reg}, {upper}"]
+    if lower:
+        lines.append(f"S_ADDI_INT gp{reg}, gp{reg}, {lower}")
+    return lines
+
+
+def addi_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> list[str]:
+    """Return ASM lines for `gp{dest_reg} = gp{src_reg} + value`.
+
+    For values < 2^18 a single S_ADDI_INT is enough. Larger values are first
+    materialised into `gp{temp_reg}` via load_large_int, then added.
+    """
+    if value < IMM2_BOUND:
+        return [f"S_ADDI_INT gp{dest_reg}, gp{src_reg}, {value}"]
+    lines = load_large_int(temp_reg, value)
+    lines.append(f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}")
+    return lines
+
+
+def load_large_int_str(reg: int, value: int) -> str:
+    """String variant: each instruction terminated with a newline."""
+    return "".join(line + "\n" for line in load_large_int(reg, value))
+
+
+def addi_large_int_str(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> str:
+    """String variant of addi_large_int."""
+    return "".join(line + "\n" for line in addi_large_int(dest_reg, src_reg, value, temp_reg))

--- a/asm_templates/batched_matmul_asm.py
+++ b/asm_templates/batched_matmul_asm.py
@@ -45,38 +45,78 @@ def batched_matmul_asm(
     w_actual_register = alive_registers[1]
     result_actual_register = alive_registers[2]
 
+    k_tiles = k // mlen  # number of k-dimension tiles
+    n_tiles = n // blen  # total n-dimension tiles
+    tiles_per_mlen = mlen // blen  # n-tiles that fit in one matrix SRAM bank width
+    n_groups = n // mlen  # number of mlen-wide column groups
+    stride_len = n // mlen  # VRAM row stride for mm_wo (N/mlen vectors per result row)
+
     generated_code += f"S_ADDI_INT gp{result_actual_register}, gp0, {result_base_address} \n"
     for batch in range(1, b + 1):
-        # preload the activation matrix
-        for i in range(math.ceil(n // blen)):
-            assert w_prefetch_amount >= k, "w_prefetch_amount must be greater than or equal to k"
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {m * k * batch} \n"
-            generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {n} \n"
-            generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-            generated_code += (
-                f"H_PREFETCH_M gp{w_actual_register}, gp{w_actual_register}, a{w_base_hbm_offset_reg}, 1, 0 \n"
-            )
-
-            for j in range(math.ceil(m // blen)):
-                if j == 0:
-                    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {k * n * batch} \n"
-                    generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
-                    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {k} \n"
-                    generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
-                    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-                if j % math.ceil((a_prefetch_amount * mlen) // k) == 0:
+        batch_offset = (batch - 1) * m * n
+        for i in range(n_tiles):
+            # --- Weight prefetch: reload matrix SRAM when starting a new mlen-wide group ---
+            if i % tiles_per_mlen == 0:
+                assert w_prefetch_amount >= k, "w_prefetch_amount must be greater than or equal to k"
+                # Set scale and stride for weight matrix prefetch
+                # Weight layout in HBM: (B, K, N), scale = K*N per batch, stride = N
+                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {b * k * n} \n"
+                generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
+                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {n} \n"
+                generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
+                # Prefetch all k-tiles of weight into separate matrix SRAM banks
+                # HBM column offset for this n-group
+                n_group_col_offset = (i // tiles_per_mlen) * mlen
+                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
+                generated_code += (
+                    f"S_ADDI_INT gp{a_actual_register}, gp0, {(batch - 1) * k * n + n_group_col_offset} \n"
+                )
+                for g in range(k_tiles):
                     generated_code += (
-                        f"H_PREFETCH_V gp{a_actual_register}, gp{a_actual_register}, a{a_base_hbm_offset_reg}, 1, 0 \n"
+                        f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{w_base_hbm_offset_reg}, 1, 0 \n"
                     )
-                    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, 0 \n"
-                for g in range(math.ceil(k // mlen)):
+                    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
+                    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * n} \n"
+
+                # Set scale and stride for activation prefetch
+                # Activation layout in HBM: (B, M, K), scale = M*K per batch, stride = K
+                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {b * m * k} \n"
+                generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
+                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {k} \n"
+                generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
+
+            # Column offset within the current matrix SRAM bank
+            col_offset = (i % tiles_per_mlen) * blen
+
+            for j in range(m // blen):
+                # Prefetch all k-tiles of this j-tile's activation rows into VRAM.
+                # For batch b (1-indexed), j-tile j, k-tile g:
+                #   HBM element byte offset = (batch-1)*M*K + j*blen*K + g*mlen
+                #   VRAM dest (element addr) = g*blen*mlen
+                hbm_j_base = (batch - 1) * m * k + j * blen * k
+                for g in range(k_tiles):
+                    vram_dest = g * blen * mlen
+                    hbm_g_off = hbm_j_base + g * mlen
+                    generated_code += f"S_ADDI_INT gp{result_actual_register}, gp0, {vram_dest} \n"
+                    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, {hbm_g_off} \n"
+                    generated_code += f"H_PREFETCH_V gp{result_actual_register}, gp{a_actual_register}, a{a_base_hbm_offset_reg}, 1, 0 \n"
+                # Set weight register to column offset within the first bank
+                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {col_offset} \n"
+                # M_MM for each k-tile; a_reg explicitly set to k-tile's VRAM address
+                for g in range(k_tiles):
+                    a_vram = g * blen * mlen
+                    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, {a_vram} \n"
                     generated_code += f"M_MM 0, gp{w_actual_register}, gp{a_actual_register} \n"
-                    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen * mlen} \n"
-                    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {blen * mlen} \n"
-                generated_code += f"M_MM_WO {result_actual_register}, gp0, 0 \n"
-                generated_code += f"S_ADDI_INT gp{result_actual_register}, gp0, {j * n + i * blen} \n"
+                    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
+                # Set result address BEFORE M_MM_WO:
+                # v_addr = result_base + batch_offset + j*blen*n + (i//tiles_per_mlen)*mlen + (i%tiles_per_mlen)*blen
+                result_addr = (
+                    result_base_address + batch_offset + j * blen * n + (i // tiles_per_mlen) * mlen + col_offset
+                )
+                generated_code += f"S_ADDI_INT gp{result_actual_register}, gp0, {result_addr} \n"
+                # Set stride register for mm_wo (N/mlen vectors per result row)
+                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {stride_len} \n"
+                generated_code += f"M_MM_WO gp{result_actual_register}, gp{w_actual_register}, 0 \n"
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, 0 \n"
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
 

--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -1,4 +1,30 @@
-IMM2_BOUND = 2**18
+def _load_large_int(reg: int, value: int) -> str:
+    """Generate instructions to load any non-negative integer into a GP register.
+
+    S_ADDI_INT supports 18-bit immediates (values 0..2^18-1).
+    For values < 2^18, emit a single S_ADDI_INT from gp0.
+    For values >= 2^18, use S_LUI_INT (rd = imm << 12) + optional S_ADDI_INT.
+    """
+    IMM2_BOUND = 1 << 18
+    if value < IMM2_BOUND:
+        return f"S_ADDI_INT gp{reg}, gp0, {value}\n"
+    upper = value >> 12
+    lower = value & 0xFFF
+    code = f"S_LUI_INT gp{reg}, {upper}\n"
+    if lower:
+        code += f"S_ADDI_INT gp{reg}, gp{reg}, {lower}\n"
+    return code
+
+
+def _addi_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> str:
+    """Generate rd = rs1 + value, handling values >= 2^18 by loading into temp_reg first."""
+    IMM2_BOUND = 1 << 18
+    if value < IMM2_BOUND:
+        return f"S_ADDI_INT gp{dest_reg}, gp{src_reg}, {value}\n"
+    else:
+        code = _load_large_int(temp_reg, value)
+        code += f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}\n"
+        return code
 
 
 def ffn_asm(
@@ -89,28 +115,7 @@ def _ffn_asm_unrolled(
     const_one_fp_address: int,
     activation_base_address: int,
 ) -> str:
-    """
-    Generates assembly code for a FFN operation.
-
-    Args:
-        mlen (int): The number of rows in the matrix.
-        vlen (int): The number of columns in the matrix.
-        blen (int): The number of columns in the second matrix.
-        batch (int): The number of batches.
-        hidden_size (int): The number of rows in the hidden size.
-        intermediate_size (int): The number of rows in the intermediate size.
-        alive_registers (List[int]): List of registers that are alive.
-        gate_weight_hbm_offset_reg (int): index for the address mapper pointing to the base addr of the gate weight matrix.
-        up_weight_hbm_offset_reg (int): index for the address mapper pointing to the base addr of the up weight matrix.
-        down_weight_hbm_offset_reg (int): index for the address mapper pointing to the base addr of the down weight matrix.
-        activation_base_address (int): index for the address mapper pointing to the base addr of the activation matrix.
-        result_base_address (int): index for the address mapper pointing to the base addr of the result matrix.
-    Functionality:
-        Upsize linear   (b, s, hidden_size) @ (hidden_size, intermediate_size) - > (b, s, intermediate_size)
-        Gate Projection (b, s, hidden_size) @ (hidden_size, intermediate_size) -> (b, s, intermediate_size)
-        SILU Activation (b, s, intermediate_size) -> (b, s, intermediate_size)
-        Downsize linear (b, s, intermediate_size) @ (intermediate_size, hidden_size) -> (b, s, hidden_size)
-    """
+    """Unrolled FFN: up + gate + SiLU + down projections."""
 
     # memory assignment
     # 0 -> activation
@@ -130,18 +135,14 @@ def _ffn_asm_unrolled(
     generated_code = "; FFN Generation \n"
 
     # Settings for up and gate weight matrices prefetching
-    assert hidden_size * intermediate_size < IMM2_BOUND, f"hidden_size * hidden_size must be less than {IMM2_BOUND}"
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size} \n"
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {intermediate_size} \n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-    assert hidden_size * batch * seq_len < IMM2_BOUND, f"hidden_size * batch * seq_len must be less than {IMM2_BOUND}"
     # Set the address for on-chip sram
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size} \n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len} \n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
 
     generated_code += " ; FFN Upsize Linear Generation \n"
     for weight_row in range(intermediate_size // blen):
@@ -153,8 +154,8 @@ def _ffn_asm_unrolled(
             for weight_col in range(hidden_size // mlen):
                 generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{up_weight_hbm_offset_reg}, 1, 0 \n"
                 generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
-                generated_code += (
-                    f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen * intermediate_size} \n"
+                generated_code += _addi_large_int(
+                    w_hbm_offset_register, w_hbm_offset_register, mlen * intermediate_size, w_temp_register
                 )
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
         else:
@@ -172,7 +173,7 @@ def _ffn_asm_unrolled(
                     f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
                 )
             generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n"  # generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {activation_base_address} \n"
+            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n"
         if (weight_row + 1) % (mlen // blen) == 0 and weight_row != intermediate_size // blen - 1:
             generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {mlen * batch * seq_len} \n"
 
@@ -186,8 +187,8 @@ def _ffn_asm_unrolled(
             for weight_col in range(hidden_size // mlen):
                 generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{gate_weight_hbm_offset_reg}, 1, 0 \n"
                 generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
-                generated_code += (
-                    f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen * intermediate_size} \n"
+                generated_code += _addi_large_int(
+                    w_hbm_offset_register, w_hbm_offset_register, mlen * intermediate_size, w_temp_register
                 )
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
         else:
@@ -205,38 +206,28 @@ def _ffn_asm_unrolled(
                     f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
                 )
             generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n"  # generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {activation_base_address} \n"
+            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n"
         if (weight_row + 1) % (mlen // blen) == 0 and weight_row != intermediate_size // blen - 1:
             generated_code += (
                 f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {mlen * batch * seq_len} \n"
             )
 
-    # Intermediate Dim SILU Activation Generation, now x in shape of (b, s, intermediate_size)
     generated_code += "; SILU Generation \n"
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address} \n"
-    # Reset the addr for up and gate result
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size} \n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len} \n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
     generated_code += f"S_ADDI_INT gp{intermediate_register}, gp0, {activation_base_address} \n"
 
-    # Treat the original activation region as the place for scratchpad.
+    # SiLU: sigmoid(x) * x * gate, using activation region as scratchpad
     for b in range(batch * seq_len):
         for i in range(intermediate_size // vlen):
-            # 0 : -x
             generated_code += f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1 \n"
-            # 1 : exp(-x)
             generated_code += f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0 \n"
-            # 2 : 1 + exp(-x)
             generated_code += f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0 \n"
-            # 3 : 1 / (1 + exp(-x))
             generated_code += f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0 \n"
-            # 4 : (1 / (1 + exp(-x))) * gate_result
             generated_code += (
                 f"V_MUL_VV gp{intermediate_register}, gp{intermediate_register}, gp{up_result_register}, 0 \n"
             )
-            # 5: multiply by gate result and store to the up result region
             generated_code += (
                 f"V_MUL_VV gp{up_result_register}, gp{intermediate_register}, gp{gate_result_register}, 0 \n"
             )
@@ -244,8 +235,7 @@ def _ffn_asm_unrolled(
             generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen} \n"
 
     generated_code += "; FFN Downsize Linear Generation \n"
-    # Reset the addr for up and gate result
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size} \n"
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size} \n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
@@ -254,7 +244,7 @@ def _ffn_asm_unrolled(
     # Storing the results to the activation base region
     act_result_register = gate_result_register
     generated_code += f"S_ADDI_INT gp{act_result_register}, gp0, {activation_base_address} \n"
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size} \n"
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
     for weight_row in range(hidden_size // blen):
         if weight_row % (mlen // blen) == 0:
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
@@ -280,7 +270,7 @@ def _ffn_asm_unrolled(
                     f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
                 )
             generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {mlen * blen} \n"  # generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {activation_base_address} \n"
+            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {mlen * blen} \n"
         if (weight_row + 1) % (mlen // blen) == 0 and weight_row != intermediate_size // blen - 1:
             generated_code += (
                 f"S_ADDI_INT gp{act_result_register}, gp{act_result_register}, {mlen * batch * seq_len} \n"
@@ -301,13 +291,7 @@ def ffn_up_silu_asm(
     const_one_fp_address: int,
     activation_base_address: int,
 ) -> str:
-    """
-    Generates assembly code for up projection + SILU activation only.
-
-    Computes: SILU(up_proj(x)) = silu(w1(x))
-    Stops before gate projection and down projection.
-    Uses loop instructions for compact code.
-    """
+    """Up projection + SiLU only (no gate/down). Uses C_LOOP instructions."""
     # Register allocation
     w_actual_register = alive_registers[0]
     w_temp_register = alive_registers[1]
@@ -316,7 +300,6 @@ def ffn_up_silu_asm(
     intermediate_register = alive_registers[4]
     w_hbm_offset_register = alive_registers[5]
 
-    # Need extra registers for loop counters and temp save
     assert len(alive_registers) >= 10, "Loop version requires 10 registers (9 minimum + 1 temp)"
     loop_outer_reg = alive_registers[6]
     loop_inner_reg = alive_registers[7]
@@ -325,19 +308,17 @@ def ffn_up_silu_asm(
 
     generated_code = "; FFN Up Projection + SILU Generation\n"
 
-    # === SETUP PHASE ===
-    assert hidden_size * intermediate_size < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size}\n"
+    # Setup: scale/stride registers
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {intermediate_size}\n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base address for up result
-    assert hidden_size * batch * seq_len < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
 
-    # === UPSIZE LINEAR (loop version) ===
+    # Upsize linear (loop)
     generated_code += "; FFN Upsize Linear Generation (Loop)\n"
 
     # Outer loop: weight_row from 0 to intermediate_size // mlen (MLEN blocks)
@@ -359,7 +340,9 @@ def ffn_up_silu_asm(
             f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         )
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * intermediate_size}\n"
+        generated_code += _addi_large_int(
+            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+        )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
@@ -412,35 +395,6 @@ def ffn_up_silu_asm(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # # === SILU ACTIVATION (loop version) ===
-    # generated_code += "; SILU Generation (Loop)\n"
-    # generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address}\n"
-
-    # # Reset addresses - up_result_register points to up projection results
-    # generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    # generated_code += f"S_ADDI_INT gp{intermediate_register}, gp0, {activation_base_address}\n"  # Use activation_base_address as scratchpad
-
-    # Loop over batch * seq_len * (intermediate_size // vlen)
-    # num_silu_iters = batch * seq_len * (intermediate_size // vlen)
-    # generated_code += f"; SILU loop: {num_silu_iters} iterations\n"
-    # generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_silu_iters}\n"
-
-    # # SILU computation: sigmoid(x) * x (no gate multiplication)
-    # # Step 1: -x (negate)
-    # generated_code += f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1\n"
-    # # Step 2: exp(-x)
-    # generated_code += f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
-    # # Step 3: 1 + exp(-x)
-    # generated_code += f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0\n"
-    # # Step 4: 1 / (1 + exp(-x)) = sigmoid(x)
-    # generated_code += f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
-    # # Step 5: sigmoid(x) * x = silu(x), store in-place in up_result_register
-    # generated_code += f"V_MUL_VV gp{up_result_register}, gp{intermediate_register}, gp{up_result_register}, 0\n"
-    # generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen}\n"
-
-    # generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
-
-    # Note: Result is stored in up_result_register at base address batch * seq_len * hidden_size
     generated_code += "; Result (up projection only) stored at up_result_register location\n"
 
     return generated_code
@@ -460,12 +414,7 @@ def ffn_intermediate_asm(
     const_one_fp_address: int,
     activation_base_address: int,
 ) -> str:
-    """
-    Generates assembly code for FFN intermediate operations (up + gate + SILU only).
-
-    Stops before down projection to allow checking intermediate results.
-    Uses loop instructions for compact code.
-    """
+    """Up + gate + SiLU (no down projection). Uses C_LOOP instructions."""
     # Register allocation
     w_actual_register = alive_registers[0]
     w_temp_register = alive_registers[1]
@@ -475,7 +424,6 @@ def ffn_intermediate_asm(
     gate_result_register = alive_registers[5]
     w_hbm_offset_register = alive_registers[6]
 
-    # Need extra registers for loop counters
     assert len(alive_registers) >= 10, "Loop version requires 10 registers"
     loop_outer_reg = alive_registers[7]
     loop_inner_reg = alive_registers[8]
@@ -483,22 +431,18 @@ def ffn_intermediate_asm(
 
     generated_code = "; FFN Intermediate Generation (Up + Gate + SILU only)\n"
 
-    # === SETUP PHASE ===
-    assert hidden_size * intermediate_size < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size}\n"
+    # Setup: scale/stride registers
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {intermediate_size}\n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base addresses for results
-    assert hidden_size * batch * seq_len < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
 
-    # === UPSIZE LINEAR (loop version) ===
+    # Upsize linear (loop)
     generated_code += "; FFN Upsize Linear Generation (Loop)\n"
 
     # Outer loop: weight_row from 0 to intermediate_size // mlen (MLEN blocks)
@@ -507,14 +451,11 @@ def ffn_intermediate_asm(
     num_weight_tiles = hidden_size // mlen
     num_act_cols = (batch * seq_len) // blen
 
-    # w_hbm_offset_register tracks the START offset for each MLEN block
-    # It starts at 0 and increments by mlen after each outer loop iteration
     generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, 0\n"
     generated_code += f"; Outer loop: {num_mlen_blocks} MLEN blocks\n"
     generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_mlen_blocks}\n"
 
     # Prefetch weights for this MLEN block
-    # Use a_actual_register temporarily to track running HBM offset during prefetch
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
     for weight_col in range(num_weight_tiles):
@@ -522,7 +463,9 @@ def ffn_intermediate_asm(
             f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         )
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * intermediate_size}\n"
+        generated_code += _addi_large_int(
+            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+        )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
@@ -532,15 +475,13 @@ def ffn_intermediate_asm(
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen}\n"
 
-    # Inner loop: act_col iterations - track activation column base in a_actual_register
-    # Reset activation base at start of each middle loop iteration
+    # Reset activation base for each middle loop iteration
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, {activation_base_address}\n"
     generated_code += f"; Inner loop: {num_act_cols} activation columns\n"
     generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_act_cols}\n"
 
-    # Copy weight and activation pointers, iterate through weight tiles
     generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0\n"
-    # Save a_actual_register value before inner accumulation modifies it (use gate_result_register as temp)
+    # Save a_actual before accumulation loop (gate_result_register as temp)
     generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{a_actual_register}, 0\n"
 
     # Innermost accumulation (unrolled)
@@ -574,23 +515,18 @@ def ffn_intermediate_asm(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # === GATE PROJECTION (loop version) ===
+    # Gate projection (loop)
     generated_code += "; FFN Gate Projection Generation (Loop)\n"
 
     # Reset base addresses
-    # up_result_register = where upsize results start
-    # gate_result_register = where gate results should be written (after upsize results)
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
     generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, 0\n"
 
     generated_code += f"; Outer loop: {num_mlen_blocks} MLEN blocks\n"
     generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_mlen_blocks}\n"
 
     # Prefetch weights for this MLEN block
-    # Use a_actual_register temporarily to track running HBM offset during prefetch
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
     for weight_col in range(num_weight_tiles):
@@ -598,7 +534,9 @@ def ffn_intermediate_asm(
             f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
         )
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * intermediate_size}\n"
+        generated_code += _addi_large_int(
+            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+        )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
@@ -608,15 +546,13 @@ def ffn_intermediate_asm(
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen}\n"
 
-    # Inner loop: act_col iterations - track activation column base in a_actual_register
-    # Reset activation base at start of each middle loop iteration
+    # Reset activation base for each middle loop iteration
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, {activation_base_address}\n"
     generated_code += f"; Inner loop: {num_act_cols} activation columns\n"
     generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_act_cols}\n"
 
-    # Copy weight and activation pointers, iterate through weight tiles
     generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0\n"
-    # Save a_actual_register value before inner accumulation modifies it (use up_result_register as temp)
+    # Save a_actual before accumulation loop (up_result_register as temp)
     generated_code += f"S_ADDI_INT gp{up_result_register}, gp{a_actual_register}, 0\n"
 
     # Innermost accumulation (unrolled)
@@ -649,15 +585,13 @@ def ffn_intermediate_asm(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # === SILU ACTIVATION (loop version) ===
+    # SiLU activation (loop)
     generated_code += "; SILU Generation (Loop)\n"
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address}\n"
 
     # Reset addresses
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
     generated_code += f"S_ADDI_INT gp{intermediate_register}, gp0, {activation_base_address}\n"
 
     # Loop over batch * seq_len * (intermediate_size // vlen)
@@ -698,11 +632,7 @@ def _ffn_asm_with_loops(
     const_one_fp_address: int,
     activation_base_address: int,
 ) -> str:
-    """
-    Generates assembly code for FFN using C_LOOP_START/END instructions.
-
-    Uses nested loops to reduce code size at cost of some latency overhead.
-    """
+    """Full FFN (up + gate + SiLU + down) using C_LOOP instructions."""
 
     # Register allocation
     w_actual_register = alive_registers[0]
@@ -713,7 +643,6 @@ def _ffn_asm_with_loops(
     gate_result_register = alive_registers[5]
     w_hbm_offset_register = alive_registers[6]
 
-    # Need extra registers for loop counters
     assert len(alive_registers) >= 10, "Loop version requires 10 registers"
     loop_outer_reg = alive_registers[7]
     loop_inner_reg = alive_registers[8]
@@ -721,22 +650,18 @@ def _ffn_asm_with_loops(
 
     generated_code = "; FFN Generation (Loop-Optimized)\n"
 
-    # === SETUP PHASE ===
-    assert hidden_size * intermediate_size < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size}\n"
+    # Setup: scale/stride registers
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {intermediate_size}\n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base addresses for results
-    assert hidden_size * batch * seq_len < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
 
-    # === UPSIZE LINEAR (loop version) ===
+    # Upsize linear (loop)
     generated_code += "; FFN Upsize Linear Generation (Loop)\n"
 
     # Outer loop: weight_row from 0 to intermediate_size // mlen (MLEN blocks)
@@ -745,14 +670,11 @@ def _ffn_asm_with_loops(
     num_weight_tiles = hidden_size // mlen
     num_act_cols = (batch * seq_len) // blen
 
-    # w_hbm_offset_register tracks the START offset for each MLEN block
-    # It starts at 0 and increments by mlen after each outer loop iteration
     generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, 0\n"
     generated_code += f"; Outer loop: {num_mlen_blocks} MLEN blocks\n"
     generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_mlen_blocks}\n"
 
     # Prefetch weights for this MLEN block
-    # Use a_actual_register temporarily to track running HBM offset during prefetch
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
     for weight_col in range(num_weight_tiles):
@@ -760,7 +682,9 @@ def _ffn_asm_with_loops(
             f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         )
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * intermediate_size}\n"
+        generated_code += _addi_large_int(
+            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+        )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
@@ -770,15 +694,13 @@ def _ffn_asm_with_loops(
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen}\n"
 
-    # Inner loop: act_col iterations - track activation column base in a_actual_register
-    # Reset activation base at start of each middle loop iteration
+    # Reset activation base for each middle loop iteration
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, {activation_base_address}\n"
     generated_code += f"; Inner loop: {num_act_cols} activation columns\n"
     generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_act_cols}\n"
 
-    # Copy weight and activation pointers, iterate through weight tiles
     generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0\n"
-    # Save a_actual_register value before inner accumulation modifies it (use gate_result_register as temp)
+    # Save a_actual before accumulation loop (gate_result_register as temp)
     generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{a_actual_register}, 0\n"
 
     # Innermost accumulation (unrolled)
@@ -812,23 +734,18 @@ def _ffn_asm_with_loops(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # === GATE PROJECTION (loop version) ===
+    # Gate projection (loop)
     generated_code += "; FFN Gate Projection Generation (Loop)\n"
 
     # Reset base addresses
-    # up_result_register = where upsize results start
-    # gate_result_register = where gate results should be written (after upsize results)
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
     generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, 0\n"
 
     generated_code += f"; Outer loop: {num_mlen_blocks} MLEN blocks\n"
     generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_mlen_blocks}\n"
 
     # Prefetch weights for this MLEN block
-    # Use a_actual_register temporarily to track running HBM offset during prefetch
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
     for weight_col in range(num_weight_tiles):
@@ -836,7 +753,9 @@ def _ffn_asm_with_loops(
             f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
         )
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * intermediate_size}\n"
+        generated_code += _addi_large_int(
+            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+        )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
@@ -846,15 +765,13 @@ def _ffn_asm_with_loops(
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen}\n"
 
-    # Inner loop: act_col iterations - track activation column base in a_actual_register
-    # Reset activation base at start of each middle loop iteration
+    # Reset activation base for each middle loop iteration
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, {activation_base_address}\n"
     generated_code += f"; Inner loop: {num_act_cols} activation columns\n"
     generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_act_cols}\n"
 
-    # Copy weight and activation pointers, iterate through weight tiles
     generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0\n"
-    # Save a_actual_register value before inner accumulation modifies it (use up_result_register as temp)
+    # Save a_actual before accumulation loop (up_result_register as temp)
     generated_code += f"S_ADDI_INT gp{up_result_register}, gp{a_actual_register}, 0\n"
 
     # Innermost accumulation (unrolled)
@@ -887,15 +804,13 @@ def _ffn_asm_with_loops(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # === SILU ACTIVATION (loop version) ===
+    # SiLU activation (loop)
     generated_code += "; SILU Generation (Loop)\n"
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address}\n"
 
     # Reset addresses
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
     generated_code += f"S_ADDI_INT gp{intermediate_register}, gp0, {activation_base_address}\n"
 
     # Loop over batch * seq_len * (intermediate_size // vlen)
@@ -915,11 +830,11 @@ def _ffn_asm_with_loops(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # === DOWNSIZE LINEAR (loop version) ===
+    # Downsize linear (loop)
     generated_code += "; FFN Downsize Linear Generation (Loop)\n"
 
     # Setup scale and stride for downsize
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size}\n"
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size}\n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
@@ -928,21 +843,18 @@ def _ffn_asm_with_loops(
     # Result goes to activation base region
     act_result_register = gate_result_register
     generated_code += f"S_ADDI_INT gp{act_result_register}, gp0, {activation_base_address}\n"
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
 
     # Downsize: (b*s, intermediate_size) @ (intermediate_size, hidden_size) -> (b*s, hidden_size)
     num_down_mlen_blocks = hidden_size // mlen
     num_down_weight_tiles = intermediate_size // mlen
     down_act_col_advance = mlen * blen
 
-    # w_hbm_offset_register tracks the START offset for each MLEN block
-    # It starts at 0 and increments by mlen after each outer loop iteration
     generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, 0\n"
     generated_code += f"; Outer loop: {num_down_mlen_blocks} MLEN blocks\n"
     generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_down_mlen_blocks}\n"
 
     # Prefetch weights for this MLEN block
-    # Use a_actual_register temporarily to track running HBM offset during prefetch
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
     for weight_col in range(num_down_weight_tiles):
@@ -960,19 +872,15 @@ def _ffn_asm_with_loops(
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen}\n"
 
-    # Inner loop: act_col iterations - track activation column base in a_actual_register
-    # Reset activation base at start of each middle loop iteration
-    # Note: up_result_register will be used as temp save in inner loop, so recompute it here
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
+    # Reset activation base; up_result_register recomputed here (used as temp below)
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
     num_down_act_cols = (batch * seq_len) // blen
     generated_code += f"; Inner loop: {num_down_act_cols} activation columns\n"
     generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_down_act_cols}\n"
 
-    # Copy weight and activation pointers
     generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0\n"
-    # Save a_actual_register value before inner accumulation modifies it
-    # Use up_result_register as temp save (it's recomputed at each middle loop iteration start)
+    # Save a_actual before accumulation (up_result_register recomputed each middle iter)
     down_act_save_reg = up_result_register
     generated_code += f"S_ADDI_INT gp{down_act_save_reg}, gp{a_actual_register}, 0\n"
 
@@ -1024,15 +932,7 @@ def _ffn_asm_fused_up_gate(
     const_one_fp_address: int,
     activation_base_address: int,
 ) -> str:
-    """
-    Optimized FFN: Fuses upsize and gate projections to reduce HBM prefetch overhead.
-
-    Key optimization: Both up and gate weights are prefetched into MRAM for each MLEN block,
-    then both projections are computed before moving to the next block. This reduces
-    the number of times we need to refetch weights.
-
-    Requires 12 registers for optimal performance.
-    """
+    """Fused FFN: overlaps up/gate prefetch to reduce HBM traffic. Requires 12 registers."""
 
     # Register allocation for fused version
     assert len(alive_registers) >= 12, "Fused version requires 12 registers"
@@ -1053,22 +953,18 @@ def _ffn_asm_fused_up_gate(
 
     generated_code = "; FFN Generation (Fused Up+Gate Optimized)\n"
 
-    # === SETUP PHASE ===
-    assert hidden_size * intermediate_size < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size}\n"
+    # Setup: scale/stride registers
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {intermediate_size}\n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base addresses for results
-    assert hidden_size * batch * seq_len < IMM2_BOUND
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
 
-    # === FUSED UP + GATE LINEAR with overlapped prefetch ===
+    # Fused up + gate linear with overlapped prefetch
     generated_code += "; Fused Up+Gate Linear (overlapped prefetch optimization)\n"
 
     num_mlen_blocks = intermediate_size // mlen
@@ -1098,7 +994,9 @@ def _ffn_asm_fused_up_gate(
             f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         )
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * intermediate_size}\n"
+        generated_code += _addi_large_int(
+            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+        )
 
     # Setup for UP compute and GATE prefetch overlap
     generated_code += f"S_ADDI_INT gp{w_gate_base_register}, gp0, {gate_mram_offset}\n"
@@ -1107,7 +1005,7 @@ def _ffn_asm_fused_up_gate(
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
 
-    # === UP PROJECTION with interleaved GATE prefetch ===
+    # Up projection with interleaved gate prefetch
     generated_code += f"; Up projection for MLEN block (with GATE prefetch every {gate_prefetch_interval} iters)\n"
 
     # Unroll to interleave GATE prefetches during UP computation
@@ -1168,7 +1066,7 @@ def _ffn_asm_fused_up_gate(
         generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
         generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
-    # === GATE PROJECTION for this block (weights already prefetched) ===
+    # Gate projection (weights already prefetched)
     generated_code += "; Gate projection for MLEN block (weights pre-fetched during UP)\n"
     generated_code += f"S_ADDI_INT gp{a_save_register}, gp0, 0\n"  # tile offset tracker for output
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_gate_base_register}, 0\n"
@@ -1210,8 +1108,7 @@ def _ffn_asm_fused_up_gate(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # === SILU ACTIVATION with overlapped DOWN weight prefetch ===
-    # Key optimization: Prefetch first block of DOWN weights DURING SILU computation
+    # SiLU activation with overlapped down-weight prefetch
     num_down_mlen_blocks = hidden_size // mlen
     num_down_weight_tiles = intermediate_size // mlen
     num_silu_iters = batch * seq_len * (intermediate_size // vlen)
@@ -1220,16 +1117,14 @@ def _ffn_asm_fused_up_gate(
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address}\n"
 
     # Set up DOWN weight prefetch parameters
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size * intermediate_size}\n"
+    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {hidden_size}\n"
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
 
     # Initialize SILU pointers
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
-    generated_code += (
-        f"S_ADDI_INT gp{gate_result_register}, gp{up_result_register}, {intermediate_size * batch * seq_len}\n"
-    )
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
     generated_code += f"S_ADDI_INT gp{intermediate_register}, gp0, {activation_base_address}\n"
 
     # Initialize DOWN prefetch pointers (w_actual_register=MRAM offset, a_actual_register=HBM offset)
@@ -1266,12 +1161,12 @@ def _ffn_asm_fused_up_gate(
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * hidden_size}\n"
 
-    # === DOWNSIZE LINEAR (first block already prefetched) ===
+    # Downsize linear (first block already prefetched)
     generated_code += "; FFN Downsize Linear Generation (first block pre-fetched during SILU)\n"
 
     act_result_register = gate_result_register
     generated_code += f"S_ADDI_INT gp{act_result_register}, gp0, {activation_base_address}\n"
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
 
     down_act_col_advance = mlen * blen
 
@@ -1286,7 +1181,7 @@ def _ffn_asm_fused_up_gate(
     # First block computation
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen_down}\n"
 
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
+    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
     num_down_act_cols = (batch * seq_len) // blen
 
@@ -1336,7 +1231,7 @@ def _ffn_asm_fused_up_gate(
         generated_code += f"; Middle loop: {tiles_per_mlen_down} tiles per MLEN block\n"
         generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen_down}\n"
 
-        generated_code += f"S_ADDI_INT gp{up_result_register}, gp0, {batch * seq_len * hidden_size}\n"
+        generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
         generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
 
         generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_down_act_cols}\n"

--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -1,30 +1,5 @@
-def _load_large_int(reg: int, value: int) -> str:
-    """Generate instructions to load any non-negative integer into a GP register.
-
-    S_ADDI_INT supports 18-bit immediates (values 0..2^18-1).
-    For values < 2^18, emit a single S_ADDI_INT from gp0.
-    For values >= 2^18, use S_LUI_INT (rd = imm << 12) + optional S_ADDI_INT.
-    """
-    IMM2_BOUND = 1 << 18
-    if value < IMM2_BOUND:
-        return f"S_ADDI_INT gp{reg}, gp0, {value}\n"
-    upper = value >> 12
-    lower = value & 0xFFF
-    code = f"S_LUI_INT gp{reg}, {upper}\n"
-    if lower:
-        code += f"S_ADDI_INT gp{reg}, gp{reg}, {lower}\n"
-    return code
-
-
-def _addi_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> str:
-    """Generate rd = rs1 + value, handling values >= 2^18 by loading into temp_reg first."""
-    IMM2_BOUND = 1 << 18
-    if value < IMM2_BOUND:
-        return f"S_ADDI_INT gp{dest_reg}, gp{src_reg}, {value}\n"
-    else:
-        code = _load_large_int(temp_reg, value)
-        code += f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}\n"
-        return code
+from ._imm import addi_large_int_str as _addi_large_int
+from ._imm import load_large_int_str as _load_large_int
 
 
 def ffn_asm(

--- a/asm_templates/preload_act.py
+++ b/asm_templates/preload_act.py
@@ -1,19 +1,7 @@
 import math
 from typing import List
 
-
-def _load_large_int(reg: int, value: int) -> str:
-    """Generate instructions to load any non-negative integer into a GP register.
-    Uses S_LUI_INT (shifts imm left by 12) + S_ADDI_INT. Returns assembly string."""
-    upper = value >> 12
-    lower = value & 0xFFF
-    if upper:
-        code = f"S_LUI_INT gp{reg}, {upper} \n"
-        if lower:
-            code += f"S_ADDI_INT gp{reg}, gp{reg}, {lower} \n"
-    else:
-        code = f"S_ADDI_INT gp{reg}, gp0, {lower} \n"
-    return code
+from ._imm import load_large_int_str as _load_large_int
 
 
 def preload_act_asm(

--- a/asm_templates/preload_act.py
+++ b/asm_templates/preload_act.py
@@ -1,6 +1,19 @@
 import math
+from typing import List
 
-IMM2_BOUND = 2**18
+
+def _load_large_int(reg: int, value: int) -> str:
+    """Generate instructions to load any non-negative integer into a GP register.
+    Uses S_LUI_INT (shifts imm left by 12) + S_ADDI_INT. Returns assembly string."""
+    upper = value >> 12
+    lower = value & 0xFFF
+    if upper:
+        code = f"S_LUI_INT gp{reg}, {upper} \n"
+        if lower:
+            code += f"S_ADDI_INT gp{reg}, gp{reg}, {lower} \n"
+    else:
+        code = f"S_ADDI_INT gp{reg}, gp0, {lower} \n"
+    return code
 
 
 def preload_act_asm(
@@ -9,16 +22,13 @@ def preload_act_asm(
     batch: int,
     hidden_size: int,
     act_vram_offset: int,
-    alive_registers: list[int],
+    alive_registers: List[int],
     activation_offset_reg: int,
     stride_size=None,
+    vram_stride_mult: int = 1,
 ) -> str:
-    """
-    Generates assembly code for preloading activation.
-    Memory Layout: Here we assume the activation is stored in (Hidden // MLEN , Batch (Integrate with Seq Len), MLEN)
-    """
+    """Preload activation from HBM to VRAM. Layout: (hidden//mlen, batch, mlen)."""
     generated_code = "; Preload Activation Generation \n"
-    # get two registers from alive_registers, 1 as a address
     a_actual_register = alive_registers[0]
     set_stride_register = alive_registers[1]
     result_register = alive_registers[2]
@@ -28,7 +38,7 @@ def preload_act_asm(
     stride_len = vlen if stride_size is None else stride_size
 
     # Set scale offset
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, {hidden_size * batch} \n"
+    generated_code += _load_large_int(a_actual_register, hidden_size * batch)
     generated_code += f"C_SET_SCALE_REG gp{a_actual_register} \n"
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp0, 0 \n"
     generated_code += f"S_ADDI_INT gp{result_register}, gp0, {act_vram_offset} \n"
@@ -38,23 +48,25 @@ def preload_act_asm(
         # Each H_PREFETCH_V loads preload_len rows (vlen * preload_len elements)
         # HBM offset should increment by the same amount as VSRAM offset
         elements_per_prefetch = vlen * preload_len
+        vram_step = elements_per_prefetch * vram_stride_mult
         for i in range(math.ceil(hidden_size / elements_per_prefetch)):
             generated_code += (
                 f"H_PREFETCH_V gp{result_register}, gp{a_actual_register}, a{activation_offset_reg}, 0, 0, 0 \n"
             )
-            generated_code += f"S_ADDI_INT gp{result_register}, gp{result_register}, {elements_per_prefetch} \n"
+            generated_code += f"S_ADDI_INT gp{result_register}, gp{result_register}, {vram_step} \n"
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {elements_per_prefetch} \n"
     else:
         generated_code += f"S_ADDI_INT gp{set_stride_register}, gp0, {stride_len} \n"
         generated_code += f"C_SET_STRIDE_REG gp{set_stride_register} \n"
         a_offset_register = set_stride_register
-        assert batch * hidden_size <= IMM2_BOUND, "batch * hidden_size must be less than {IMM2_BOUND}"
         generated_code += f"C_LOOP_START gp{outer_loop_register}, {load_amount_per_hidden} \n"
         generated_code += f"S_ADDI_INT gp{a_offset_register}, gp{a_actual_register}, 0 \n"
         if batch > preload_len:
             generated_code += f"C_LOOP_START gp{inner_loop_register}, {math.ceil(batch / preload_len)} \n"
         generated_code += f"H_PREFETCH_V gp{result_register}, gp{a_offset_register}, a{activation_offset_reg}, 1, 0 \n"
-        generated_code += f"S_ADDI_INT gp{result_register}, gp{result_register}, {vlen * preload_len} \n"
+        generated_code += (
+            f"S_ADDI_INT gp{result_register}, gp{result_register}, {vlen * preload_len * vram_stride_mult} \n"
+        )
         if batch > preload_len:
             generated_code += f"S_ADDI_INT gp{a_offset_register}, gp{a_offset_register}, {hidden_size * preload_len} \n"
             generated_code += f"C_LOOP_END gp{inner_loop_register} \n"

--- a/asm_templates/projection_asm.py
+++ b/asm_templates/projection_asm.py
@@ -1,33 +1,7 @@
 from __future__ import annotations
 
-
-def _load_large_int(reg: int, value: int) -> list[str]:
-    """Generate instructions to load any non-negative integer into a GP register.
-
-    S_ADDI_INT supports 18-bit immediates (values 0..2^18-1).
-    For values < 2^18, emit a single S_ADDI_INT from gp0.
-    For values >= 2^18, use S_LUI_INT (rd = imm << 12) + optional S_ADDI_INT.
-    """
-    IMM2_BOUND = 1 << 18
-    if value < IMM2_BOUND:
-        return [f"S_ADDI_INT gp{reg}, gp0, {value}"]
-    upper = value >> 12
-    lower = value & 0xFFF
-    lines = [f"S_LUI_INT gp{reg}, {upper}"]
-    if lower:
-        lines.append(f"S_ADDI_INT gp{reg}, gp{reg}, {lower}")
-    return lines
-
-
-def _addi_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> list[str]:
-    """Generate rd = rs1 + value, handling values >= 2^18 by loading into temp_reg first."""
-    IMM2_BOUND = 1 << 18
-    if value < IMM2_BOUND:
-        return [f"S_ADDI_INT gp{dest_reg}, gp{src_reg}, {value}"]
-    else:
-        lines = _load_large_int(temp_reg, value)
-        lines.append(f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}")
-        return lines
+from ._imm import addi_large_int as _addi_large_int
+from ._imm import load_large_int as _load_large_int
 
 
 def projection_asm(

--- a/asm_templates/projection_asm.py
+++ b/asm_templates/projection_asm.py
@@ -1,4 +1,33 @@
-IMM2_BOUND = 2**18
+from __future__ import annotations
+
+
+def _load_large_int(reg: int, value: int) -> list[str]:
+    """Generate instructions to load any non-negative integer into a GP register.
+
+    S_ADDI_INT supports 18-bit immediates (values 0..2^18-1).
+    For values < 2^18, emit a single S_ADDI_INT from gp0.
+    For values >= 2^18, use S_LUI_INT (rd = imm << 12) + optional S_ADDI_INT.
+    """
+    IMM2_BOUND = 1 << 18
+    if value < IMM2_BOUND:
+        return [f"S_ADDI_INT gp{reg}, gp0, {value}"]
+    upper = value >> 12
+    lower = value & 0xFFF
+    lines = [f"S_LUI_INT gp{reg}, {upper}"]
+    if lower:
+        lines.append(f"S_ADDI_INT gp{reg}, gp{reg}, {lower}")
+    return lines
+
+
+def _addi_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> list[str]:
+    """Generate rd = rs1 + value, handling values >= 2^18 by loading into temp_reg first."""
+    IMM2_BOUND = 1 << 18
+    if value < IMM2_BOUND:
+        return [f"S_ADDI_INT gp{dest_reg}, gp{src_reg}, {value}"]
+    else:
+        lines = _load_large_int(temp_reg, value)
+        lines.append(f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}")
+        return lines
 
 
 def projection_asm(
@@ -61,8 +90,7 @@ def projection_asm(
 
     # Setup scale and stride registers (use act_reg as temp)
     # Scale = total weight matrix size, Stride = output dimension
-    assert in_features * out_features < IMM2_BOUND, f"Weight size {in_features}x{out_features} exceeds IMM2_BOUND"
-    lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {in_features * out_features}")
+    lines.extend(_load_large_int(act_reg, in_features * out_features))
     lines.append(f"C_SET_SCALE_REG gp{act_reg}")
     lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {out_features}")
     lines.append(f"C_SET_STRIDE_REG gp{act_reg}")
@@ -81,7 +109,9 @@ def projection_asm(
                     f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{w_base_hbm_offset_reg}, 1, 0 "
                 )
                 lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} ")
-                lines.append(f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen * out_features} ")
+                lines.extend(
+                    _addi_large_int(w_hbm_offset_register, w_hbm_offset_register, mlen * out_features, w_temp_register)
+                )
             lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
         else:
             lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} ")
@@ -96,10 +126,101 @@ def projection_asm(
                 lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} ")
                 lines.append(f"S_ADDI_INT gp{act_reg}, gp{act_reg}, {mlen * batch} ")
             lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 ")
-            lines.append(
-                f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} "
-            )  # lines.append f"S_ADDI_INT gp{act_reg}, gp{act_reg}, {activation_base_address} \n"
+            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} ")
         if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_features // blen - 1:
+            lines.append(f"S_ADDI_INT gp{result_reg}, gp{result_reg}, {mlen * batch} ")
+
+    return "\n".join(lines) + "\n"
+
+
+def projection_T_asm(
+    mlen: int,
+    blen: int,
+    batch: int,
+    hidden_size: int,
+    alive_registers: list[int],
+    w_base_hbm_offset_reg: int,
+    activation_base_address: int,
+    result_base_address: int,
+    rope_enabled: bool = False,
+    rope_hbm_offset_reg: int = 0,
+    rope_on_chip_address: int = 0,
+    out_features: int | None = None,
+) -> str:
+    """
+    Generates assembly for transposed projection: act @ weight.T
+    weight stored in HBM as (out_features, in_features).
+
+    Args:
+        mlen: Matrix tile size (rows)
+        blen: Vector tile size (batch dimension)
+        batch: Batch size
+        hidden_size: Input dimension (in_features)
+        alive_registers: Available GP registers [w_actual, w_temp, act_reg, intermediate, w_hbm_offset, result_reg]
+        w_base_hbm_offset_reg: Address register pointing to weight HBM base
+        activation_base_address: VRAM address of activations
+        result_base_address: VRAM address for output
+        out_features: Output dimension (defaults to hidden_size)
+
+    Returns:
+        Generated assembly code string
+    """
+    _ = rope_enabled, rope_hbm_offset_reg, rope_on_chip_address
+
+    in_features = hidden_size
+    if out_features is None:
+        out_features = hidden_size
+
+    w_actual_register = alive_registers[0]
+    w_temp_register = alive_registers[1]
+    act_reg = alive_registers[2]
+    intermediate_register = alive_registers[3]
+    w_hbm_offset_register = alive_registers[4]
+    result_reg = alive_registers[5]
+
+    tiles_per_mlen = mlen // blen
+
+    lines = ["; Projection_T Generation (act @ weight.T)"]
+    lines.append(f"; Linear T: (batch, {in_features}) @ ({out_features}, {in_features})^T -> (batch, {out_features})")
+
+    # Scale = total weight size, Stride = in_features (row stride of weight in HBM)
+    lines.extend(_load_large_int(act_reg, in_features * out_features))
+    lines.append(f"C_SET_SCALE_REG gp{act_reg}")
+    lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {in_features}")
+    lines.append(f"C_SET_STRIDE_REG gp{act_reg}")
+
+    lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {activation_base_address}")
+    lines.append(f"S_ADDI_INT gp{result_reg}, gp0, {result_base_address}")
+
+    for weight_row in range(out_features // blen):
+        if weight_row % tiles_per_mlen == 0:
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
+            # HBM offset: weight_row*blen rows into (out_features, in_features) layout
+            lines.extend(_load_large_int(w_hbm_offset_register, weight_row * blen * in_features))
+            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, 0 ")
+            for weight_col in range(hidden_size // mlen):
+                lines.append(
+                    f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{w_base_hbm_offset_reg}, 1, 0 "
+                )
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} ")
+                # Move to next mlen-wide column block within this row group
+                lines.append(f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen} ")
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
+        else:
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % tiles_per_mlen) * blen} ")
+            lines.append(
+                f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, {(weight_row % tiles_per_mlen) * blen} "
+            )
+        for act_col in range(batch // blen):
+            lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {activation_base_address + act_col * mlen * blen} ")
+            lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 ")
+            for inner_loop_index in range(hidden_size // mlen):
+                lines.append(f"M_MM 0, gp{w_temp_register}, gp{act_reg} ")
+                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} ")
+                lines.append(f"S_ADDI_INT gp{act_reg}, gp{act_reg}, {mlen * batch} ")
+            lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 ")
+            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} ")
+        if (weight_row + 1) % tiles_per_mlen == 0 and weight_row != out_features // blen - 1:
             lines.append(f"S_ADDI_INT gp{result_reg}, gp{result_reg}, {mlen * batch} ")
 
     return "\n".join(lines) + "\n"

--- a/asm_templates/tests/test_large_immediate.py
+++ b/asm_templates/tests/test_large_immediate.py
@@ -3,17 +3,14 @@ Unit tests for LUI+ADDI large immediate fix in ASM templates.
 Verifies that S_ADDI_INT is no longer used for values > 2^18,
 and that S_LUI_INT + S_ADDI_INT pair is emitted for large matrix sizes.
 
-Note: projection_asm._load_large_int returns list[str].
-      ffn_asm._load_large_int returns str (tested indirectly via ffn_asm()).
+The list-returning helper lives in `asm_templates._imm`; the str-returning
+helper used inside ffn_asm is exercised indirectly via ffn_asm().
 """
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))  # project root
-
 import unittest
-from compiler.asm_templates.projection_asm import projection_asm, projection_T_asm, _load_large_int
+
+from asm_templates._imm import load_large_int as _load_large_int
+from asm_templates.projection_asm import projection_asm, projection_T_asm
 
 
 class TestLoadLargeInt(unittest.TestCase):
@@ -197,7 +194,7 @@ class TestFfnAsmLargeMatrix(unittest.TestCase):
     )
 
     def _import_ffn_asm(self):
-        from compiler.asm_templates.ffn_asm import ffn_asm
+        from asm_templates.ffn_asm import ffn_asm
 
         return ffn_asm
 

--- a/asm_templates/tests/test_large_immediate.py
+++ b/asm_templates/tests/test_large_immediate.py
@@ -1,0 +1,293 @@
+"""
+Unit tests for LUI+ADDI large immediate fix in ASM templates.
+Verifies that S_ADDI_INT is no longer used for values > 2^18,
+and that S_LUI_INT + S_ADDI_INT pair is emitted for large matrix sizes.
+
+Note: projection_asm._load_large_int returns list[str].
+      ffn_asm._load_large_int returns str (tested indirectly via ffn_asm()).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))  # project root
+
+import unittest
+from compiler.asm_templates.projection_asm import projection_asm, projection_T_asm, _load_large_int
+
+
+class TestLoadLargeInt(unittest.TestCase):
+    """Test the _load_large_int helper from projection_asm directly (returns list[str])."""
+
+    def test_small_value_single_addi(self):
+        """Values < 4096 (upper=0) use a single S_ADDI_INT."""
+        result = _load_large_int(1, 256)
+        asm = "\n".join(result)
+        self.assertIn("S_ADDI_INT gp1, gp0, 256", asm)
+        self.assertNotIn("S_LUI_INT", asm)
+
+    def test_small_value_below_2_18(self):
+        """128*256 = 32768 < 2^18: fits in 18-bit immediate -> single S_ADDI_INT from gp0."""
+        val = 128 * 256  # 32768
+        result = _load_large_int(2, val)
+        asm = "\n".join(result)
+        # 32768 < 2^18, so single S_ADDI_INT from gp0 (no LUI needed)
+        self.assertIn("S_ADDI_INT gp2, gp0, 32768", asm)
+        self.assertNotIn("S_LUI_INT", asm)
+
+    def test_boundary_value_2_18(self):
+        """Value = 2^18 = 262144 needs LUI (upper=64, lower=0)."""
+        result = _load_large_int(2, 262144)
+        asm = "\n".join(result)
+        self.assertIn("S_LUI_INT gp2, 64", asm)  # 262144 >> 12 = 64
+        self.assertNotIn("S_ADDI_INT", asm)  # lower = 262144 & 0xFFF = 0
+
+    def test_2048x2048(self):
+        """2048*2048 = 4194304: upper=1024, lower=0 -> LUI only."""
+        val = 2048 * 2048  # 4194304
+        result = _load_large_int(3, val)
+        asm = "\n".join(result)
+        self.assertIn("S_LUI_INT gp3, 1024", asm)  # 4194304 >> 12 = 1024
+        self.assertNotIn("S_ADDI_INT", asm)  # lower = 0
+
+    def test_2048x8192(self):
+        """2048*8192 = 16777216: upper=4096, lower=0 -> LUI only."""
+        val = 2048 * 8192  # 16777216
+        result = _load_large_int(4, val)
+        asm = "\n".join(result)
+        self.assertIn("S_LUI_INT gp4, 4096", asm)  # 16777216 >> 12 = 4096
+        self.assertNotIn("S_ADDI_INT", asm)  # lower = 0
+
+    def test_value_with_remainder(self):
+        """Value with non-zero lower 12 bits emits both LUI and ADDI."""
+        val = (100 << 12) + 500  # upper=100, lower=500
+        result = _load_large_int(5, val)
+        asm = "\n".join(result)
+        self.assertIn("S_LUI_INT gp5, 100", asm)
+        self.assertIn("S_ADDI_INT gp5, gp5, 500", asm)
+
+    def test_zero_value(self):
+        """Zero should emit S_ADDI_INT gp{reg}, gp0, 0."""
+        result = _load_large_int(0, 0)
+        asm = "\n".join(result)
+        self.assertIn("S_ADDI_INT gp0, gp0, 0", asm)
+        self.assertNotIn("S_LUI_INT", asm)
+
+    def test_64x64_small(self):
+        """64*64 = 4096 < 2^18: fits in 18-bit immediate -> single S_ADDI_INT from gp0."""
+        val = 64 * 64  # 4096
+        result = _load_large_int(1, val)
+        asm = "\n".join(result)
+        # 4096 < 2^18, so single S_ADDI_INT from gp0 (no LUI needed)
+        self.assertIn("S_ADDI_INT gp1, gp0, 4096", asm)
+        self.assertNotIn("S_LUI_INT", asm)
+
+
+class TestProjectionAsmLargeMatrix(unittest.TestCase):
+    """Test that projection_asm generates valid code for large matrices."""
+
+    BASE_ARGS = dict(
+        mlen=64,
+        blen=4,
+        batch=4,
+        alive_registers=[1, 2, 3, 4, 5, 6],
+        w_base_hbm_offset_reg=0,
+        activation_base_address=0,
+        result_base_address=4096,
+    )
+
+    def test_small_matrix_no_change(self):
+        """64x64 should still work and contain expected instructions."""
+        asm = projection_asm(hidden_size=64, **self.BASE_ARGS)
+        self.assertIn("C_SET_SCALE_REG", asm)
+        self.assertIn("C_SET_STRIDE_REG", asm)
+
+    def test_small_matrix_no_lui(self):
+        """64x64 = 4096 elements < 2^18: single S_ADDI_INT from gp0 (no LUI needed)."""
+        asm = projection_asm(hidden_size=64, **self.BASE_ARGS)
+        # 4096 < 2^18, so scale loads via S_ADDI_INT gp3, gp0, 4096 (act_reg = alive_registers[2] = 3)
+        self.assertIn("S_ADDI_INT gp3, gp0, 4096", asm)
+        # Must NOT use LUI for this small value
+        self.assertNotIn("S_LUI_INT gp3, 1", asm)
+
+    def test_128x256_no_assertion_error(self):
+        """128*256 = 32768 < 2^18: should not raise AssertionError."""
+        try:
+            asm = projection_asm(hidden_size=128, out_features=256, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"projection_asm raised AssertionError for 128x256: {e}")
+        self.assertIn("C_SET_SCALE_REG", asm)
+
+    def test_512x512_boundary(self):
+        """512*512 = 262144 = 2^18: needs LUI (upper=64, lower=0)."""
+        try:
+            asm = projection_asm(hidden_size=512, out_features=512, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"projection_asm raised AssertionError for 512x512: {e}")
+        self.assertIn("S_LUI_INT", asm)
+        self.assertNotIn("S_ADDI_INT gp3, gp0, 262144", asm)
+
+    def test_2048x2048_no_assertion_error(self):
+        """2048x2048 should not raise AssertionError and must use LUI."""
+        try:
+            asm = projection_asm(hidden_size=2048, out_features=2048, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"projection_asm raised AssertionError for 2048x2048: {e}")
+        self.assertIn("S_LUI_INT", asm)
+        # Must not have the raw large value in a single ADDI from gp0
+        self.assertNotIn("S_ADDI_INT gp3, gp0, 4194304", asm)
+
+    def test_2048x8192_no_assertion_error(self):
+        """2048x8192 = 16777216 should not raise AssertionError and must use LUI."""
+        try:
+            asm = projection_asm(hidden_size=2048, out_features=8192, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"projection_asm raised AssertionError for 2048x8192: {e}")
+        self.assertIn("S_LUI_INT", asm)
+        self.assertNotIn("S_ADDI_INT gp3, gp0, 16777216", asm)
+        _check_all_addi_immediates(self, asm, "projection_asm(2048,8192)")
+
+
+class TestProjectionTAsmLargeMatrix(unittest.TestCase):
+    """Test that projection_T_asm also handles large matrices correctly."""
+
+    BASE_ARGS = dict(
+        mlen=64,
+        blen=4,
+        batch=4,
+        alive_registers=[1, 2, 3, 4, 5, 6],
+        w_base_hbm_offset_reg=0,
+        activation_base_address=0,
+        result_base_address=4096,
+    )
+
+    def test_small_matrix(self):
+        """64x64 works without error."""
+        asm = projection_T_asm(hidden_size=64, **self.BASE_ARGS)
+        self.assertIn("C_SET_SCALE_REG", asm)
+
+    def test_2048x2048_no_assertion_error(self):
+        """2048x2048 projection_T_asm should not raise AssertionError."""
+        try:
+            asm = projection_T_asm(hidden_size=2048, out_features=2048, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"projection_T_asm raised AssertionError for 2048x2048: {e}")
+        self.assertIn("S_LUI_INT", asm)
+        _check_all_addi_immediates(self, asm, "projection_T_asm(2048,2048)")
+
+
+class TestFfnAsmLargeMatrix(unittest.TestCase):
+    """Test that ffn_asm handles large matrices without AssertionError.
+
+    ffn_asm has its own _load_large_int (returns str), tested indirectly.
+    """
+
+    BASE_ARGS = dict(
+        mlen=64,
+        vlen=64,
+        blen=4,
+        batch=4,
+        seq_len=64,
+        alive_registers=list(range(12)),
+        gate_weight_hbm_offset_reg=0,
+        up_weight_hbm_offset_reg=1,
+        down_weight_hbm_offset_reg=2,
+        const_one_fp_address=5,
+        activation_base_address=0,
+    )
+
+    def _import_ffn_asm(self):
+        from compiler.asm_templates.ffn_asm import ffn_asm
+
+        return ffn_asm
+
+    def test_small_ffn_no_error(self):
+        """hidden=64, intermediate=128 (current test scale) works fine."""
+        ffn_asm = self._import_ffn_asm()
+        try:
+            asm = ffn_asm(hidden_size=64, intermediate_size=128, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"ffn_asm raised AssertionError for 64x128: {e}")
+        self.assertIsInstance(asm, str)
+        self.assertGreater(len(asm), 0)
+
+    def test_large_ffn_hidden128_inter256_no_assertion_error(self):
+        """hidden=128, intermediate=256 (smollm2 test scale) should not raise.
+        128*256=32768 < 2^18: fits in 18-bit immediate, no LUI needed."""
+        ffn_asm = self._import_ffn_asm()
+        try:
+            asm = ffn_asm(hidden_size=128, intermediate_size=256, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"ffn_asm raised AssertionError for 128x256: {e}")
+        # 128*256=32768 < 2^18 -> single S_ADDI_INT from gp0, no LUI needed
+        self.assertIn("S_ADDI_INT", asm)
+        self.assertNotIn("S_LUI_INT", asm)
+
+    def test_large_ffn_2048_8192_no_assertion_error(self):
+        """hidden=2048, intermediate=8192 (SmolVLM2 FFN scale) should not raise."""
+        ffn_asm = self._import_ffn_asm()
+        try:
+            asm = ffn_asm(hidden_size=2048, intermediate_size=8192, **self.BASE_ARGS)
+        except AssertionError as e:
+            self.fail(f"ffn_asm raised AssertionError for 2048x8192: {e}")
+        self.assertIn("S_LUI_INT", asm)
+        # S_ADD_INT must appear (proving LUI+ADD pattern for large loop increments)
+        self.assertIn("S_ADD_INT", asm)
+        # All S_ADDI_INT immediates must be < 2^18 regardless of rs1
+        _check_all_addi_immediates(self, asm, "ffn_asm(2048, 8192)")
+
+    def test_large_ffn_2048_8192_gate_result_absolute(self):
+        """gate_result address must be computed as absolute, not relative with large offset."""
+        ffn_asm = self._import_ffn_asm()
+        asm = ffn_asm(hidden_size=2048, intermediate_size=8192, **self.BASE_ARGS)
+        # gate_result = batch*seq_len*(hidden+inter) = 4*64*(2048+8192) = 2621440
+        # Must use LUI, not a single ADDI
+        self.assertNotIn("S_ADDI_INT gp5, gp3, 2097152", asm)  # old bad pattern
+
+    def test_small_ffn_all_addi_bounded(self):
+        """Even for small FFN, all S_ADDI_INT immediates must fit in 18 bits."""
+        ffn_asm = self._import_ffn_asm()
+        asm = ffn_asm(hidden_size=64, intermediate_size=128, **self.BASE_ARGS)
+        _check_all_addi_immediates(self, asm, "ffn_asm(64, 128)")
+
+    def test_loop_path_large_2048_8192_no_assertion_error(self):
+        """use_loop_instructions=True (production path) must handle large matrices."""
+        ffn_asm = self._import_ffn_asm()
+        args = dict(self.BASE_ARGS)
+        args["alive_registers"] = list(range(10))  # loop version needs 10
+        try:
+            asm = ffn_asm(hidden_size=2048, intermediate_size=8192, use_loop_instructions=True, **args)
+        except AssertionError as e:
+            self.fail(f"ffn_asm loop path raised AssertionError for 2048x8192: {e}")
+        self.assertIn("S_LUI_INT", asm)
+        _check_all_addi_immediates(self, asm, "ffn_asm(loop,2048,8192)")
+
+    def test_loop_path_smollm2_scale(self):
+        """Production path with smollm2 scale (hidden=128, inter=256) all immediates bounded."""
+        ffn_asm = self._import_ffn_asm()
+        args = dict(self.BASE_ARGS)
+        args["alive_registers"] = list(range(10))
+        asm = ffn_asm(hidden_size=128, intermediate_size=256, use_loop_instructions=True, **args)
+        _check_all_addi_immediates(self, asm, "ffn_asm(loop,128,256)")
+
+
+def _check_all_addi_immediates(test_case, asm: str, label: str) -> None:
+    """Assert every S_ADDI_INT immediate in asm is < 2^18."""
+    IMM2_BOUND = 1 << 18
+    for line in asm.splitlines():
+        line = line.strip()
+        if not line.startswith("S_ADDI_INT"):
+            continue
+        parts = line.split(",")
+        if len(parts) >= 3:
+            try:
+                imm = int(parts[-1].strip())
+                test_case.assertLess(
+                    imm, IMM2_BOUND, f"[{label}] S_ADDI_INT with large immediate {imm} (>= 2^18): {line}"
+                )
+            except ValueError:
+                pass  # not a plain integer literal, skip
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Split from kev/aten. Fixes batched_matmul addressing, 18-bit IMM2 bound in ffn/projection, fp_sram save/restore in preload_act. Adds projection_T_asm + tests + .gitignore for generated *.asm/*.mem.