### PR TITLE
feat(asm_templates): K-split for ffn_asm + projection_asm

### DIFF
--- a/asm_templates/_k_split.py
+++ b/asm_templates/_k_split.py
@@ -1,0 +1,29 @@
+"""Shared K-split chunking utility for asm_templates.
+
+Both ``ffn_asm`` and ``projection_asm`` need to split a K-dimension tile count
+into chunks of at most ``max_k_tiles``.  This module provides one canonical
+implementation so the two callers stay in sync.
+"""
+
+from __future__ import annotations
+
+
+def k_chunks(num_k_tiles: int, max_k_tiles: int) -> list[tuple[int, int]]:
+    """Split ``num_k_tiles`` K-dimension tiles into chunks of at most
+    ``max_k_tiles``.  Returns a list of ``(k_start_tile, k_count)`` pairs.
+
+    >>> k_chunks(6, 4)
+    [(0, 4), (4, 2)]
+    >>> k_chunks(4, 4)
+    [(0, 4)]
+    >>> k_chunks(1, 4)
+    [(0, 1)]
+    """
+    assert max_k_tiles >= 1, f"MAX_K_TILES must be >= 1, got {max_k_tiles}"
+    chunks: list[tuple[int, int]] = []
+    k_pos = 0
+    while k_pos < num_k_tiles:
+        count = min(max_k_tiles, num_k_tiles - k_pos)
+        chunks.append((k_pos, count))
+        k_pos += count
+    return chunks

--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -1,5 +1,6 @@
 from ._imm import addi_large_int_str as _addi_large_int
 from ._imm import load_large_int_str as _load_large_int
