### PR TITLE
doc/Model_Lib + src/definitions: add model configs and SV stubs

### DIFF
--- a/doc/Model_Lib/llada-8b.json
+++ b/doc/Model_Lib/llada-8b.json
@@ -1,0 +1,25 @@
+{
+    "architectures": [
+        "LlamaForMaskedDiffusion"
+    ],
+    "attention_bias": false,
+    "attention_dropout": 0.0,
+    "bos_token_id": 128000,
+    "eos_token_id": 128001,
+    "hidden_act": "silu",
+    "hidden_size": 4096,
+    "initializer_range": 0.02,
+    "intermediate_size": 14336,
+    "max_position_embeddings": 131072,
+    "mlp_bias": false,
+    "model_type": "llama",
+    "num_attention_heads": 32,
+    "num_hidden_layers": 32,
+    "num_key_value_heads": 8,
+    "rms_norm_eps": 1e-05,
+    "rope_theta": 500000.0,
+    "tie_word_embeddings": false,
+    "torch_dtype": "bfloat16",
+    "vocab_size": 128256,
+    "_note": "LLaDA-8B: LLaMA-3-8B backbone with bidirectional (non-causal) attention for masked diffusion. Inference = T denoising steps, each a full-sequence prefill (no autoregressive decode). Total cost = T * prefill_cost(seq_len = prompt_len + output_len)."
+}

--- a/doc/Model_Lib/smolvlm2-2.2b-text.json
+++ b/doc/Model_Lib/smolvlm2-2.2b-text.json
@@ -1,0 +1,22 @@
+{
+    "architectures": [
+        "SmolVLMForConditionalGeneration"
+    ],
+    "model_component": "text_decoder",
+    "model_type": "llama",
+    "batchsize": 1,
+    "hidden_size": 2048,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 1,
+    "num_hidden_layers": 24,
+    "intermediate_size": 8192,
+    "vocab_size": 49280,
+    "max_position_embeddings": 8192,
+    "head_dim": 64,
+    "rms_norm_eps": 1e-05,
+    "hidden_act": "silu",
+    "rope_theta": 10000.0,
+    "tie_word_embeddings": false,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.49.0"
+}

--- a/doc/Model_Lib/smolvlm2-2.2b-vision.json
+++ b/doc/Model_Lib/smolvlm2-2.2b-vision.json
@@ -1,0 +1,23 @@
+{
+    "architectures": [
+        "SmolVLMForConditionalGeneration"
+    ],
+    "model_component": "vision_encoder",
+    "model_type": "siglip_vision_model",
+    "batchsize": 1,
+    "hidden_size": 1152,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 16,
+    "num_hidden_layers": 27,
+    "intermediate_size": 4304,
+    "vocab_size": 0,
+    "image_size": 384,
+    "patch_size": 14,
+    "num_channels": 3,
+    "num_patches": 729,
+    "head_dim": 72,
+    "norm_eps": 1e-06,
+    "hidden_act": "gelu_pytorch_tanh",
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.49.0"
+}

--- a/doc/precision.svh
+++ b/doc/precision.svh
@@ -1,0 +1,30 @@
+// precision.svh - PLENA numeric precision parameters.
+//
+// Intentionally minimal: compiler/generator/parser/hardware_parser.py (and the
+// helpers under tools/) tolerate an empty precision file and fall back to the
+// following per-parameter defaults when the corresponding `parameter` line is
+// absent:
+//
+//   WT_MX_MANT_WIDTH   = 3,  WT_MX_EXP_WIDTH    = 4   // weight MX mantissa/exp
+//   KV_MX_MANT_WIDTH   = 3,  KV_MX_EXP_WIDTH    = 4   // KV-cache MX mantissa/exp
+//   ACT_MX_MANT_WIDTH  = 3,  ACT_MX_EXP_WIDTH   = 4   // activation MX mantissa/exp
+//   MX_SCALE_WIDTH     = 3,  SCALE_MX_EXP_WIDTH = 4   // shared-scale mantissa/exp
+//   BLOCK_DIM          = 4                            // MX block dimension
+//
+// Override any of them by declaring, e.g.:
+//
+//   parameter WT_MX_MANT_WIDTH = 4;
+//
+// Included transitively from configuration.svh via:
+//   `include "precision.svh"
+//
+// This header is the canonical source-of-truth; the compiler reads it directly
+// from compiler/doc/ and the RTL's configuration.svh includes it from the same
+// directory.
+`ifndef PRECISION_SVH
+`define PRECISION_SVH
+
+package precision_pkg;
+endpackage
+
+`endif

--- a/generator/runner.py
+++ b/generator/runner.py
@@ -17,8 +17,8 @@ def run():
     mode = sys.argv[1]
     model_path = sys.argv[2]
     output_file = sys.argv[3]
-    hardware_config_path = Path(__file__).resolve().parents[1] / "src" / "definitions" / "configuration.svh"
-    precision_config_path = Path(__file__).resolve().parents[1] / "src" / "definitions" / "precision.svh"
+    hardware_config_path = Path(__file__).resolve().parents[1] / "doc" / "configuration.svh"
+    precision_config_path = Path(__file__).resolve().parents[1] / "doc" / "precision.svh"
     mem_layout_lib_path = Path(__file__).resolve().parents[0] / "scheduler" / "mem_layout_lib.json"
     reg_assignment_lib_path = Path(__file__).resolve().parents[0] / "scheduler" / "reg_assignment_lib.json"
     # Validate that output file ends with .asm

--- a/generator/tests/test_embedding_code_gen.py
+++ b/generator/tests/test_embedding_code_gen.py
@@ -44,7 +44,7 @@ def test_embeddings_code_generation():
 
 if __name__ == "__main__":
     test_embeddings_code_generation()
-    config_path = Path(__file__).resolve().parents[2] / "src" / "definitions" / "configuration.svh"
-    isa_def_path = Path(__file__).resolve().parents[2] / "src" / "definitions" / "operation.svh"
+    config_path = Path(__file__).resolve().parents[2] / "doc" / "configuration.svh"
+    isa_def_path = Path(__file__).resolve().parents[2] / "doc" / "operation.svh"
     assembler = AssemblyToBinary(isa_def_path, config_path)
     assembler.generate_binary("generated_embedding_assembly.asm", "generated_embedding_assembly.mem")

--- a/src/definitions/configuration.svh
+++ b/src/definitions/configuration.svh
@@ -1,1 +1,0 @@
-/home/khl22/new_plena/PLENA_Simulator/compiler/doc/configuration.svh

--- a/src/definitions/configuration.svh
+++ b/src/definitions/configuration.svh
@@ -1,0 +1,1 @@
+/home/khl22/new_plena/PLENA_Simulator/compiler/doc/configuration.svh


### PR DESCRIPTION
Split from kev/aten. LLaDA-8B and SmolVLM2 (text+vision) configs; configuration.svh / precision.svh stubs needed by runner.