### PR TITLE
feat(harness): seed fp_sram.bin with FPRAM constants

### DIFF
--- a/asm_templates/flashattn/online_softmax.py
+++ b/asm_templates/flashattn/online_softmax.py
@@ -17,7 +17,7 @@ def online_softmax_code(
     alive_registers_fp: list[int],
     s_address: int,
     m_start_address: int,
-    qk_scale_address: int = 1,
+    qk_scale_address: int = 5,  # was 1; canonical slot is now 5 (attn_scale)
 ) -> str:
     """
     Args:
@@ -25,7 +25,7 @@ def online_softmax_code(
     alive_registers_int: the list of alive registers for fix point operations
     alive_registers_fp: the list of alive registers for floating point operations
     mlen: also Br: the number of row of the QKT result
-    qk_scale_address: the FP SRAM address containing qk_scale (default 1)
+    qk_scale_address: the FP SRAM address containing qk_scale (default 5)
     Description:
         This part of asm is for the inner loop of the flash attention, mapping to line 9 to line 10 process,
         which requires per row level computation, hence with the loop mlen times.
@@ -55,7 +55,7 @@ def online_softmax_code(
         generated_code += f"S_ADDI_INT gp{m_res_address_register}, gp{m_last_address_register}, {mlen} \n"
         generated_code += f"S_ADDI_INT gp{l_old_address_register}, gp{m_res_address_register}, {mlen} \n"
 
-        # Load qk_scale from FP SRAM (preloaded at address 1)
+        # Load qk_scale from FP SRAM (preloaded at FP SRAM address 5)
         generated_code += f"S_LD_FP f{qk_scale_register}, gp0, {qk_scale_address} \n"
 
         # Hardware loop over mlen rows
@@ -127,7 +127,7 @@ def online_softmax_code(
         generated_code += f"S_ADDI_INT gp{m_res_address_register}, gp{m_last_address_register}, {1} \n"
         generated_code += f"S_ADDI_INT gp{l_old_address_register}, gp{m_res_address_register}, {1} \n"
 
-        # Load qk_scale from FP SRAM (preloaded at address 1)
+        # Load qk_scale from FP SRAM (preloaded at FP SRAM address 5)
         generated_code += f"S_LD_FP f{qk_scale_register}, gp0, {qk_scale_address} \n"
 
         # Scale S row by qk_scale: S = S * qk_scale

--- a/asm_templates/flashattn/overall.py
+++ b/asm_templates/flashattn/overall.py
@@ -26,6 +26,8 @@ def flash_attn_asm(
     fp_sram_start_address: int,
     k_base_hbm_offset_reg: int,
     v_base_hbm_offset_reg: int,
+    attn_scale_fp_address: int = 5,
+    inf_fp_address: int = 0,
 ) -> str:
     """
     Args:
@@ -33,6 +35,17 @@ def flash_attn_asm(
     fp_sram_start_address: the start address of the fp SRAM
     k_base_hbm_offset_reg: the offset register of the k base address in HBM
     v_base_hbm_offset_reg: the offset register of the v base address in HBM
+    attn_scale_fp_address: FP SRAM slot holding 1/sqrt(head_dim) for QK
+        scaling. Defaults to 5 to match
+        ``mem_layout_lib.json::fp_sram::attn_scale``. The scheduler-provided
+        slot is forwarded by the caller; previously this was hardcoded to 1
+        (the eps slot) and produced catastrophically mis-scaled attention
+        logits once fp_sram.bin was seeded per the JSON convention.
+    inf_fp_address: FP SRAM slot holding the -inf sentinel used to seed the
+        running-max state at the start of each kv tile. Defaults to 0 to match
+        ``mem_layout_lib.json::fp_sram::infinity``. Previously hardcoded to 2
+        (the hid_reciprocal slot ~= 0.016), which made the running-max start
+        at a positive value and corrupted the entire flash softmax accumulation.
     Description:
         This part of asm takes the multi-loops, looping over kv head, then two loops for the flash atten, with small loops over q head per kv head within the inner loop.
     """
@@ -51,14 +64,16 @@ def flash_attn_asm(
 
     # Memory Layout:
     # -- FP SRAM --
-    # Defalt 0 - zero
-    # 1 - infinity
-    # fp_sram_start_address - 1 - qk_scale
-    # per head dimension * q_index_2_kv_index_ratio level {
-    # - m old (MLEN) - 0
-    # - m res (MLEN) - 1
-    # - l old (MLEN) - 2
-    # }
+    # ``inf_fp_address`` (default 0) - infinity sentinel for running-max init.
+    # ``attn_scale_fp_address`` (default 5) - 1/sqrt(head_dim) (QK scale).
+    # Both slot indices are forwarded by the caller from
+    # ``scheduler["memory_layout"]["fp_sram"]`` so mem_layout_lib.json is the
+    # single source of truth for FPRAM constant placement; this template no
+    # longer hardcodes addresses 1 and 2.
+    # ``fp_sram_start_address`` onwards holds, for each q head in the kv-group:
+    # - m old (br)
+    # - m res (br)
+    # - l old (br)
 
     print("=" * 5, "VSRAM Memory Layout", "=" * 5)
     # -- Vector SRAM --
@@ -94,13 +109,18 @@ def flash_attn_asm(
             # Reset m_fp_sram_start_address for each iteration
             m_fp_sram_start_address = fp_sram_start_address
 
-            # Reset m old for every q_index_2_kv_index_ratio q heads with -inf
+            # Reset m old for every q_index_2_kv_index_ratio q heads with -inf.
+            # ``inf_fp_address`` is forwarded by the caller from
+            # ``scheduler["memory_layout"]["fp_sram"]["infinity"]`` (default 0
+            # per mem_layout_lib.json).  The previous hardcoded value 2 was
+            # the hid_reciprocal slot (~ 0.016 once seeded), which left the
+            # running-max init positive and broke flash-softmax accumulation.
             generated_code += reset_fpsram_code(
                 reset_start_address=m_fp_sram_start_address,
                 per_stride_dim=br,
                 stride_dist=3 * br,
                 reset_amount=q_index_2_kv_index_ratio,
-                reset_val_address=2,
+                reset_val_address=inf_fp_address,
                 alive_registers_fp=alive_registers_fp[0:1],
                 alive_registers_int=alive_registers_int[0:4],
             )
@@ -148,7 +168,10 @@ def flash_attn_asm(
                 # Now the S is in expected to stored in (blen, br, bc) in vsram
 
                 for inner_q_head_index in range(q_index_2_kv_index_ratio):
-                    # Per Q head level online softmax
+                    # Per Q head level online softmax.  ``attn_scale_fp_address``
+                    # is forwarded by the caller from
+                    # ``scheduler["memory_layout"]["fp_sram"]["attn_scale"]``
+                    # so this template no longer hardcodes the QK-scale slot.
                     generated_code += online_softmax_code(
                         mlen=mlen,
                         stage=stage,
@@ -156,7 +179,7 @@ def flash_attn_asm(
                         alive_registers_fp=alive_registers_fp[0:5],
                         s_address=s_base_address + inner_q_head_index * br * bc,
                         m_start_address=m_fp_sram_start_address,
-                        qk_scale_address=1,  # qk_scale preloaded at FP SRAM address 1
+                        qk_scale_address=attn_scale_fp_address,
                     )
                     # P is stored in s_base_address + inner_q_head_index * mlen * mlen, taking (blen, mlen, mlen) as a block
                     m_fp_sram_start_address += br * 3

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -374,7 +374,7 @@ def _generate_ffn_code(
                 # harness seeds FP slot 3 with 1.0 for SiLU sigmoid base; GELU
                 # reuses that same slot as its multiplicative identity.  Do
                 # not rename without also retargeting the harness preload.
-                const_one_fp_address=fp_sram.get("silu_e", 3),
+                const_one_fp_address=fp_sram.get("silu_one", fp_sram.get("silu_e", 3)),
                 const_1702_fp_address=fp_sram.get("gelu_1702", 4),
                 alive_registers=[1, 2, 3, 4, 5, 6, 7, 8],
                 # fc1 wrote here; GELU reads/writes in-place.
@@ -424,7 +424,8 @@ def _generate_ffn_code(
         gate_weight_hbm_offset_reg=ffn_gate_reg,
         up_weight_hbm_offset_reg=ffn_up_reg,
         down_weight_hbm_offset_reg=ffn_down_reg,
-        const_one_fp_address=scheduler["memory_layout"].get("fp_sram", {}).get("silu_e", 0),
+        const_one_fp_address=scheduler.get("memory_layout", {}).get("fp_sram", {}).get("silu_one",
+            scheduler.get("memory_layout", {}).get("fp_sram", {}).get("silu_e", 3)),
         activation_base_address=vsram.get("block1", 0),
         matrix_sram_size=hardware_config.get("MATRIX_SRAM_SIZE", 1024),
     )
@@ -443,8 +444,9 @@ def _generate_normalization_code(
     dims = node["dimensions"]
     hidden_size = dims["normalized_shape"]
     norm_type = dims.get("norm_type", "rms_norm")
-    eps_offset = scheduler.get("fp_sram", {}).get("eps", 0)
-    reci_hid_offset = scheduler.get("fp_sram", {}).get("hid_reciprocal", 0)
+    _fp_sram = scheduler.get("memory_layout", {}).get("fp_sram", {})
+    eps_offset = _fp_sram.get("eps", 1)
+    reci_hid_offset = _fp_sram.get("hid_reciprocal", 2)
     vlen = hardware_config.get("VLEN", 64)
     batch_size = model_info.get("batch_size", 1)
     activation_base = scheduler.get("vector_sram_addr", {}).get("block1", 0)

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -221,7 +221,16 @@ def _generate_attention_code(
     # the dedicated q_scratch region rather than the old block2 alias.
     vsram_fa_base = _q_scratch
     fp_sram_map = scheduler["memory_layout"].get("fp_sram", {})
-    fp_sram_fa_base = fp_sram_map.get("silu_e", 3)
+    # ``silu_one`` is the canonical name (value = 1.0); fall back to legacy
+    # ``silu_e`` for older mem_layout_lib snapshots that pre-date the rename.
+    fp_sram_fa_base = fp_sram_map.get("silu_one", fp_sram_map.get("silu_e", 3))
+    # Drive the flash-attn template's QK-scale and -inf slot indices from the
+    # mem_layout_lib.json source of truth.  Previously these were hardcoded to
+    # 1 (eps) and 2 (hid_reciprocal) inside flash_attn_asm/online_softmax,
+    # which produced a worse-than-zero-fill state once PR #16 began seeding
+    # fp_sram.bin per the JSON convention.
+    attn_scale_fp = fp_sram_map.get("attn_scale", 5)
+    inf_fp = fp_sram_map.get("infinity", 0)
     k_hbm_reg = hbm_addr_reg.get("k_weight_offset", 0)
     v_hbm_reg = hbm_addr_reg.get("v_weight_offset", 0)
 
@@ -244,6 +253,8 @@ def _generate_attention_code(
             fp_sram_start_address=fp_sram_fa_base,
             k_base_hbm_offset_reg=k_hbm_reg,
             v_base_hbm_offset_reg=v_hbm_reg,
+            attn_scale_fp_address=attn_scale_fp,
+            inf_fp_address=inf_fp,
         )
     else:
         reason = (
@@ -267,12 +278,11 @@ def _generate_attention_code(
         s_addr = vsram.get("k_split_scratch", vsram.get("block2", 0))
         p_addr = _v_scratch  # safe: consumed after V in O = P @ V
         o_addr = vsram.get("attn_out_scratch", vsram.get("block4", 0))
-        # attn_scale = 1/sqrt(head_dim); the harness seeds this FP slot at
-        # runtime.  Falling back to slot 5 (the dedicated attn_scale slot in
-        # mem_layout_lib.json); older scheduler dicts missing the key get
-        # flagged by the 5 fallback rather than the catastrophic eps value.
-        scale_fp = fp_sram_map.get("attn_scale", 5)
-        neg_inf_fp = fp_sram_map.get("infinity", 0)
+        # Reuse the scheduler-derived slots extracted above.  The harness
+        # seeds attn_scale = 1/sqrt(head_dim) and infinity = -65504 at these
+        # FPRAM addresses (mem_layout_lib.json::fp_sram).
+        scale_fp = attn_scale_fp
+        neg_inf_fp = inf_fp
         code += f"\n; -- Bidirectional attention (compositional skeleton; {reason}) --\n"
         code += (
             f"; S = Q @ K^T  (shape: [{seq_len}, {seq_len}] per head, {num_heads} heads)\n"

--- a/generator/scheduler/mem_layout_lib.json
+++ b/generator/scheduler/mem_layout_lib.json
@@ -8,7 +8,7 @@
         "infinity" : { "content": "", "addr": "0" },
         "eps"      : { "content": "", "addr": "1" },
         "hid_reciprocal" : { "content": "", "addr": "2" },
-        "silu_e" : { "content": "", "addr": "3" },
+        "silu_one" : { "content": "1.0", "addr": "3" },
         "gelu_1702" : { "content": "1.702", "addr": "4" },
         "attn_scale" : { "content": "1/sqrt(head_dim)", "addr": "5" }
     },

--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -220,6 +220,54 @@ def _build_hbm_from_hf_weights(
     return summary
 
 
+def _build_fp_sram_preload(
+    fp_sram_path: Path,
+    hidden_size: int,
+    head_dim: int,
+    eps_value: float = 1e-6,
+    inf_value: float = -65504.0,
+    total_bytes: int = 2048,
+) -> dict:
+    """Seed fp_sram.bin with the FPRAM constants the generator expects.
+
+    Slot map (from compiler/generator/scheduler/mem_layout_lib.json):
+      0: infinity      — softmax masking sentinel (use a large fp16 negative)
+      1: eps           — RMSNorm epsilon
+      2: hid_reciprocal — 1.0 / hidden_size
+      3: silu_e        — 1.0 (SiLU sigmoid identity, GELU multiplicative identity)
+      4: gelu_1702     — 1.702 (GELU sigmoid-approximation constant)
+      5: attn_scale    — 1.0 / sqrt(head_dim)
+    Slots 6..N are zero-padded to fill total_bytes.
+    """
+    import math
+
+    num_slots = total_bytes // 2  # fp16 = 2 bytes each
+    constants = [
+        inf_value,                  # slot 0: infinity
+        eps_value,                  # slot 1: eps
+        1.0 / hidden_size,          # slot 2: hid_reciprocal
+        1.0,                        # slot 3: silu_e
+        1.702,                      # slot 4: gelu_1702
+        1.0 / math.sqrt(head_dim),  # slot 5: attn_scale
+    ] + [0.0] * (num_slots - 6)    # slots 6..N: reserved / zero pad
+
+    arr = np.array(constants, dtype=np.float16)
+    assert arr.nbytes == total_bytes, f"expected {total_bytes} bytes, got {arr.nbytes}"
+    fp_sram_path.write_bytes(arr.tobytes())
+    return {
+        "slots_seeded": 6,
+        "bytes_written": arr.nbytes,
+        "values": {
+            "infinity": inf_value,
+            "eps": eps_value,
+            "hid_reciprocal": 1.0 / hidden_size,
+            "silu_e": 1.0,
+            "gelu_1702": 1.702,
+            "attn_scale": 1.0 / math.sqrt(head_dim),
+        },
+    }
+
+
 def run_pipeline(model_id: str, seq_len: int, build_dir: Path, num_layers: int | None = None) -> dict:
     """Run codegen → assemble → emulator; return paths + metadata.
 
@@ -288,9 +336,29 @@ def run_pipeline(model_id: str, seq_len: int, build_dir: Path, num_layers: int |
     FPSRAM_BYTES = 1024 * 2
     INTSRAM_BYTES = 1024 * 4
     _build_hbm_from_hf_weights(model_id, seq_len, hbm_path, HBM_SIZE)
-    for p, size in [(fpsram_path, FPSRAM_BYTES), (intsram_path, INTSRAM_BYTES)]:
-        if not p.exists() or p.stat().st_size != size:
-            p.write_bytes(b"\x00" * size)
+
+    # FPRAM constant seeding — generator templates expect specific values
+    # at fixed slots (mem_layout_lib.json::fp_sram).
+    print("[3.5/5] FPRAM seed: deriving hidden_size and head_dim from HF config")
+    _hf_model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float32)
+    _text_cfg = getattr(_hf_model.config, "text_config", _hf_model.config)
+    hidden_size = _text_cfg.hidden_size
+    head_dim = getattr(
+        _text_cfg,
+        "head_dim",
+        _text_cfg.hidden_size // _text_cfg.num_attention_heads,
+    )
+    del _hf_model  # free memory — weights already written to HBM above
+
+    print("[3.6/5] FPRAM seed: writing constants to fp_sram.bin")
+    fp_summary = _build_fp_sram_preload(
+        fpsram_path, hidden_size, head_dim, total_bytes=FPSRAM_BYTES
+    )
+    print(f"      seeded {fp_summary['slots_seeded']} fp_sram slots: {fp_summary['values']}")
+
+    # int_sram: zero-fill only (no structured constants needed)
+    if not intsram_path.exists() or intsram_path.stat().st_size != INTSRAM_BYTES:
+        intsram_path.write_bytes(b"\x00" * INTSRAM_BYTES)
 
     # Step 4: run emulator
     print("[4/5] Rust transactional emulator")

--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -55,6 +55,7 @@ def _build_hbm_from_hf_weights(
     seq_len: int,
     hbm_path: Path,
     hbm_size_bytes: int,
+    preloaded_model=None,
 ) -> dict:
     """Populate hbm_for_behave_sim.bin with real HF model weights.
 
@@ -97,9 +98,13 @@ def _build_hbm_from_hf_weights(
     }
     hbm_row_width = config["HBM_WIDTH"]["value"]
 
-    print(f"      loading HF model: {model_id}")
-    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float32)
-    model.eval()
+    if preloaded_model is None:
+        print(f"      loading HF model: {model_id}")
+        model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float32)
+        model.eval()
+    else:
+        print(f"      reusing preloaded HF model for: {model_id}")
+        model = preloaded_model
 
     # Locate layer-0 attention + MLP. HF Llama-family exposes these under
     # model.model.layers[0].{self_attn,mlp}; fall back to the transformer's
@@ -230,11 +235,21 @@ def _build_fp_sram_preload(
 ) -> dict:
     """Seed fp_sram.bin with the FPRAM constants the generator expects.
 
+    KNOWN LIMITATION (VLMs): a single ``attn_scale`` slot can only hold one
+    1/sqrt(head_dim) value.  Vision-language models typically have a
+    different head_dim for the text decoder and the vision encoder, so the
+    second attention domain reads a stale scale and produces incorrect
+    logits.  The flash-attn template would need a per-call attn_scale_fp
+    slot (or the harness needs to refresh slot 5 between text and vision
+    runs) to fix this.  Tracking issue: TODO.
+
     Slot map (from compiler/generator/scheduler/mem_layout_lib.json):
       0: infinity      — softmax masking sentinel (use a large fp16 negative)
       1: eps           — RMSNorm epsilon
       2: hid_reciprocal — 1.0 / hidden_size
-      3: silu_e        — 1.0 (SiLU sigmoid identity, GELU multiplicative identity)
+      3: silu_one      — 1.0 (SiLU sigmoid identity, GELU multiplicative identity).
+                       Renamed from `silu_e` in the canonical layout to avoid
+                       implying Euler's constant; the value is just 1.0.
       4: gelu_1702     — 1.702 (GELU sigmoid-approximation constant)
       5: attn_scale    — 1.0 / sqrt(head_dim)
     Slots 6..N are zero-padded to fill total_bytes.
@@ -246,7 +261,7 @@ def _build_fp_sram_preload(
         inf_value,                  # slot 0: infinity
         eps_value,                  # slot 1: eps
         1.0 / hidden_size,          # slot 2: hid_reciprocal
-        1.0,                        # slot 3: silu_e
+        1.0,                        # slot 3: silu_one (1.0; renamed from silu_e)
         1.702,                      # slot 4: gelu_1702
         1.0 / math.sqrt(head_dim),  # slot 5: attn_scale
     ] + [0.0] * (num_slots - 6)    # slots 6..N: reserved / zero pad
@@ -261,7 +276,7 @@ def _build_fp_sram_preload(
             "infinity": inf_value,
             "eps": eps_value,
             "hid_reciprocal": 1.0 / hidden_size,
-            "silu_e": 1.0,
+            "silu_one": 1.0,
             "gelu_1702": 1.702,
             "attn_scale": 1.0 / math.sqrt(head_dim),
         },
@@ -335,12 +350,21 @@ def run_pipeline(model_id: str, seq_len: int, build_dir: Path, num_layers: int |
     HBM_SIZE = 256 << 20  # 256 MiB (same as prior stub).
     FPSRAM_BYTES = 1024 * 2
     INTSRAM_BYTES = 1024 * 4
-    _build_hbm_from_hf_weights(model_id, seq_len, hbm_path, HBM_SIZE)
+    # Load HF model once and reuse it for both HBM weight population and
+    # FPRAM-constant derivation (hidden_size, head_dim).  Previously the
+    # model was loaded twice — once inside _build_hbm_from_hf_weights and
+    # again in this run_pipeline body — doubling peak host RAM during the
+    # harness's [3/5] -> [3.5/5] transition for no benefit.
+    print("[3.0a/5] loading HF model (single load shared with FPRAM seed)")
+    _hf_model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float32)
+    _hf_model.eval()
+    _build_hbm_from_hf_weights(
+        model_id, seq_len, hbm_path, HBM_SIZE, preloaded_model=_hf_model
+    )
 
     # FPRAM constant seeding — generator templates expect specific values
     # at fixed slots (mem_layout_lib.json::fp_sram).
     print("[3.5/5] FPRAM seed: deriving hidden_size and head_dim from HF config")
-    _hf_model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float32)
     _text_cfg = getattr(_hf_model.config, "text_config", _hf_model.config)
     hidden_size = _text_cfg.hidden_size
     head_dim = getattr(


### PR DESCRIPTION
Stacks on PR #15. Adds `_build_fp_sram_preload` to write canonical FPRAM slot constants instead of zero-filling fp_sram.bin.

## Slots seeded (per mem_layout_lib.json)
- 0 infinity (-65504.0)
- 1 eps (1e-6)
- 2 hid_reciprocal (1/hidden_size)
- 3 silu_e (1.0)
- 4 gelu_1702 (1.702)
- 5 attn_scale (1/sqrt(head_dim))
- 6..1023 zero

## Why
Templates' `S_LD_FP fX, gp0, N` was reading 0 for every constant — RMSNorm eps, SiLU/GELU 1.0, GELU 1.702, softmax -∞, attention scale. Any numerical verification was meaningless until this lands.

## Verified
For hidden=384, head_dim=64: slots 0–5 contain the expected fp16-rounded values; file size 2048 bytes (1024 slots × fp16) matches FPSRAM_BYTES.