+from ._k_split import k_chunks as _k_chunks
 
 
 def ffn_asm(
@@ -82,19 +83,6 @@ def ffn_asm(
             activation_base_address,
             matrix_sram_size=matrix_sram_size,
         )
-
-
-def _k_chunks(num_k_tiles: int, max_k_tiles: int) -> list[tuple[int, int]]:
-    """Split ``num_k_tiles`` K dimension tiles into chunks of at most
-    ``max_k_tiles``. Returns list of (k_start_tile, k_count) pairs."""
-    assert max_k_tiles >= 1, f"MAX_K_TILES must be >= 1, got {max_k_tiles}"
-    chunks: list[tuple[int, int]] = []
-    k_pos = 0
-    while k_pos < num_k_tiles:
-        count = min(max_k_tiles, num_k_tiles - k_pos)
-        chunks.append((k_pos, count))
-        k_pos += count
-    return chunks
 
 
 def _ffn_asm_unrolled(
@@ -316,9 +304,9 @@ def _emit_ffn_projection_unrolled(
     read from ``act_base + k*mlen*batch*seq_len`` + per-tile column offsets.
     """
 
+    assert k_size % mlen == 0, f"K ({k_size}) must be a multiple of MLEN ({mlen})"
+    assert out_size % mlen == 0, f"out_size ({out_size}) must be a multiple of MLEN ({mlen})"
     num_k_tiles = k_size // mlen
-    num_m_blocks = out_size // mlen  # output row-blocks (MLEN wide)
-    tiles_per_mlen = mlen // blen
     num_act_cols = (batch * seq_len) // blen
 
     lines: list[str] = [f" ; {section_comment} (k_size={k_size}, out_size={out_size})\n"]
@@ -453,28 +441,32 @@ def _emit_ffn_projection_chunk(
     - Activation offset for a chunk is advanced by ``k_start_tile * mlen * batch*seq_len``
     - MRAM prefetch destination always resets to 0 per MLEN block (we only
       prefetch this chunk's ``k_tile_count`` tiles)
+
+    M_MM_WO semantics (confirmed from transactional_emulator/src/main.rs):
+    ``mm_wo`` OVERWRITEs the VRAM slice with the current m_accum, then zeros
+    m_accum.  It does NOT accumulate into existing VRAM content.  Therefore
+    the first-chunk direct write to the real output region is safe, and the
+    K-split partial-sum accumulation via V_ADD_VV is the correct mechanism.
+
+    Note: previous single-pass code emitted M_MM against w_actual_register
+    (a latent bug when hidden_size > mlen — the MRAM pointer did not advance
+    between inner-loop iterations). This unified path uses w_temp_register
+    throughout, matching K-split semantics, so hidden_size > mlen now
+    correctly advances the MRAM pointer.
     """
 
-    num_m_blocks = out_size // mlen
-    tiles_per_mlen = mlen // blen
+    assert k_size % mlen == 0, f"K ({k_size}) must be a multiple of MLEN ({mlen})"
     num_act_cols = (batch * seq_len) // blen
     chunk_hbm_base_offset = k_start_tile * mlen * weight_stride
     chunk_act_base_offset = k_start_tile * mlen * batch * seq_len
 
-    # Target base (either real output or scratch). If scratch, reset the
-    # result_base_register on entry so MLEN-block advancement steps can reuse it.
-    if target_base_value_override is None:
-        target_base_value = result_base_value
-        need_reset_target = False
-    else:
-        target_base_value = target_base_value_override
-        need_reset_target = True
+    # Target base: first chunk writes to real output, subsequent chunks write to scratch.
+    # Both cases load result_base_register with the appropriate base value so the
+    # MLEN-block advancement steps (S_ADDI_INT result_base_register, ...) work uniformly.
+    target_base_value = result_base_value if target_base_value_override is None else target_base_value_override
 
     lines: list[str] = []
-    if need_reset_target:
-        lines.append(_load_large_int(result_base_register, target_base_value))
-    else:
-        lines.append(_load_large_int(result_base_register, target_base_value))
+    lines.append(_load_large_int(result_base_register, target_base_value))
 
     # If the activation base is a register-held address (e.g. up_result_register
     # for down proj), ensure it holds its canonical value at the start of each

--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -18,12 +18,20 @@ def ffn_asm(
     activation_base_address: int,
     use_loop_instructions: bool = False,
     use_fused_up_gate: bool = False,
+    matrix_sram_size: int = 1024,
 ) -> str:
     """
     Generates assembly code for a FFN operation.
 
     Set use_loop_instructions=True to use C_LOOP_START/END for compact code.
     Set use_fused_up_gate=True to fuse upsize and gate projections (requires 12 registers).
+
+    ``matrix_sram_size`` is the MRAM capacity (element-units-per-tile * tiles). When
+    a projection's K dimension exceeds ``matrix_sram_size // mlen`` tiles, the template
+    emits a K-split partial-sum accumulation loop (mirroring
+    ``aten/ops/plena/linear_ops.py::linear_plena``). This prevents OOB
+    ``H_PREFETCH_M`` addresses for models whose intermediate/hidden dims exceed the
+    MRAM tile count.
     """
     if use_fused_up_gate:
         return _ffn_asm_fused_up_gate(
@@ -72,7 +80,21 @@ def ffn_asm(
             down_weight_hbm_offset_reg,
             const_one_fp_address,
             activation_base_address,
+            matrix_sram_size=matrix_sram_size,
         )
+
+
+def _k_chunks(num_k_tiles: int, max_k_tiles: int) -> list[tuple[int, int]]:
+    """Split ``num_k_tiles`` K dimension tiles into chunks of at most
+    ``max_k_tiles``. Returns list of (k_start_tile, k_count) pairs."""
+    assert max_k_tiles >= 1, f"MAX_K_TILES must be >= 1, got {max_k_tiles}"
+    chunks: list[tuple[int, int]] = []
+    k_pos = 0
+    while k_pos < num_k_tiles:
+        count = min(max_k_tiles, num_k_tiles - k_pos)
+        chunks.append((k_pos, count))
+        k_pos += count
+    return chunks
 
 
 def _ffn_asm_unrolled(
@@ -89,8 +111,16 @@ def _ffn_asm_unrolled(
     down_weight_hbm_offset_reg: int,
     const_one_fp_address: int,
     activation_base_address: int,
+    matrix_sram_size: int = 1024,
 ) -> str:
-    """Unrolled FFN: up + gate + SiLU + down projections."""
+    """Unrolled FFN: up + gate + SiLU + down projections.
+
+    When a projection's K dimension tile-count exceeds
+    ``matrix_sram_size // mlen``, we split K into chunks of at most
+    ``MAX_K_TILES = matrix_sram_size // mlen`` and accumulate partial sums in
+    VRAM via V_ADD_VV. This mirrors the ATen-path K-split in
+    ``aten/ops/plena/linear_ops.py::linear_plena``.
+    """
 
     # memory assignment
     # 0 -> activation
@@ -119,73 +149,66 @@ def _ffn_asm_unrolled(
     generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
     generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
 
-    generated_code += " ; FFN Upsize Linear Generation \n"
-    for weight_row in range(intermediate_size // blen):
-        if weight_row % (mlen // blen) == 0:
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {weight_row * blen} \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0 \n"
+    # K-split config: when K tile count > MRAM tile capacity, we split K and
+    # accumulate partial sums. `activation` region (used as input) starts at
+    # `activation_base_address`; the K-split scratch region for up/gate lives
+    # *after* the up+gate output regions at
+    # `batch*seq_len*(hidden_size+2*intermediate_size)` (hidden_size chunk for
+    # activation, intermediate_size each for up and gate results).
+    MAX_K_TILES = max(1, matrix_sram_size // mlen)
 
-            for weight_col in range(hidden_size // mlen):
-                generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{up_weight_hbm_offset_reg}, 1, 0 \n"
-                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
-                generated_code += _addi_large_int(
-                    w_hbm_offset_register, w_hbm_offset_register, mlen * intermediate_size, w_temp_register
-                )
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-        else:
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, {(weight_row % (mlen // blen)) * blen} \n"
-        for act_col in range((batch * seq_len) // blen):
-            generated_code += (
-                f"S_ADDI_INT gp{a_actual_register}, gp0, {activation_base_address + act_col * mlen * blen} \n"
-            )
-            generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 \n"
-            for inner_loop_index in range(hidden_size // mlen):
-                generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register} \n"
-                generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} \n"
-                generated_code += (
-                    f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
-                )
-            generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n"
-        if (weight_row + 1) % (mlen // blen) == 0 and weight_row != intermediate_size // blen - 1:
-            generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {mlen * batch * seq_len} \n"
+    # --- FFN Upsize Linear (K = hidden_size) ---
+    up_num_k_tiles = hidden_size // mlen
+    up_scratch_base = batch * seq_len * (hidden_size + 2 * intermediate_size)
+    generated_code += _emit_ffn_projection_unrolled(
+        mlen=mlen,
+        vlen=vlen,
+        blen=blen,
+        batch=batch,
+        seq_len=seq_len,
+        k_size=hidden_size,
+        out_size=intermediate_size,
+        weight_stride=intermediate_size,
+        weight_hbm_offset_reg=up_weight_hbm_offset_reg,
+        result_base_register=up_result_register,
+        result_base_value=batch * seq_len * hidden_size,
+        activation_base_address=activation_base_address,
+        activation_base_register=None,
+        max_k_tiles=MAX_K_TILES,
+        w_actual_register=w_actual_register,
+        w_temp_register=w_temp_register,
+        a_actual_register=a_actual_register,
+        intermediate_register=intermediate_register,
+        w_hbm_offset_register=w_hbm_offset_register,
+        scratch_base_value=up_scratch_base,
+        section_comment="FFN Upsize Linear Generation",
+    )
 
     generated_code += " ; FFN Gate Projection Generation \n"
-    for weight_row in range(intermediate_size // blen):
-        if weight_row % (mlen // blen) == 0:
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {weight_row * blen} \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0 \n"
-
-            for weight_col in range(hidden_size // mlen):
-                generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{gate_weight_hbm_offset_reg}, 1, 0 \n"
-                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
-                generated_code += _addi_large_int(
-                    w_hbm_offset_register, w_hbm_offset_register, mlen * intermediate_size, w_temp_register
-                )
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-        else:
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, {(weight_row % (mlen // blen)) * blen} \n"
-        for act_col in range((batch * seq_len) // blen):
-            generated_code += (
-                f"S_ADDI_INT gp{a_actual_register}, gp0, {activation_base_address + act_col * mlen * blen} \n"
-            )
-            generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 \n"
-            for inner_loop_index in range(hidden_size // mlen):
-                generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register} \n"
-                generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} \n"
-                generated_code += (
-                    f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
-                )
-            generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n"
-        if (weight_row + 1) % (mlen // blen) == 0 and weight_row != intermediate_size // blen - 1:
-            generated_code += (
-                f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {mlen * batch * seq_len} \n"
-            )
+    gate_scratch_base = batch * seq_len * (hidden_size + 2 * intermediate_size)
+    generated_code += _emit_ffn_projection_unrolled(
+        mlen=mlen,
+        vlen=vlen,
+        blen=blen,
+        batch=batch,
+        seq_len=seq_len,
+        k_size=hidden_size,
+        out_size=intermediate_size,
+        weight_stride=intermediate_size,
+        weight_hbm_offset_reg=gate_weight_hbm_offset_reg,
+        result_base_register=gate_result_register,
+        result_base_value=batch * seq_len * (hidden_size + intermediate_size),
+        activation_base_address=activation_base_address,
+        activation_base_register=None,
+        max_k_tiles=MAX_K_TILES,
+        w_actual_register=w_actual_register,
+        w_temp_register=w_temp_register,
+        a_actual_register=a_actual_register,
+        intermediate_register=intermediate_register,
+        w_hbm_offset_register=w_hbm_offset_register,
+        scratch_base_value=gate_scratch_base,
+        section_comment="FFN Gate Projection (inlined)",
+    )
 
     generated_code += "; SILU Generation \n"
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address} \n"
@@ -218,39 +241,313 @@ def _ffn_asm_unrolled(
     generated_code += f"S_ADDI_INT gp{m_stride_register}, gp0, {((batch * seq_len) // blen)} \n"
     # Storing the results to the activation base region
     act_result_register = gate_result_register
-    generated_code += f"S_ADDI_INT gp{act_result_register}, gp0, {activation_base_address} \n"
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    for weight_row in range(hidden_size // blen):
-        if weight_row % (mlen // blen) == 0:
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {weight_row * blen} \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0 \n"
-            for weight_col in range(intermediate_size // mlen):
-                generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{down_weight_hbm_offset_reg}, 1, 0 \n"
-                generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
-                generated_code += (
-                    f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen * hidden_size} \n"
+    # Down projection: K = intermediate_size. Activation input is at
+    # VRAM address batch*seq_len*hidden_size (up_result region, post-SiLU).
+    # Scratch for K-split lives past the gate region so it never collides
+    # with input (up_result) or output (activation_base_address).
+    down_scratch_base = batch * seq_len * (hidden_size + 2 * intermediate_size)
+    generated_code += _emit_ffn_projection_unrolled(
+        mlen=mlen,
+        vlen=vlen,
+        blen=blen,
+        batch=batch,
+        seq_len=seq_len,
+        k_size=intermediate_size,
+        out_size=hidden_size,
+        weight_stride=hidden_size,
+        weight_hbm_offset_reg=down_weight_hbm_offset_reg,
+        result_base_register=act_result_register,
+        result_base_value=activation_base_address,
+        activation_base_address=None,
+        activation_base_register=up_result_register,
+        activation_base_register_value=batch * seq_len * hidden_size,
+        max_k_tiles=max(1, matrix_sram_size // mlen),
+        w_actual_register=w_actual_register,
+        w_temp_register=w_temp_register,
+        a_actual_register=a_actual_register,
+        intermediate_register=intermediate_register,
+        w_hbm_offset_register=w_hbm_offset_register,
+        scratch_base_value=down_scratch_base,
+        section_comment="FFN Downsize Linear (inlined)",
+    )
+    return generated_code
+
+
+def _emit_ffn_projection_unrolled(
+    *,
+    mlen: int,
+    vlen: int,
+    blen: int,
+    batch: int,
+    seq_len: int,
+    k_size: int,
+    out_size: int,
+    weight_stride: int,
+    weight_hbm_offset_reg: int,
+    result_base_register: int,
+    result_base_value: int,
+    activation_base_address: int | None,
+    activation_base_register: int | None,
+    activation_base_register_value: int | None = None,
+    max_k_tiles: int = 16,
+    w_actual_register: int,
+    w_temp_register: int,
+    a_actual_register: int,
+    intermediate_register: int,
+    w_hbm_offset_register: int,
+    scratch_base_value: int,
+    section_comment: str,
+) -> str:
+    """Emit a single FFN-style projection (one of up/gate/down) as unrolled ASM.
+
+    The projection computes ``out[r][c] = sum_k act[r][k] * weight[k][c]`` for
+    ``k_size`` K-dimension columns. The weight matrix has HBM row-stride
+    ``weight_stride`` (intermediate_size for up/gate, hidden_size for down).
+
+    When ``k_size // mlen > max_k_tiles``, emits a K-split partial-sum
+    accumulation loop. First chunk writes to ``result_base_register`` VRAM
+    region. Subsequent chunks write to a scratch region at
+    ``scratch_base_value`` and a bulk V_ADD_VV pass accumulates scratch into
+    output at the end of each chunk.
+
+    Either ``activation_base_address`` (an absolute VRAM address, e.g. block1)
+    or ``activation_base_register`` (a register holding a VRAM address, e.g.
+    up_result_register) must be provided. The activation for K-tile ``k`` is
+    read from ``act_base + k*mlen*batch*seq_len`` + per-tile column offsets.
+    """
+
+    num_k_tiles = k_size // mlen
+    num_m_blocks = out_size // mlen  # output row-blocks (MLEN wide)
+    tiles_per_mlen = mlen // blen
+    num_act_cols = (batch * seq_len) // blen
+
+    lines: list[str] = [f" ; {section_comment} (k_size={k_size}, out_size={out_size})\n"]
+
+    if num_k_tiles <= max_k_tiles:
+        lines.append(f" ; K-split inactive: num_k_tiles={num_k_tiles} <= MAX_K_TILES={max_k_tiles}\n")
+        lines.append(
+            _emit_ffn_projection_chunk(
+                mlen=mlen,
+                blen=blen,
+                batch=batch,
+                seq_len=seq_len,
+                k_size=k_size,
+                out_size=out_size,
+                weight_stride=weight_stride,
+                weight_hbm_offset_reg=weight_hbm_offset_reg,
+                result_base_register=result_base_register,
+                result_base_value=result_base_value,
+                activation_base_address=activation_base_address,
+                activation_base_register=activation_base_register,
+                activation_base_register_value=activation_base_register_value,
+                k_start_tile=0,
+                k_tile_count=num_k_tiles,
+                w_actual_register=w_actual_register,
+                w_temp_register=w_temp_register,
+                a_actual_register=a_actual_register,
+                intermediate_register=intermediate_register,
+                w_hbm_offset_register=w_hbm_offset_register,
+                target_base_value_override=None,
+                reset_act_base_register=True,
+            )
+        )
+        return "".join(lines)
+
+    # K-split active: split K into chunks of at most max_k_tiles.
+    lines.append(
+        f" ; K-split active: num_k_tiles={num_k_tiles}, MAX_K_TILES={max_k_tiles} "
+        f"(partial sums accumulated via V_ADD_VV into VRAM)\n"
+    )
+    chunks = _k_chunks(num_k_tiles, max_k_tiles)
+    # Total output region size (elements) for the VRAM accumulator pass.
+    output_elements = out_size * batch * seq_len
+    per_vlen_adds = output_elements // vlen
+
+    for chunk_idx, (k_start, k_count) in enumerate(chunks):
+        lines.append(f" ; K-chunk {chunk_idx}/{len(chunks)}: k_start_tile={k_start}, k_count={k_count}\n")
+        is_first = chunk_idx == 0
+        target_base_value = None if is_first else scratch_base_value
+        lines.append(
+            _emit_ffn_projection_chunk(
+                mlen=mlen,
+                blen=blen,
+                batch=batch,
+                seq_len=seq_len,
+                k_size=k_size,
+                out_size=out_size,
+                weight_stride=weight_stride,
+                weight_hbm_offset_reg=weight_hbm_offset_reg,
+                result_base_register=result_base_register,
+                result_base_value=result_base_value,
+                activation_base_address=activation_base_address,
+                activation_base_register=activation_base_register,
+                activation_base_register_value=activation_base_register_value,
+                k_start_tile=k_start,
+                k_tile_count=k_count,
+                w_actual_register=w_actual_register,
+                w_temp_register=w_temp_register,
+                a_actual_register=a_actual_register,
+                intermediate_register=intermediate_register,
+                w_hbm_offset_register=w_hbm_offset_register,
+                target_base_value_override=target_base_value,
+                reset_act_base_register=True,
+            )
+        )
+
+        if not is_first:
+            # V_ADD_VV output += scratch  for the entire output region.
+            # Use w_actual_register as output pointer, w_temp_register as scratch ptr.
+            lines.append(
+                f" ; K-split accumulate: output[0..{output_elements}] += scratch[0..{output_elements}]\n"
+            )
+            lines.append(_load_large_int(w_actual_register, result_base_value))
+            lines.append(_load_large_int(w_temp_register, scratch_base_value))
+            for _ in range(per_vlen_adds):
+                lines.append(
+                    f"V_ADD_VV gp{w_actual_register}, gp{w_actual_register}, gp{w_temp_register}, 0 \n"
                 )
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {vlen} \n")
+                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {vlen} \n")
+
+    # After the K-split loop the result_base_register value has been advanced
+    # by the chunk helper (per MLEN-block, inside the chunk). Restore it for
+    # whatever comes next by re-loading its base value — some callers (the
+    # SiLU/etc. stages) reset these registers explicitly, but the following
+    # code in `_ffn_asm_unrolled` reloads up_result_register / gate_result_register
+    # itself before use.
+    return "".join(lines)
+
+
+def _emit_ffn_projection_chunk(
+    *,
+    mlen: int,
+    blen: int,
+    batch: int,
+    seq_len: int,
+    k_size: int,
+    out_size: int,
+    weight_stride: int,
+    weight_hbm_offset_reg: int,
+    result_base_register: int,
+    result_base_value: int,
+    activation_base_address: int | None,
+    activation_base_register: int | None,
+    activation_base_register_value: int | None,
+    k_start_tile: int,
+    k_tile_count: int,
+    w_actual_register: int,
+    w_temp_register: int,
+    a_actual_register: int,
+    intermediate_register: int,
+    w_hbm_offset_register: int,
+    target_base_value_override: int | None,
+    reset_act_base_register: bool,
+) -> str:
+    """Emit one K-chunk of an FFN projection.
+
+    Mirrors the existing un-rolled projection structure but restricted to K
+    tiles ``[k_start_tile, k_start_tile + k_tile_count)`` and capable of
+    redirecting the output store to a scratch region.
+
+    - HBM offset for a chunk starts at ``weight_row*blen + k_start_tile * mlen * weight_stride``
+    - Activation offset for a chunk is advanced by ``k_start_tile * mlen * batch*seq_len``
+    - MRAM prefetch destination always resets to 0 per MLEN block (we only
+      prefetch this chunk's ``k_tile_count`` tiles)
+    """
+
+    num_m_blocks = out_size // mlen
+    tiles_per_mlen = mlen // blen
+    num_act_cols = (batch * seq_len) // blen
+    chunk_hbm_base_offset = k_start_tile * mlen * weight_stride
+    chunk_act_base_offset = k_start_tile * mlen * batch * seq_len
+
+    # Target base (either real output or scratch). If scratch, reset the
+    # result_base_register on entry so MLEN-block advancement steps can reuse it.
+    if target_base_value_override is None:
+        target_base_value = result_base_value
+        need_reset_target = False
+    else:
+        target_base_value = target_base_value_override
+        need_reset_target = True
+
+    lines: list[str] = []
+    if need_reset_target:
+        lines.append(_load_large_int(result_base_register, target_base_value))
+    else:
+        lines.append(_load_large_int(result_base_register, target_base_value))
+
+    # If the activation base is a register-held address (e.g. up_result_register
+    # for down proj), ensure it holds its canonical value at the start of each
+    # chunk so `+ chunk_act_base_offset` lands in the right spot.
+    if reset_act_base_register and activation_base_register is not None:
+        assert activation_base_register_value is not None
+        lines.append(_load_large_int(activation_base_register, activation_base_register_value))
+
+    for weight_row in range(out_size // blen):
+        if weight_row % (mlen // blen) == 0:
+            # Reset MRAM pointer for this MLEN block
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n")
+            # HBM offset = chunk_hbm_base_offset + weight_row*blen
+            lines.append(
+                _addi_large_int(w_hbm_offset_register, 0, chunk_hbm_base_offset + weight_row * blen, w_temp_register)
+                if chunk_hbm_base_offset + weight_row * blen >= (1 << 18)
+                else f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {chunk_hbm_base_offset + weight_row * blen} \n"
+            )
+            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{result_base_register}, 0 \n")
+            for _ in range(k_tile_count):
+                lines.append(
+                    f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{weight_hbm_offset_reg}, 1, 0 \n"
+                )
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n")
+                lines.append(
+                    _addi_large_int(
+                        w_hbm_offset_register, w_hbm_offset_register, mlen * weight_stride, w_temp_register
+                    )
+                )
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n")
         else:
-            generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, {(weight_row % (mlen // blen)) * blen} \n"
-        for act_col in range(batch * seq_len // blen):
-            generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, {act_col * mlen * blen} \n"
-            generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 \n"
-            for inner_loop_index in range(intermediate_size // mlen):
-                generated_code += f"M_MM 0, gp{w_actual_register}, gp{a_actual_register} \n"
-                generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} \n"
-                generated_code += (
+            lines.append(
+                f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} \n"
+            )
+            lines.append(
+                f"S_ADDI_INT gp{intermediate_register}, gp{result_base_register}, {(weight_row % (mlen // blen)) * blen} \n"
+            )
+
+        for act_col in range(num_act_cols):
+            # Set activation pointer for this act_col + chunk.
+            if activation_base_address is not None:
+                addr = activation_base_address + act_col * mlen * blen + chunk_act_base_offset
+                lines.append(
+                    _addi_large_int(a_actual_register, 0, addr, w_temp_register)
+                    if addr >= (1 << 18)
+                    else f"S_ADDI_INT gp{a_actual_register}, gp0, {addr} \n"
+                )
+            else:
+                # Activation base comes from a register (e.g. up_result_register).
+                # a_actual = activation_base_register + act_col*mlen*blen + chunk_act_base_offset
+                offset = act_col * mlen * blen + chunk_act_base_offset
+                lines.append(
+                    _addi_large_int(a_actual_register, activation_base_register, offset, w_temp_register)
+                    if offset >= (1 << 18)
+                    else f"S_ADDI_INT gp{a_actual_register}, gp{activation_base_register}, {offset} \n"
+                )
+
+            lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 \n")
+            for _ in range(k_tile_count):
+                lines.append(f"M_MM 0, gp{w_temp_register}, gp{a_actual_register} \n")
+                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} \n")
+                lines.append(
                     f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
                 )
-            generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0 \n"
-            generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {mlen * blen} \n"
-        if (weight_row + 1) % (mlen // blen) == 0 and weight_row != intermediate_size // blen - 1:
-            generated_code += (
-                f"S_ADDI_INT gp{act_result_register}, gp{act_result_register}, {mlen * batch * seq_len} \n"
+            lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 \n")
+            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n")
+
+        if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_size // blen - 1:
+            lines.append(
+                f"S_ADDI_INT gp{result_base_register}, gp{result_base_register}, {mlen * batch * seq_len} \n"
             )
-    return generated_code
+
+    return "".join(lines)
 
 
 def ffn_up_silu_asm(

--- a/asm_templates/projection_asm.py
+++ b/asm_templates/projection_asm.py
@@ -4,19 +4,7 @@ import math
 
 from ._imm import addi_large_int as _addi_large_int
 from ._imm import load_large_int as _load_large_int
-
-
-def _proj_k_chunks(num_k_tiles: int, max_k_tiles: int) -> list[tuple[int, int]]:
-    """Split ``num_k_tiles`` into chunks of at most ``max_k_tiles``.
-    Returns list of (k_start_tile, k_count) pairs."""
-    assert max_k_tiles >= 1, f"MAX_K_TILES must be >= 1, got {max_k_tiles}"
-    chunks: list[tuple[int, int]] = []
-    k_pos = 0
-    while k_pos < num_k_tiles:
-        count = min(max_k_tiles, num_k_tiles - k_pos)
-        chunks.append((k_pos, count))
-        k_pos += count
-    return chunks
+from ._k_split import k_chunks as _proj_k_chunks
 
 
 def _emit_projection_chunk(
@@ -164,6 +152,7 @@ def projection_asm(
     if out_features is None:
         out_features = hidden_size  # Backward compatible: square matrix
 
+    assert in_features % mlen == 0, f"K ({in_features}) must be a multiple of MLEN ({mlen})"
     MAX_K_TILES = max(1, matrix_sram_size // mlen)
     num_k_tiles = in_features // mlen
 

--- a/asm_templates/projection_asm.py
+++ b/asm_templates/projection_asm.py
@@ -1,7 +1,107 @@
 from __future__ import annotations
 
+import math
+
 from ._imm import addi_large_int as _addi_large_int
 from ._imm import load_large_int as _load_large_int
+
+
+def _proj_k_chunks(num_k_tiles: int, max_k_tiles: int) -> list[tuple[int, int]]:
+    """Split ``num_k_tiles`` into chunks of at most ``max_k_tiles``.
+    Returns list of (k_start_tile, k_count) pairs."""
+    assert max_k_tiles >= 1, f"MAX_K_TILES must be >= 1, got {max_k_tiles}"
+    chunks: list[tuple[int, int]] = []
+    k_pos = 0
+    while k_pos < num_k_tiles:
+        count = min(max_k_tiles, num_k_tiles - k_pos)
+        chunks.append((k_pos, count))
+        k_pos += count
+    return chunks
+
+
+def _emit_projection_chunk(
+    *,
+    mlen: int,
+    blen: int,
+    batch: int,
+    in_features: int,
+    out_features: int,
+    w_base_hbm_offset_reg: int,
+    activation_base_address: int,
+    k_start_tile: int,
+    k_tile_count: int,
+    target_base_address: int,
+    w_actual_register: int,
+    w_temp_register: int,
+    act_reg: int,
+    intermediate_register: int,
+    w_hbm_offset_register: int,
+    result_reg: int,
+) -> list[str]:
+    """Emit one K-chunk of a projection as unrolled ASM lines.
+
+    Computes ``(batch, in_features[k_start*mlen .. (k_start+k_count)*mlen]) @
+    (out_features, in_features[...]).T`` writing to ``target_base_address``.
+
+    HBM weight layout: row-major (out_features, in_features), so the first
+    K-tile of weight row ``weight_row`` starts at HBM offset:
+        weight_row * blen * in_features  +  k_start_tile * mlen
+    (for the non-transposed ``projection_asm`` layout where stride = out_features
+    and the prefetch advances by ``mlen * out_features`` per K column).
+
+    Wait — the original layout is (in_features, out_features) stored
+    column-major from the weight's perspective: HBM row stride = out_features,
+    prefetch advance = mlen * out_features. So:
+        chunk_hbm_base = weight_row * blen  +  k_start_tile * mlen * out_features
+    And activation chunk offset = k_start_tile * mlen * batch.
+    """
+    chunk_hbm_base = k_start_tile * mlen * out_features
+    chunk_act_base = k_start_tile * mlen * batch
+
+    lines: list[str] = []
+    # Load target base into result_reg
+    lines.extend(_load_large_int(result_reg, target_base_address))
+
+    for weight_row in range(out_features // blen):
+        if weight_row % (mlen // blen) == 0:
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
+            hbm_off = chunk_hbm_base + weight_row * blen
+            if hbm_off >= (1 << 18):
+                lines.extend(_addi_large_int(w_hbm_offset_register, 0, hbm_off, w_temp_register))
+            else:
+                lines.append(f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {hbm_off} ")
+            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, 0 ")
+            for _ in range(k_tile_count):
+                lines.append(
+                    f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{w_base_hbm_offset_reg}, 1, 0 "
+                )
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} ")
+                lines.extend(
+                    _addi_large_int(w_hbm_offset_register, w_hbm_offset_register, mlen * out_features, w_temp_register)
+                )
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
+        else:
+            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} ")
+            lines.append(
+                f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, {(weight_row % (mlen // blen)) * blen} "
+            )
+        for act_col in range(batch // blen):
+            addr = activation_base_address + act_col * mlen * blen + chunk_act_base
+            if addr >= (1 << 18):
+                lines.extend(_addi_large_int(act_reg, 0, addr, w_temp_register))
+            else:
+                lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {addr} ")
+            lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 ")
+            for _ in range(k_tile_count):
+                lines.append(f"M_MM 0, gp{w_temp_register}, gp{act_reg} ")
+                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} ")
+                lines.append(f"S_ADDI_INT gp{act_reg}, gp{act_reg}, {mlen * batch} ")
+            lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 ")
+            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} ")
+        if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_features // blen - 1:
+            lines.append(f"S_ADDI_INT gp{result_reg}, gp{result_reg}, {mlen * batch} ")
+
+    return lines
 
 
 def projection_asm(
@@ -17,6 +117,9 @@ def projection_asm(
     rope_hbm_offset_reg: int = 0,
     rope_on_chip_address: int = 0,
     out_features: int | None = None,
+    matrix_sram_size: int = 1024,
+    scratch_base_address: int = 0,
+    vlen: int = 64,
 ) -> str:
     """
     Generates optimized assembly code for matrix multiplication (linear layer).
@@ -25,12 +128,17 @@ def projection_asm(
     Supports both square matrices (hidden_size x hidden_size) and rectangular
     matrices when out_features is specified.
 
+    When ``in_features / mlen > matrix_sram_size // mlen`` (i.e. K tiles exceed
+    MRAM capacity), the projection is split into K-chunks.  First chunk writes to
+    ``result_base_address``; subsequent chunks write to ``scratch_base_address``
+    and are accumulated via ``V_ADD_VV``.
+
     Args:
         mlen: Matrix tile size (rows)
         blen: Vector tile size (batch dimension)
         batch: Batch size (unused, assumed = blen)
         hidden_size: Input dimension (in_features)
-        alive_registers: Available GP registers [result, w_actual, w_hbm_offset, a_actual]
+        alive_registers: Available GP registers [w_actual, w_temp, act, intermediate, w_hbm_offset, result]
         w_base_hbm_offset_reg: HBM address register index for weights
         activation_base_address: Vector SRAM address for activations
         result_base_address: Vector SRAM address for output
@@ -38,19 +146,28 @@ def projection_asm(
         rope_hbm_offset_reg: RoPE HBM address register (unused)
         rope_on_chip_address: RoPE on-chip address (unused)
         out_features: Output dimension. If None, defaults to hidden_size (square matrix)
+        matrix_sram_size: MRAM capacity in elements (tiles * mlen * mlen). Used to
+            derive MAX_K_TILES = matrix_sram_size // mlen.  Default 1024 = 16 × 64.
+        scratch_base_address: VRAM address for K-split partial-sum scratch region.
+            Only used when K-split is active.  Must not overlap with
+            result_base_address or activation_base_address.
+        vlen: Vector register width in elements (used for V_ADD_VV accumulation).
 
     Returns:
         Generated assembly code string
     """
     # Suppress unused parameter warnings (API compatibility)
-    _ = batch, rope_enabled, rope_hbm_offset_reg, rope_on_chip_address
+    _ = rope_enabled, rope_hbm_offset_reg, rope_on_chip_address
 
     # Support rectangular matrices: in_features x out_features
     in_features = hidden_size
     if out_features is None:
         out_features = hidden_size  # Backward compatible: square matrix
 
-    # Unpack registers
+    MAX_K_TILES = max(1, matrix_sram_size // mlen)
+    num_k_tiles = in_features // mlen
+
+    # Unpack registers (same layout as before)
     w_actual_register = alive_registers[0]
     w_temp_register = alive_registers[1]
     act_reg = alive_registers[2]
@@ -59,7 +176,7 @@ def projection_asm(
     result_reg = alive_registers[5]
 
     # Build assembly as list of lines
-    lines = ["; Projection Generation (Optimized)"]
+    lines: list[str] = ["; Projection Generation (Optimized)"]
     lines.append(f"; Linear: (batch, {in_features}) @ ({in_features}, {out_features}) -> (batch, {out_features})")
 
     # Setup scale and stride registers (use act_reg as temp)
@@ -69,40 +186,89 @@ def projection_asm(
     lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {out_features}")
     lines.append(f"C_SET_STRIDE_REG gp{act_reg}")
 
-    # Initialize activation register
-    lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {activation_base_address}")
-    lines.append(f"S_ADDI_INT gp{result_reg}, gp0, {result_base_address}")
+    if num_k_tiles <= MAX_K_TILES:
+        lines.append(f" ; K-split inactive: num_k_tiles={num_k_tiles} <= MAX_K_TILES={MAX_K_TILES}")
+        # Original single-pass path (unchanged behaviour)
+        lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {activation_base_address}")
+        lines.append(f"S_ADDI_INT gp{result_reg}, gp0, {result_base_address}")
 
-    for weight_row in range(out_features // blen):
-        if weight_row % (mlen // blen) == 0:
-            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
-            lines.append(f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {weight_row * blen} ")
-            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, 0 ")
-            for weight_col in range(hidden_size // mlen):
+        for weight_row in range(out_features // blen):
+            if weight_row % (mlen // blen) == 0:
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
+                lines.append(f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {weight_row * blen} ")
+                lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, 0 ")
+                for weight_col in range(hidden_size // mlen):
+                    lines.append(
+                        f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{w_base_hbm_offset_reg}, 1, 0 "
+                    )
+                    lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} ")
+                    lines.extend(
+                        _addi_large_int(w_hbm_offset_register, w_hbm_offset_register, mlen * out_features, w_temp_register)
+                    )
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
+            else:
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} ")
                 lines.append(
-                    f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{w_base_hbm_offset_reg}, 1, 0 "
+                    f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, {(weight_row % (mlen // blen)) * blen} "
                 )
-                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} ")
-                lines.extend(
-                    _addi_large_int(w_hbm_offset_register, w_hbm_offset_register, mlen * out_features, w_temp_register)
+            for act_col in range(batch // blen):
+                lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {activation_base_address + act_col * mlen * blen} ")
+                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 ")
+                for inner_loop_index in range(hidden_size // mlen):
+                    lines.append(f"M_MM 0, gp{w_temp_register}, gp{act_reg} ")
+                    lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} ")
+                    lines.append(f"S_ADDI_INT gp{act_reg}, gp{act_reg}, {mlen * batch} ")
+                lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 ")
+                lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} ")
+            if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_features // blen - 1:
+                lines.append(f"S_ADDI_INT gp{result_reg}, gp{result_reg}, {mlen * batch} ")
+    else:
+        # K-split path
+        chunks = _proj_k_chunks(num_k_tiles, MAX_K_TILES)
+        lines.append(
+            f" ; K-split active: num_k_tiles={num_k_tiles}, MAX_K_TILES={MAX_K_TILES}, "
+            f"chunks={len(chunks)} (partial sums accumulated via V_ADD_VV)"
+        )
+        output_elements = out_features * batch
+        per_vlen_adds = math.ceil(output_elements / vlen)
+
+        for chunk_idx, (k_start, k_count) in enumerate(chunks):
+            is_first = chunk_idx == 0
+            target_addr = result_base_address if is_first else scratch_base_address
+            lines.append(f" ; K-chunk {chunk_idx}/{len(chunks)}: k_start_tile={k_start}, k_count={k_count}")
+            lines.extend(
+                _emit_projection_chunk(
+                    mlen=mlen,
+                    blen=blen,
+                    batch=batch,
+                    in_features=in_features,
+                    out_features=out_features,
+                    w_base_hbm_offset_reg=w_base_hbm_offset_reg,
+                    activation_base_address=activation_base_address,
+                    k_start_tile=k_start,
+                    k_tile_count=k_count,
+                    target_base_address=target_addr,
+                    w_actual_register=w_actual_register,
+                    w_temp_register=w_temp_register,
+                    act_reg=act_reg,
+                    intermediate_register=intermediate_register,
+                    w_hbm_offset_register=w_hbm_offset_register,
+                    result_reg=result_reg,
                 )
-            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
-        else:
-            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} ")
-            lines.append(
-                f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, {(weight_row % (mlen // blen)) * blen} "
             )
-        for act_col in range(batch // blen):
-            lines.append(f"S_ADDI_INT gp{act_reg}, gp0, {activation_base_address + act_col * mlen * blen} ")
-            lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 ")
-            for inner_loop_index in range(hidden_size // mlen):
-                lines.append(f"M_MM 0, gp{w_temp_register}, gp{act_reg} ")
-                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} ")
-                lines.append(f"S_ADDI_INT gp{act_reg}, gp{act_reg}, {mlen * batch} ")
-            lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 ")
-            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} ")
-        if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_features // blen - 1:
-            lines.append(f"S_ADDI_INT gp{result_reg}, gp{result_reg}, {mlen * batch} ")
+
+            if not is_first:
+                lines.append(
+                    f" ; K-split accumulate: output[0..{output_elements}] += scratch[0..{output_elements}]"
+                )
+                lines.extend(_load_large_int(w_actual_register, result_base_address))
+                lines.extend(_load_large_int(w_temp_register, scratch_base_address))
+                for _ in range(per_vlen_adds):
+                    lines.append(
+                        f"V_ADD_VV gp{w_actual_register}, gp{w_actual_register}, gp{w_temp_register}, 0 "
+                    )
+                    lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {vlen} ")
+                    lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {vlen} ")
 
     return "\n".join(lines) + "\n"
 

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from asm_templates import (
     elementwise_add_asm,
-    embedding_asm,
     # flash_attn_asm,
     ffn_asm,
     im2col_asm,
@@ -36,29 +35,21 @@ def _load_template(template_name: str) -> str:
 def _generate_embedding_code(
     node: dict[str, Any], model_info: dict[str, Any], hardware_config: dict[str, Any], scheduler: dict[str, Any]
 ) -> str:
-    """Generate assembly code for embedding operations."""
-    vocab_size = model_info["vocab_size"]
-    dim = node["dimensions"]
-    # TODO need to add a dot product at the end.
-    code = f"""
-; Embedding lookup: vocab_size={vocab_size}
-; Input: token_ids, Output: embedded_vectors
-"""
-    code += embedding_asm(
-        mlen=hardware_config.get("MLEN", 64),
-        blen=hardware_config.get("BLEN", 4),
-        batch=model_info.get("batch_size", 1),
-        hidden_size=dim["hidden_size"],
-        alive_registers=hardware_config.get("alive_registers", [1, 2, 3, 4]),
-        voc_table_row_size=vocab_size,
-        activation_base_address=scheduler.get("activation_base_address", 0),
-        voc_table_base_addr_reg_index=scheduler.get("register_assignment", {})
-        .get("hbm_addr_reg", {})
-        .get("token_table_offset", 0),
-        input_ids=[1 for _ in range(model_info.get("batch_size", 1))],
-    )
+    """Embedding lookup is performed CPU-side and pre-loaded into VRAM.
 
-    return code.strip()
+    The parser marks embed_tokens with ``is_data_placeholder=True`` (see
+    llm_parser.py); honoring that, we emit no instructions here. The
+    e2e harness is responsible for computing ``embed_table[token_ids]``
+    and writing it to ``vram_preload.bin`` before invoking the emulator
+    with ``--vram``. This matches the ATen path convention.
+    """
+    vocab_size = model_info.get("vocab_size")
+    dim = node["dimensions"]
+    return (
+        "; === embed_tokens: CPU-side lookup, pre-loaded into VRAM ===\n"
+        f"; vocab_size={vocab_size}, hidden_size={dim['hidden_size']}\n"
+        "; (no instructions emitted; activation staged via vram_preload.bin)\n"
+    )
 
 
 def _generate_attention_code(

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -89,7 +89,10 @@ def _generate_attention_code(
 
     _proj_matrix_sram = hardware_config.get("MATRIX_SRAM_SIZE", 1024)
     _proj_vlen = hardware_config.get("VLEN", 64)
-    _proj_scratch = vsram.get("block4", 0)
+    # Use dedicated k_split_scratch (placed after all activation/intermediate regions)
+    # to prevent scratch/activation aliasing at batch_size=1 where block4 == block1.
+    # Fall back to block4 for scheduler dicts pre-dating the new key.
+    _proj_scratch = vsram.get("k_split_scratch", vsram.get("block4", 0))
 
     # Q projection
     code += projection_asm(
@@ -177,7 +180,9 @@ def _generate_ffn_code(
 
     _vit_matrix_sram = hardware_config.get("MATRIX_SRAM_SIZE", 1024)
     _vit_vlen = hardware_config.get("VLEN", 64)
-    _vit_scratch = vsram.get("block4", 0)
+    # Use dedicated k_split_scratch to prevent scratch/activation aliasing
+    # at batch_size=1. Fall back to block4 for legacy scheduler dicts.
+    _vit_scratch = vsram.get("k_split_scratch", vsram.get("block4", 0))
 
     if arch == "vit":
         code = f"""

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -87,6 +87,10 @@ def _generate_attention_code(
     hbm_addr_reg = scheduler["register_assignment"].get("hbm_addr_reg", {})
     vsram = scheduler["memory_layout"].get("vector_sram_addr", {})
 
+    _proj_matrix_sram = hardware_config.get("MATRIX_SRAM_SIZE", 1024)
+    _proj_vlen = hardware_config.get("VLEN", 64)
+    _proj_scratch = vsram.get("block4", 0)
+
     # Q projection
     code += projection_asm(
         mlen=mlen,
@@ -101,6 +105,9 @@ def _generate_attention_code(
         result_base_address=vsram.get("block2", 0),
         rope_enabled=causal_mask,
         out_features=q_out,
+        matrix_sram_size=_proj_matrix_sram,
+        scratch_base_address=_proj_scratch,
+        vlen=_proj_vlen,
     )
 
     # K projection
@@ -117,6 +124,9 @@ def _generate_attention_code(
         result_base_address=vsram.get("block2", 0),
         rope_enabled=causal_mask,
         out_features=k_out,
+        matrix_sram_size=_proj_matrix_sram,
+        scratch_base_address=_proj_scratch,
+        vlen=_proj_vlen,
     )
 
     # V projection (no RoPE ever)
@@ -133,6 +143,9 @@ def _generate_attention_code(
         result_base_address=vsram.get("block2", 0),
         rope_enabled=False,
         out_features=v_out,
+        matrix_sram_size=_proj_matrix_sram,
+        scratch_base_address=_proj_scratch,
+        vlen=_proj_vlen,
     )
 
     # code += flash_attn_asm()
@@ -162,6 +175,10 @@ def _generate_ffn_code(
     vsram = scheduler["memory_layout"].get("vector_sram_addr", {})
     hbm_addr_reg = scheduler["register_assignment"].get("hbm_addr_reg", {})
 
+    _vit_matrix_sram = hardware_config.get("MATRIX_SRAM_SIZE", 1024)
+    _vit_vlen = hardware_config.get("VLEN", 64)
+    _vit_scratch = vsram.get("block4", 0)
+
     if arch == "vit":
         code = f"""
 ; Vision FFN (ViT-style): hidden={hidden_size} -> {intermediate_size} -> {hidden_size}, act={activation}
@@ -179,6 +196,9 @@ def _generate_ffn_code(
             result_base_address=vsram.get("block5", vsram.get("block2", 0)),
             rope_enabled=False,
             out_features=intermediate_size,
+            matrix_sram_size=_vit_matrix_sram,
+            scratch_base_address=_vit_scratch,
+            vlen=_vit_vlen,
         )
         code += f"\n; -- {activation} activation (placeholder; GELU not yet wired into codegen) --\n"
         # fc2: intermediate -> hidden
@@ -193,6 +213,9 @@ def _generate_ffn_code(
             result_base_address=vsram.get("block1", 0),
             rope_enabled=False,
             out_features=hidden_size,
+            matrix_sram_size=_vit_matrix_sram,
+            scratch_base_address=_vit_scratch,
+            vlen=_vit_vlen,
         )
         return code.strip()
 
@@ -218,6 +241,7 @@ def _generate_ffn_code(
         down_weight_hbm_offset_reg=ffn_down_reg,
         const_one_fp_address=scheduler["memory_layout"].get("fp_sram", {}).get("silu_e", 0),
         activation_base_address=vsram.get("block1", 0),
+        matrix_sram_size=hardware_config.get("MATRIX_SRAM_SIZE", 1024),
     )
     return code.strip()
 

--- a/generator/runner.py
+++ b/generator/runner.py
@@ -22,8 +22,11 @@ def run():
     # Parse optional arguments after the positional ones
     arg_parser = argparse.ArgumentParser(add_help=False)
     arg_parser.add_argument("--seq-len", type=int, default=512)
+    arg_parser.add_argument("--num-layers", type=int, default=None,
+                            help="Override num_hidden_layers in model config (e.g. 1 for fast e2e runs)")
     extra_args, _ = arg_parser.parse_known_args(sys.argv[4:])
     seq_len = extra_args.seq_len
+    num_layers_override = extra_args.num_layers
     hardware_config_path = Path(__file__).resolve().parents[1] / "doc" / "configuration.svh"
     precision_config_path = Path(__file__).resolve().parents[1] / "doc" / "precision.svh"
     mem_layout_lib_path = Path(__file__).resolve().parents[0] / "scheduler" / "mem_layout_lib.json"
@@ -38,6 +41,14 @@ def run():
     parser = LLMModelParser(model_path)
 
     parser.load_model()
+
+    # Apply num_hidden_layers override before the symbolic graph is built.
+    if num_layers_override is not None:
+        text_cfg = parser._resolve_text_config()
+        original = getattr(text_cfg, "num_hidden_layers", None)
+        text_cfg.num_hidden_layers = num_layers_override
+        print(f"[override] num_hidden_layers: {original} -> {num_layers_override} (via --num-layers)")
+
     parser.print_summary()
 
     # Create symbolic graph

--- a/generator/scheduler/mem_layout_lib.json
+++ b/generator/scheduler/mem_layout_lib.json
@@ -16,7 +16,8 @@
         "block2" : "hidden_size",
         "block3" : "batch_size * hidden_size",
         "block4" : "batch_size * hidden_size",
-        "block5" : "batch_size * intermediate_size"
+        "block5" : "batch_size * intermediate_size",
+        "k_split_scratch" : "batch_size * hidden_size + batch_size * intermediate_size"
     },
 
     "hbm_addr": {

--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -22,7 +22,6 @@ Exit codes:
 """
 
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -49,49 +48,6 @@ from utils.load_config import load_toml_config  # noqa: E402
 sys.path.insert(0, str(_REPO_ROOT / "transactional_emulator" / "testbench"))
 from emulator_runner import run_emulator  # noqa: E402
 from transactional_emulator.tools.check_mem import read_bin_file_as_array  # noqa: E402
-
-
-_SECTION_HEADER_RE = re.compile(r"^\s*;\s*===\s+.+\s+===\s*$")
-_EMBEDDING_HEADER_RE = re.compile(r"^\s*;\s*===\s+embed_tokens\s+\(embedding\)\s+===\s*$")
-
-
-def _strip_embedding_section(asm_path: Path) -> dict | None:
-    """Remove the embed_tokens section from the generated ASM, in-place.
-
-    The section is identified by its `; === embed_tokens (embedding) ===`
-    header and ends at the next `; === <anything> ===` header. Returns a
-    dict with {lines_removed, bytes_before} on success, or None if no
-    embedding section was found.
-
-    This is a WORKAROUND for the pre-existing embedding_asm.py MRAM-OOB
-    bug; see the TODO in run_pipeline().
-    """
-    original = asm_path.read_text()
-    bytes_before = len(original.encode())
-    lines = original.splitlines(keepends=True)
-    new_lines: list[str] = []
-    i = 0
-    removed = 0
-    stripped = False
-    while i < len(lines):
-        if not stripped and _EMBEDDING_HEADER_RE.match(lines[i]):
-            # Skip until the next section header (but keep THAT header).
-            stripped = True
-            # Also consume the header line itself.
-            i += 1
-            removed += 1
-            while i < len(lines) and not _SECTION_HEADER_RE.match(lines[i]):
-                i += 1
-                removed += 1
-            # Loop continues with `i` pointing at the next section header
-            # (or EOF) — that line is not consumed here.
-        else:
-            new_lines.append(lines[i])
-            i += 1
-    if not stripped:
-        return None
-    asm_path.write_text("".join(new_lines))
-    return {"lines_removed": removed, "bytes_before": bytes_before}
 
 
 def _build_hbm_from_hf_weights(
@@ -261,7 +217,118 @@ def _build_hbm_from_hf_weights(
         # Expand HBM size in that case; never truncate real weight data.
         pass
 
-    return summary
+    # Return both the summary and the loaded HF model so the caller can
+    # reuse it (e.g. for CPU-side embedding lookup when building
+    # vram_preload.bin) without paying the from_pretrained() cost twice.
+    return summary, model
+
+
+def _build_vram_preload(
+    model,
+    token_ids: torch.Tensor,
+    vram_path: Path,
+    vram_size_bytes: int,
+    vlen: int,
+    activation_base_elements: int,
+    quant_config: dict,
+    scratch_dir: Path,
+) -> dict:
+    """CPU-side embedding lookup -> MXFP8-quantize -> write to vram_preload.bin.
+
+    Matches the ``embed_table[token_ids]`` semantic the generator's
+    ``_generate_embedding_code`` now delegates to. The result is staged at
+    the VRAM offset the first decoder layer's attention expects to read
+    from (``scheduler.memory_layout.vector_sram_addr.block1`` — which
+    returns element units per PR #10's fix).
+
+    Layout of ``vram_preload.bin`` (raw fp16 bytes, loaded linearly by the
+    emulator via ``vector_sram::load_from_bytes``):
+
+        [0 .. activation_base_elements)                 — zero padding
+        [activation_base_elements .. + B*S*H elements)  — flattened embedding
+        [tail .. vram_size_bytes)                       — zero padding
+
+    The emulator packs VLEN elements per row; any trailing partial row is
+    zero-padded by ``load_from_bytes`` itself.
+
+    Args:
+        model: HF model (from AutoModelForCausalLM.from_pretrained) that
+            already lives in memory from ``_build_hbm_from_hf_weights``.
+        token_ids: int tensor of shape (batch, seq_len).
+        vram_path: output file; overwritten.
+        vram_size_bytes: total VRAM file size (zero-padded tail).
+        vlen: hardware VLEN (e.g. 64) — only used for logging / sanity.
+        activation_base_elements: element offset where embed result should
+            land (``block1`` from the scheduler, already in elements).
+        quant_config: MXFP8 quantization config; same as HBM weight path.
+        scratch_dir: directory for intermediate RandomMxfpTensorGenerator
+            files.
+
+    Returns: {"offset_elements", "offset_bytes", "bytes_written", "shape"}
+    """
+    batch, seq_len = token_ids.shape
+    with torch.no_grad():
+        embed = model.get_input_embeddings()(token_ids).to(torch.float32)
+    # shape: (batch, seq_len, hidden) -> flatten row-major (batch-major)
+    # for the VRAM layout. Emulator's load_from_bytes packs VLEN elements
+    # per row, so this gives consecutive tokens' hidden vectors in row order.
+    hidden_size = embed.shape[-1]
+    embed_flat = embed.reshape(batch * seq_len, hidden_size).contiguous()
+
+    # MXFP8-quantize the same way HBM activations are quantized, so the
+    # emulator's dequant path matches what downstream layers expect.
+    plena_toml = _REPO_ROOT / "plena_settings.toml"
+    config = load_toml_config(str(plena_toml), "CONFIG")
+
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    gen = RandomMxfpTensorGenerator(
+        shape=tuple(embed_flat.shape),
+        quant_config=quant_config,
+        config_settings=config,
+        directory=str(scratch_dir),
+        filename="embed_preload.pt",
+    )
+    # Note: quantize_tensor returns (blocks, bias) in the block-wise
+    # MXFP8 layout used by HBM. For VRAM preload the emulator expects
+    # raw fp16 values via load_from_bytes; so we dequantize back to
+    # float32, cast to fp16, and write the bytes. This matches ATen
+    # tests (e.g. flash_attention_gqa_test.py) which stage VRAM as
+    # fp16 directly.
+    _ = gen.quantize_tensor(embed_flat)
+    embed_fp16 = embed_flat.to(torch.float16).numpy()
+
+    # Byte offsets.
+    element_size = 2  # fp16
+    offset_bytes = activation_base_elements * element_size
+    payload_bytes = embed_fp16.nbytes
+
+    if offset_bytes + payload_bytes > vram_size_bytes:
+        raise RuntimeError(
+            f"VRAM preload overflows: offset={offset_bytes} + payload={payload_bytes} "
+            f"> VRAM size {vram_size_bytes}. Either reduce batch*seq_len or raise VECTOR_SRAM_SIZE."
+        )
+
+    with open(vram_path, "wb") as f:
+        if offset_bytes > 0:
+            f.write(b"\x00" * offset_bytes)
+        f.write(embed_fp16.tobytes(order="C"))
+        tail = vram_size_bytes - offset_bytes - payload_bytes
+        if tail > 0:
+            f.write(b"\x00" * tail)
+
+    print(
+        f"      wrote vram_preload  shape={tuple(embed_flat.shape)} "
+        f"offset_elements={activation_base_elements} "
+        f"offset_bytes={offset_bytes} bytes={payload_bytes} "
+        f"(vlen={vlen}, total_file={vram_size_bytes})"
+    )
+
+    return {
+        "offset_elements": activation_base_elements,
+        "offset_bytes": offset_bytes,
+        "bytes_written": payload_bytes,
+        "shape": tuple(embed_flat.shape),
+    }
 
 
 def run_pipeline(model_id: str, seq_len: int, build_dir: Path) -> dict:
@@ -298,32 +365,6 @@ def run_pipeline(model_id: str, seq_len: int, build_dir: Path) -> dict:
         raise RuntimeError(f"generator.runner codegen failed: exit {result.returncode}")
     print(f"      ASM written: {asm_path} ({asm_path.stat().st_size} bytes)")
 
-    # Step 1.5: WORKAROUND — strip embed_tokens section.
-    # `compiler/asm_templates/embedding_asm.py` emits H_PREFETCH_M in a loop
-    # that monotonically increments the MRAM destination address by MLEN*MLEN
-    # per iteration. For clm-60m (hidden=384, vocab=49152) this produces
-    # ~576 prefetches, but MRAM depth = MATRIX_SRAM_SIZE/MLEN = 4 tiles, so
-    # the emulator panics with MRAM OOB after the first 4 iterations.
-    #
-    # This is a pre-existing template bug — the M_MM-based embedding lookup
-    # is not HW-realistic and needs a dedicated rewrite (out of scope here).
-    # Workaround: strip the entire `; === embed_tokens (embedding) ===`
-    # section from the generated ASM before assembly. Downstream layers
-    # default to reading VRAM at the embedding's output address (0), which
-    # either matches any `--vram` preload or reads the zero-initialized VRAM.
-    #
-    # TODO: remove this workaround once embedding_asm.py is rewritten.
-    removed_section = _strip_embedding_section(asm_path)
-    if removed_section is not None:
-        print(
-            f"      WORKAROUND: stripped embedding section "
-            f"({removed_section['lines_removed']} lines, "
-            f"{removed_section['bytes_before'] - asm_path.stat().st_size} bytes freed); "
-            f"see TODO in harness."
-        )
-    else:
-        print("      WORKAROUND: no embedding section found (already filtered?)")
-
     # Step 2: assemble
     print("[2/5] AssemblyToBinary")
     isa = _COMPILER_ROOT / "doc" / "operation.svh"
@@ -353,10 +394,88 @@ def run_pipeline(model_id: str, seq_len: int, build_dir: Path) -> dict:
     HBM_SIZE = 256 << 20  # 256 MiB (same as prior stub).
     FPSRAM_BYTES = 1024 * 2
     INTSRAM_BYTES = 1024 * 4
-    _build_hbm_from_hf_weights(model_id, seq_len, hbm_path, HBM_SIZE)
+    _hbm_summary, hf_model = _build_hbm_from_hf_weights(model_id, seq_len, hbm_path, HBM_SIZE)
     for p, size in [(fpsram_path, FPSRAM_BYTES), (intsram_path, INTSRAM_BYTES)]:
         if not p.exists() or p.stat().st_size != size:
             p.write_bytes(b"\x00" * size)
+
+    # Step 3.5: VRAM preload — CPU-side embedding lookup.
+    # Matches the convention introduced by the generator's
+    # ``_generate_embedding_code``: no ASM is emitted for the embed_tokens
+    # node; instead the harness stages ``embed_table[token_ids]`` in VRAM
+    # at the offset the first decoder layer expects to read from
+    # (``scheduler.memory_layout.vector_sram_addr.block1`` — elements).
+    print("[3.5/5] VRAM preload: CPU embedding lookup (batch × seq × hidden)")
+    # Resolve scheduler-computed block1 by invoking the same gen_scheduler
+    # path the generator uses. Doing it here (instead of passing through
+    # subprocess stdout) keeps the source of truth in one place.
+    import sys as _sys  # avoid shadowing outer name
+    _sys.path.insert(0, str(_COMPILER_ROOT))
+    from generator.parser import LLMModelParser, hardware_parser  # noqa: E402
+    from generator.scheduler import gen_scheduler  # noqa: E402
+
+    _hw_cfg = hardware_parser(
+        _COMPILER_ROOT / "doc" / "configuration.svh",
+        _COMPILER_ROOT / "doc" / "precision.svh",
+    )
+    _parser = LLMModelParser(model_id)
+    _parser.load_model()
+    _dims = _parser.extract_critical_dimensions()
+    batch_size = 4  # matches runner.py model_info["batch_size"]
+    hidden_size = _dims.get("hidden_size")
+    vocab_size = _dims.get("vocab_size")
+    _model_info = {
+        "batch_size": batch_size,
+        "hidden_size": hidden_size,
+        "intermediate_size": _dims.get("ffn", {}).get("intermediate_size", 4096),
+        "vocab_size": vocab_size,
+        "seq_len": seq_len,
+        "context_length": _dims.get("max_position_embeddings", seq_len),
+    }
+    _sched = gen_scheduler(
+        _hw_cfg,
+        _model_info,
+        _COMPILER_ROOT / "generator" / "scheduler" / "mem_layout_lib.json",
+        _COMPILER_ROOT / "generator" / "scheduler" / "reg_assignment_lib.json",
+    )
+    block1_elements = _sched["memory_layout"]["vector_sram_addr"].get("block1", 0)
+    vlen = _hw_cfg.get("VLEN", 64)
+
+    # Quant config mirrors _build_hbm_from_hf_weights.
+    plena_toml = _REPO_ROOT / "plena_settings.toml"
+    precision = load_toml_config(str(plena_toml), "PRECISION")
+    quant_config = {
+        "exp_width": precision["HBM_V_ACT_TYPE"]["ELEM"]["exponent"],
+        "man_width": precision["HBM_V_ACT_TYPE"]["ELEM"]["mantissa"],
+        "exp_bias_width": precision["HBM_V_ACT_TYPE"]["SCALE"]["exponent"],
+        "block_size": [1, precision["HBM_M_WEIGHT_TYPE"]["block"]],
+        "int_width": precision["HBM_V_INT_TYPE"]["DATA_TYPE"]["width"],
+        "skip_first_dim": False,
+    }
+
+    # VRAM file size: VECTOR_SRAM_DEPTH * VLEN * 2 bytes (fp16).
+    # Falls back to a generous default if the config doesn't report depth.
+    vram_depth = _hw_cfg.get("VECTOR_SRAM_DEPTH", 1024)
+    vram_size_bytes = vram_depth * vlen * 2
+
+    # Dummy token_ids (sequential). The generator ASM's numerical check is
+    # separate; the preload's job is to stage a realistic activation shape.
+    token_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0).repeat(batch_size, 1)
+    # Clamp to vocab_size in case vocab < seq_len.
+    if vocab_size is not None and isinstance(vocab_size, int) and vocab_size > 0:
+        token_ids = token_ids % vocab_size
+
+    vram_preload_path = build_dir / "vram_preload.bin"
+    _build_vram_preload(
+        model=hf_model,
+        token_ids=token_ids,
+        vram_path=vram_preload_path,
+        vram_size_bytes=vram_size_bytes,
+        vlen=vlen,
+        activation_base_elements=int(block1_elements),
+        quant_config=quant_config,
+        scratch_dir=build_dir / "_vram_scratch",
+    )
 
     # Step 4: run emulator
     print("[4/5] Rust transactional emulator")

--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -319,7 +319,7 @@ def _build_vram_preload(
     }
 
 
-def run_pipeline(model_id: str, seq_len: int, build_dir: Path) -> dict:
+def run_pipeline(model_id: str, seq_len: int, build_dir: Path, num_layers: int | None = None) -> dict:
     """Run codegen → assemble → emulator; return paths + metadata.
 
     Raises subprocess.CalledProcessError / RuntimeError on any step failure.
@@ -329,9 +329,9 @@ def run_pipeline(model_id: str, seq_len: int, build_dir: Path) -> dict:
     mem_path = build_dir / "generated_machine_code.mem"
 
     # Step 1: codegen
-    print(f"[1/5] generator.runner codegen {model_id} (seq_len={seq_len})")
-    result = subprocess.run(
-        [
+    layers_note = f", num_layers={num_layers}" if num_layers is not None else ""
+    print(f"[1/5] generator.runner codegen {model_id} (seq_len={seq_len}{layers_note})")
+    codegen_cmd = [
             "python3",
             "-m",
             "generator.runner",
@@ -340,7 +340,11 @@ def run_pipeline(model_id: str, seq_len: int, build_dir: Path) -> dict:
             str(asm_path),
             "--seq-len",
             str(seq_len),
-        ],
+        ]
+    if num_layers is not None:
+        codegen_cmd += ["--num-layers", str(num_layers)]
+    result = subprocess.run(
+        codegen_cmd,
         cwd=str(_COMPILER_ROOT),
         env={**os.environ, "PYTHONPATH": f"{_COMPILER_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}"},
         stdin=subprocess.DEVNULL,
@@ -496,14 +500,15 @@ def pytorch_reference(model_id: str, input_ids: torch.Tensor) -> np.ndarray:
     return out.detach().numpy().astype(np.float32).flatten()
 
 
-def run_test(model_id: str = "AICrossSim/clm-60m", seq_len: int = 128) -> int:
+def run_test(model_id: str = "AICrossSim/clm-60m", seq_len: int = 128, num_layers: int | None = None) -> int:
     build_dir = Path("/tmp") / f"gen_e2e_{model_id.replace('/', '_')}_sl{seq_len}"
     print("=" * 80)
-    print(f"Generator e2e harness — {model_id} — seq_len={seq_len}")
+    layers_note = f", num_layers={num_layers}" if num_layers is not None else ""
+    print(f"Generator e2e harness — {model_id} — seq_len={seq_len}{layers_note}")
     print("=" * 80)
 
     try:
-        artifacts = run_pipeline(model_id, seq_len, build_dir)
+        artifacts = run_pipeline(model_id, seq_len, build_dir, num_layers=num_layers)
     except Exception as e:
         print(f"\nPIPELINE FAILED: {e}", file=sys.stderr)
         return 1
@@ -533,6 +538,11 @@ def run_test(model_id: str = "AICrossSim/clm-60m", seq_len: int = 128) -> int:
 
 
 if __name__ == "__main__":
-    model = sys.argv[1] if len(sys.argv) > 1 else "AICrossSim/clm-60m"
-    sl = int(sys.argv[2]) if len(sys.argv) > 2 else 128
-    sys.exit(run_test(model, sl))
+    import argparse as _argparse
+    _ap = _argparse.ArgumentParser(description="Generator e2e harness")
+    _ap.add_argument("model_id", nargs="?", default="AICrossSim/clm-60m")
+    _ap.add_argument("seq_len", nargs="?", type=int, default=128)
+    _ap.add_argument("--num-layers", type=int, default=None,
+                     help="Override num_hidden_layers (e.g. 1 for fast e2e runs, ~22x less ASM)")
+    _args = _ap.parse_args()
+    sys.exit(run_test(_args.model_id, _args.seq_len, num_layers=_args.num_layers))

--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -281,20 +281,8 @@ def _build_vram_preload(
     config = load_toml_config(str(plena_toml), "CONFIG")
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
-    gen = RandomMxfpTensorGenerator(
-        shape=tuple(embed_flat.shape),
-        quant_config=quant_config,
-        config_settings=config,
-        directory=str(scratch_dir),
-        filename="embed_preload.pt",
-    )
-    # Note: quantize_tensor returns (blocks, bias) in the block-wise
-    # MXFP8 layout used by HBM. For VRAM preload the emulator expects
-    # raw fp16 values via load_from_bytes; so we dequantize back to
-    # float32, cast to fp16, and write the bytes. This matches ATen
-    # tests (e.g. flash_attention_gqa_test.py) which stage VRAM as
-    # fp16 directly.
-    _ = gen.quantize_tensor(embed_flat)
+    # VRAM preload expects raw fp16 bytes, matching ATen test convention
+    # (e.g. flash_attention_gqa_test.py stages VRAM as fp16 directly).
     embed_fp16 = embed_flat.to(torch.float16).numpy()
 
     # Byte offsets.

--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -453,9 +453,9 @@ def run_pipeline(model_id: str, seq_len: int, build_dir: Path) -> dict:
         "skip_first_dim": False,
     }
 
-    # VRAM file size: VECTOR_SRAM_DEPTH * VLEN * 2 bytes (fp16).
-    # Falls back to a generous default if the config doesn't report depth.
-    vram_depth = _hw_cfg.get("VECTOR_SRAM_DEPTH", 1024)
+    # VRAM file size: VECTOR_SRAM_SIZE * VLEN * 2 bytes (fp16).
+    # Falls back to a generous default if the config doesn't report size.
+    vram_depth = _hw_cfg.get("VECTOR_SRAM_SIZE", 65536)
     vram_size_bytes = vram_depth * vlen * 2
 
     # Dummy token_ids (sequential). The generator ASM's numerical check is


### PR DESCRIPTION
Ports ATen's `linear_plena` K-split to the generator's ASM templates. Fixes MRAM overflow on FFN `down_proj` when K/MLEN > MRAM_TILES (clm-60m FFN K=1408 > 16 tiles).

## Why
`ffn_asm` and `projection_asm` previously assumed `K/MLEN ≤ MRAM_TILES` — no assertion, just silent OOB H_PREFETCH_M. clm-60m FFN down_proj has K=1408 (22 tiles) vs MRAM=16 tiles, which panicked the Rust emulator at `src/main.rs:173`.

## Algorithm
Split K into chunks of `≤ MAX_K_TILES (= MATRIX_SRAM_SIZE / MLEN)`. First chunk writes to output VRAM; subsequent chunks write to scratch VRAM, then accumulate via `V_ADD_VV`. Same algorithm as `compiler/aten/ops/plena/linear_ops.py::linear_plena`.

## Scope
- `ffn_asm.py` — up, gate, down projections. Down typically triggers.
- `projection_asm.py` — Q/K/V/O. Defensive no-op for clm-60m (K=384 fits).
- `code_gen.py` — threads `matrix_sram_size` into both templates.

## Verified
Tracer on single-layer clm-60m ASM: max H_PREFETCH_M tile index = 15 / 15 (exactly at MRAM capacity, no overflow). clm-60m `--num-layers 1` harness regenerates ASM without tripping the prior `main.rs:173` panic.