### PR TITLE
sim_env + assembler: self-containment and QoL fixes

### DIFF
--- a/assembler/assembly_to_binary.py
+++ b/assembler/assembly_to_binary.py
@@ -1,6 +1,6 @@
 from utils.load_config import load_svh_settings
 
-from compiler.assembler.parser import load_isa_definitions, parse_asm_file
+from assembler.parser import load_isa_definitions, parse_asm_file
 
 
 class AssemblyToBinary:

--- a/assembler/assembly_to_binary.py
+++ b/assembler/assembly_to_binary.py
@@ -1,6 +1,6 @@
 from utils.load_config import load_svh_settings
 
-from assembler.parser import load_isa_definitions, parse_asm_file
+from .parser import load_isa_definitions, parse_asm_file
 
 
 class AssemblyToBinary:

--- a/assembler/parser.py
+++ b/assembler/parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/sim_env_utils/__init__.py
+++ b/sim_env_utils/__init__.py
@@ -1,1 +1,4 @@
-from .build_env import create_mem_for_sim as create_mem_for_sim
+from .build_env import create_mem_for_sim
+
+# Legacy alias
+build_sim_env = create_mem_for_sim

--- a/sim_env_utils/build_env.py
+++ b/sim_env_utils/build_env.py
@@ -1,5 +1,13 @@
 import logging
+import sys
 from pathlib import Path
+
+# Ensure PLENA_Simulator/tools/ is on sys.path so that the
+# 'utils', 'memory_mapping', and 'quant' packages resolve to
+# the versions shipped with this simulator (not an older plena install).
+_TOOLS_PATH = str(Path(__file__).parent.parent.parent / "tools")
+if _TOOLS_PATH not in sys.path:
+    sys.path.insert(0, _TOOLS_PATH)
 
 import torch
 from memory_mapping.rand_gen import RandomMxfpTensorGenerator

--- a/sim_env_utils/build_sys_tools.py
+++ b/sim_env_utils/build_sys_tools.py
@@ -138,6 +138,12 @@ def parse_args():
 def init_mem(build_path):
     """Initialize memory files and environment variables for simulation."""
     build_path.mkdir(parents=True, exist_ok=True)
+
+    # Clear HBM binary so each test starts with a fresh HBM (not accumulating stale data).
+    hbm_bin_file = build_path / "hbm_for_behave_sim.bin"
+    if hbm_bin_file.exists():
+        hbm_bin_file.unlink()
+
     hbm_element_file = build_path / "hbm_ele.mem"
     hbm_scale_file = build_path / "hbm_scale.mem"
     hbm_file_for_behave_sim = build_path / "hbm_for_behave_sim.mem"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,2 @@
+"""Small utility helpers for the compiler toolchain."""
+

--- a/utils/load_config.py
+++ b/utils/load_config.py
@@ -1,0 +1,36 @@
+import re
+from pathlib import Path
+from typing import Union
+
+
+_PARAM_PATTERN = re.compile(r"\s*(?:localparam|parameter)\s+(?:\w+\s+)?(\w+)\s*=\s*([^;]+);")
+
+
+def load_svh_settings(file_path: Union[str, Path]) -> dict[str, int]:
+    """Parse integer `parameter`/`localparam` definitions from a SystemVerilog .svh/.sv file.
+
+    This is intentionally tiny and self-contained so the `compiler/` repo can run
+    its assembler/generator without depending on the simulator monorepo's `tools/`.
+    """
+    hardware_settings: dict[str, int] = {}
+    path = Path(file_path)
+
+    with path.open() as f:
+        for line in f:
+            match = _PARAM_PATTERN.match(line)
+            if not match:
+                continue
+
+            name, value_str = match.groups()
+            value_str = value_str.strip()
+
+            # Keep behavior minimal: only accept plain integers.
+            try:
+                value = int(value_str)
+            except ValueError:
+                continue
+
+            hardware_settings[name] = value
+
+    return hardware_settings
+


### PR DESCRIPTION
Split from kev/aten. Local utils/load_svh_settings so compiler/ is self-contained; sim_env_utils sys.path shim, HBM cleanup on init_mem, legacy build_sim_env alias; assembler imports tidied.