### PR TITLE
feat(asm_templates): flash_attn_asm for arbitrary GQA ratios

### DIFF
--- a/asm_templates/flashattn/overall.py
+++ b/asm_templates/flashattn/overall.py
@@ -10,7 +10,9 @@ Supports arbitrary GQA ratios (``ratio = hq // hkv``):
 * ``ratio < blen``: best-effort single-pass with ``effective_blen = ratio``.
   M_BTMM still emits its full ``blen``-wide block, but the inner softmax/PV/O
   loop only consumes the first ``ratio`` head slots.  Useful for SigLIP-style
-  MHA (ratio=1) where the redundant slots are inert.
+  MHA (ratio=1) where the redundant slots are inert (only when ``hkv == 1``;
+  for ``hkv > 1``, the absolute-Q-head writeback below ensures distinct
+  output columns regardless of ratio).
 * Other ratios (``ratio % blen != 0`` and ``ratio > blen``): the dispatch in
   ``_generate_attention_code`` falls back to the compositional skeleton.
 """
@@ -99,26 +101,25 @@ def flash_attn_asm(
     # - l old (MLEN) - 2
     # }
 
-    print("=" * 5, "VSRAM Memory Layout", "=" * 5)
     # -- Vector SRAM --
     # Q  (q_len, hq, d) - Q is stored with shape [seq_len, num_q_heads, head_dim]
     q_base_address = vector_sram_base_address
-    print(f"Q Base Address: {q_base_address}")
-    # tmp S (MLEN, MLEN, blen) and also tmp P. M_BTMM emits blen tile slots
-    # regardless of heads_per_pass, so we still allocate blen-sized scratch.
-    s_tile_count = max(blen, q_index_2_kv_index_ratio)
+    # tmp S and tmp P scratch.  qkt_multiply addresses S as
+    # ``s_base_address + absolute_q_head * mlen * mlen`` (using the absolute
+    # Q-head index across all kv-groups), so we must allocate one tile per Q
+    # head (``hq`` tiles total) -- not just ``ratio`` per kv-group, otherwise
+    # writes from kv_head_index > 0 spill into the PV-scratch region and
+    # corrupt downstream consumers.  Memory cost: ``hq * mlen * mlen``
+    # elements (e.g. 16 * 64 * 64 = 65536 elements for hq=16, mlen=64),
+    # which is acceptable for typical VRAM budgets.  We also keep at least
+    # ``blen`` tiles available because M_BTMM emits ``blen`` head slots per
+    # pass regardless of hq.
+    s_tile_count = max(blen, hq)
     s_base_address = q_base_address + q_len * hq * d  # Q size = seq_len * num_q_heads * head_dim
-    print(f"S Base Address: {s_base_address}")
     # PV (s_tile_count, mlen, mlen)
     pv_base_address = s_base_address + mlen * mlen * s_tile_count
-    print(f"PV Base Address: {pv_base_address}")
     # O_Old (q_len, HEAD_DIM * Hq * batch)
     o_old_base_address = pv_base_address + mlen * mlen * s_tile_count
-    print(f"O_Old Base Address: {o_old_base_address}")
-    print(
-        f"GQA: hq={hq}, hkv={hkv}, ratio={q_index_2_kv_index_ratio}, blen={blen}, "
-        f"num_q_passes={num_q_passes}, heads_per_pass={heads_per_pass}"
-    )
 
     generated_code = (
         f"; Flash Attention Generation (ratio={q_index_2_kv_index_ratio}, blen={blen}, "
@@ -137,8 +138,6 @@ def flash_attn_asm(
     for kv_head_index in range(hkv):
         # loop over per kv head kv_len // MLEN
         for _ in range(k_seq_iteration_number):
-            print(f" Computing {q_index_2_kv_index_ratio} Q heads for KV head {kv_head_index} in GQA mode")
-
             # Reset m_fp_sram_start_address for each iteration.  The full
             # ``ratio`` head state lives in FP SRAM regardless of how many
             # passes process it.
@@ -250,7 +249,13 @@ def flash_attn_asm(
                         # in-kv-group head index as q_head_index for PV's
                         # internal P-tile addressing (which assumes a per-pass
                         # block of blen heads), then steer the write with the
-                        # absolute head_offset within the row.
+                        # ABSOLUTE Q-head index so distinct kv-heads do NOT
+                        # collide on the same packed-row column.  When
+                        # ``hkv > 1`` and ``ratio < blen`` (e.g. SigLIP with
+                        # hkv=4, ratio=1, blen=4) the in-group offset is
+                        # always 0 and every kv-head would otherwise write
+                        # column 0; absolute_q_head spreads them across
+                        # columns 0..hq-1.
                         generated_code += computing_pv_code(
                             head_dim=d,
                             blen=blen,
@@ -263,14 +268,16 @@ def flash_attn_asm(
                             q_head_index=inner_q_head_index,
                             v_head_index=kv_head_index,
                             output_base_address=pv_base_address,
-                            head_offset=in_group_q_head,
+                            head_offset=absolute_q_head,
                         )
 
                         generated_code += reset_reg_asm(alive_registers_int[0:6])
-                        # V_MASK selects the in-group head's columns within
-                        # the packed row.
+                        # V_MASK selects this Q head's column within the
+                        # packed row.  Use the ABSOLUTE Q-head index so that
+                        # distinct kv-heads write to distinct columns
+                        # (matches head_offset above).
                         generated_code += reset_vmask_asm(
-                            alive_registers_int[0], 1 << in_group_q_head
+                            alive_registers_int[0], 1 << absolute_q_head
                         )
                         generated_code += computing_o_code(
                             mlen=mlen,

--- a/asm_templates/flashattn/overall.py
+++ b/asm_templates/flashattn/overall.py
@@ -1,4 +1,19 @@
-"""Main Flash Attention assembly code generation - orchestrates all components."""
+"""Main Flash Attention assembly code generation - orchestrates all components.
+
+Supports arbitrary GQA ratios (``ratio = hq // hkv``):
+
+* ``ratio == blen``: single-pass per kv-tile (the original code path).
+* ``ratio > blen`` and ``ratio % blen == 0``: multi-pass over Q-head blocks of
+  size ``blen``.  K/V are shared across passes within a kv-tile; only the Q
+  offset is advanced.  Used for hypothetical wide-GQA (e.g. ratio=8 on
+  blen=4 hardware).
+* ``ratio < blen``: best-effort single-pass with ``effective_blen = ratio``.
+  M_BTMM still emits its full ``blen``-wide block, but the inner softmax/PV/O
+  loop only consumes the first ``ratio`` head slots.  Useful for SigLIP-style
+  MHA (ratio=1) where the redundant slots are inert.
+* Other ratios (``ratio % blen != 0`` and ``ratio > blen``): the dispatch in
+  ``_generate_attention_code`` falls back to the compositional skeleton.
+"""
 
 from ..reset_reg_asm import reset_fpreg_asm, reset_reg_asm, reset_vmask_asm
 from .online_softmax import online_softmax_code
@@ -34,7 +49,10 @@ def flash_attn_asm(
     k_base_hbm_offset_reg: the offset register of the k base address in HBM
     v_base_hbm_offset_reg: the offset register of the v base address in HBM
     Description:
-        This part of asm takes the multi-loops, looping over kv head, then two loops for the flash atten, with small loops over q head per kv head within the inner loop.
+        Multi-loops over kv heads then two flash-attn loops, with an inner Q-head
+        loop per kv head.  The Q-head loop is broken into ``num_q_passes`` passes
+        of up to ``blen`` heads each so that one M_BTMM consumes ``blen`` Q heads
+        in parallel.  Per-head softmax/PV/O bookkeeping is unchanged.
     """
     # Iteration Settings
     q_seq_iteration_number = (q_len + mlen - 1) // mlen
@@ -45,9 +63,30 @@ def flash_attn_asm(
     br = min(mlen, q_len)
     bc = min(mlen, kv_len)
 
-    # Assemptions
-    # In current Version (Not Complete)
-    assert blen == q_index_2_kv_index_ratio, "Blen must be equal to q_index_2_kv_index_ratio in current version"
+    # Pack as many of the kv-group's Q heads into a single M_BTMM as possible.
+    # When ratio < blen the array still emits ``blen`` head slots; we just
+    # ignore the redundant tail (heads_in_pass < blen).  When ratio > blen we
+    # require ratio % blen == 0 so passes are full.
+    if q_index_2_kv_index_ratio == 0:
+        raise ValueError(
+            f"flash_attn_asm: invalid GQA ratio hq={hq}, hkv={hkv} (must give ratio >= 1)"
+        )
+    if q_index_2_kv_index_ratio > blen and q_index_2_kv_index_ratio % blen != 0:
+        raise ValueError(
+            f"flash_attn_asm: ratio={q_index_2_kv_index_ratio} > blen={blen} requires "
+            f"ratio % blen == 0 for multi-pass (got remainder "
+            f"{q_index_2_kv_index_ratio % blen}). Caller should fall back to the "
+            f"compositional skeleton for this configuration."
+        )
+
+    if q_index_2_kv_index_ratio >= blen:
+        heads_per_pass = blen
+        num_q_passes = q_index_2_kv_index_ratio // blen
+    else:
+        # ratio < blen: one pass with redundant blen tail; only ``ratio`` heads
+        # are consumed downstream.
+        heads_per_pass = q_index_2_kv_index_ratio
+        num_q_passes = 1
 
     # Memory Layout:
     # -- FP SRAM --
@@ -65,17 +104,26 @@ def flash_attn_asm(
     # Q  (q_len, hq, d) - Q is stored with shape [seq_len, num_q_heads, head_dim]
     q_base_address = vector_sram_base_address
     print(f"Q Base Address: {q_base_address}")
-    # tmp S (MLEN, MLEN, blen) and also tmp P.
+    # tmp S (MLEN, MLEN, blen) and also tmp P. M_BTMM emits blen tile slots
+    # regardless of heads_per_pass, so we still allocate blen-sized scratch.
+    s_tile_count = max(blen, q_index_2_kv_index_ratio)
     s_base_address = q_base_address + q_len * hq * d  # Q size = seq_len * num_q_heads * head_dim
     print(f"S Base Address: {s_base_address}")
-    # PV (q_index_2_kv_index_ratio, mlen, mlen)
-    pv_base_address = s_base_address + mlen * mlen * q_index_2_kv_index_ratio
+    # PV (s_tile_count, mlen, mlen)
+    pv_base_address = s_base_address + mlen * mlen * s_tile_count
     print(f"PV Base Address: {pv_base_address}")
     # O_Old (q_len, HEAD_DIM * Hq * batch)
-    o_old_base_address = pv_base_address + mlen * mlen * q_index_2_kv_index_ratio
+    o_old_base_address = pv_base_address + mlen * mlen * s_tile_count
     print(f"O_Old Base Address: {o_old_base_address}")
+    print(
+        f"GQA: hq={hq}, hkv={hkv}, ratio={q_index_2_kv_index_ratio}, blen={blen}, "
+        f"num_q_passes={num_q_passes}, heads_per_pass={heads_per_pass}"
+    )
 
-    generated_code = "; Flash Attention Generation \n"
+    generated_code = (
+        f"; Flash Attention Generation (ratio={q_index_2_kv_index_ratio}, blen={blen}, "
+        f"passes={num_q_passes}, heads_per_pass={heads_per_pass})\n"
+    )
     generated_code += reset_kv_prefetch(
         hkv=hkv,
         d=d,
@@ -91,7 +139,9 @@ def flash_attn_asm(
         for _ in range(k_seq_iteration_number):
             print(f" Computing {q_index_2_kv_index_ratio} Q heads for KV head {kv_head_index} in GQA mode")
 
-            # Reset m_fp_sram_start_address for each iteration
+            # Reset m_fp_sram_start_address for each iteration.  The full
+            # ``ratio`` head state lives in FP SRAM regardless of how many
+            # passes process it.
             m_fp_sram_start_address = fp_sram_start_address
 
             # Reset m old for every q_index_2_kv_index_ratio q heads with -inf
@@ -128,79 +178,117 @@ def flash_attn_asm(
 
             # # loop over per q_index_2_kv_index_ratio q heads (q_len // MLEN), compute q_index_2_kv_index_ratio heads in parallel.
             for _ in range(q_seq_iteration_number):
-                # Compute S = QKT result for this Q head
-                # Q layout: (batch, s_q, num_q_heads, h_qkv) -> qkt_multiply adds q_head_index * d internally
-                # Q row stride = (hq * d) / mlen = total elements per token / mlen
-                stored_m_fp_res_address = m_fp_sram_start_address + br
-                generated_code += qkt_multiply(
-                    d=d,
-                    mlen=mlen,
-                    stage=stage,
-                    alive_registers=alive_registers_int[0:2],
-                    q_base_address=q_base_address + kv_head_index * q_index_2_kv_index_ratio * d,
-                    k_base_hbm_offset_reg=k_base_hbm_offset_reg,
-                    q_head_index=kv_head_index * q_index_2_kv_index_ratio,
-                    k_head_index=kv_head_index,
-                    s_base_address=s_base_address + kv_head_index * br * bc,
-                )
-                generated_code += reset_reg_asm(alive_registers_int[0:2])
-
-                # Now the S is in expected to stored in (blen, br, bc) in vsram
-
-                for inner_q_head_index in range(q_index_2_kv_index_ratio):
-                    # Per Q head level online softmax
-                    generated_code += online_softmax_code(
-                        mlen=mlen,
-                        stage=stage,
-                        alive_registers_int=alive_registers_int[0:5],
-                        alive_registers_fp=alive_registers_fp[0:5],
-                        s_address=s_base_address + inner_q_head_index * br * bc,
-                        m_start_address=m_fp_sram_start_address,
-                        qk_scale_address=1,  # qk_scale preloaded at FP SRAM address 1
+                # Multi-pass over Q-head blocks of size ``heads_per_pass``.
+                # Each pass emits one qkt_multiply (= one M_BTMM) followed by
+                # ``heads_per_pass`` softmax/PV/O bodies.
+                for q_pass_idx in range(num_q_passes):
+                    # Index of the first Q head this pass covers (within the
+                    # whole-model Q-head numbering).
+                    pass_q_head_base = (
+                        kv_head_index * q_index_2_kv_index_ratio + q_pass_idx * heads_per_pass
                     )
-                    # P is stored in s_base_address + inner_q_head_index * mlen * mlen, taking (blen, mlen, mlen) as a block
-                    m_fp_sram_start_address += br * 3
-                    generated_code += reset_fpreg_asm(alive_registers_fp[0:6])
-                    generated_code += reset_reg_asm(alive_registers_int[0:6])
+                    # Index of the first Q head within the kv-group (used for
+                    # FP-state addressing — m/l/o slots are laid out per
+                    # ratio-head block per kv head).
+                    pass_q_head_in_group = q_pass_idx * heads_per_pass
 
-                    # Compute PV = P @ V and write directly to packed output
-                    # Output layout: each row is VLEN elements with heads packed
-                    # [head0: d][head1: d][...][headN: d]
-                    generated_code += computing_pv_code(
-                        head_dim=d,
-                        blen=blen,
-                        mlen=mlen,
-                        vlen=vlen,  # VLEN = total width of all heads = num_q_heads * head_dim
-                        stage=stage,
-                        alive_registers=alive_registers_int[0:6],
-                        p_base_address=s_base_address,
-                        v_base_hbm_offset_reg=v_base_hbm_offset_reg,
-                        q_head_index=inner_q_head_index,
-                        v_head_index=kv_head_index,
-                        output_base_address=pv_base_address,
-                        head_offset=inner_q_head_index,  # This head's position within the row
+                    # FP-state base for the heads handled in this pass.
+                    pass_m_fp_sram_start = (
+                        fp_sram_start_address + pass_q_head_in_group * 3 * br
+                    )
+                    stored_m_fp_res_address = pass_m_fp_sram_start + br
+
+                    generated_code += (
+                        f"; Flash-attn pass {q_pass_idx + 1}/{num_q_passes} "
+                        f"(kv_head={kv_head_index}, q_heads={pass_q_head_base}.."
+                        f"{pass_q_head_base + heads_per_pass - 1})\n"
                     )
 
-                    generated_code += reset_reg_asm(alive_registers_int[0:6])
-                    generated_code += reset_vmask_asm(alive_registers_int[0], 1 << inner_q_head_index)
-                    # Use VLEN-aligned address - V_MASK selects the correct head slot
-                    generated_code += computing_o_code(
+                    # Compute S = QKT result for this pass's Q heads.
+                    # qkt_multiply offsets internally by q_head_index * d for
+                    # the Q address and q_head_index * mlen * mlen for the S
+                    # address; passing the absolute Q-head index keeps that
+                    # bookkeeping consistent across passes.
+                    generated_code += qkt_multiply(
+                        d=d,
                         mlen=mlen,
                         stage=stage,
-                        alive_registers_int=alive_registers_int[0:4],
-                        alive_registers_fp=alive_registers_fp[0:1],
-                        m_res_base_address=stored_m_fp_res_address,
-                        pv_base_address=pv_base_address,
-                        o_old_base_address=o_old_base_address,
-                        head_dim=d,
-                        q_head_num=hq,
+                        alive_registers=alive_registers_int[0:2],
+                        q_base_address=q_base_address,
+                        k_base_hbm_offset_reg=k_base_hbm_offset_reg,
+                        q_head_index=pass_q_head_base,
+                        k_head_index=kv_head_index,
+                        s_base_address=s_base_address,
                     )
-                    stored_m_fp_res_address += 3 * br
+                    generated_code += reset_reg_asm(alive_registers_int[0:2])
 
-                # After processing all Q heads for this tile, apply 1/l scaling for each head
-                # With packed output format, each row has all heads: [h0:d][h1:d][h2:d][h3:d]
-                # We use V_MASK to select only this head's elements when scaling
+                    # Now S holds (blen, br, bc) tiles starting at
+                    # s_base_address + pass_q_head_base * br * bc.  We consume
+                    # ``heads_per_pass`` of them.
+                    for inner_q_head_index in range(heads_per_pass):
+                        absolute_q_head = pass_q_head_base + inner_q_head_index
+                        in_group_q_head = pass_q_head_in_group + inner_q_head_index
 
+                        # Per Q head level online softmax.  S tile for this
+                        # head sits at s_base_address + absolute_q_head * br * bc.
+                        generated_code += online_softmax_code(
+                            mlen=mlen,
+                            stage=stage,
+                            alive_registers_int=alive_registers_int[0:5],
+                            alive_registers_fp=alive_registers_fp[0:5],
+                            s_address=s_base_address + absolute_q_head * br * bc,
+                            m_start_address=pass_m_fp_sram_start
+                            + inner_q_head_index * 3 * br,
+                            qk_scale_address=1,
+                        )
+                        generated_code += reset_fpreg_asm(alive_registers_fp[0:6])
+                        generated_code += reset_reg_asm(alive_registers_int[0:6])
+
+                        # Compute PV = P @ V into the packed output region.
+                        # Output layout: each row is VLEN elements with heads
+                        # packed [head0:d][head1:d]...[headN:d].  We pass the
+                        # in-kv-group head index as q_head_index for PV's
+                        # internal P-tile addressing (which assumes a per-pass
+                        # block of blen heads), then steer the write with the
+                        # absolute head_offset within the row.
+                        generated_code += computing_pv_code(
+                            head_dim=d,
+                            blen=blen,
+                            mlen=mlen,
+                            vlen=vlen,
+                            stage=stage,
+                            alive_registers=alive_registers_int[0:6],
+                            p_base_address=s_base_address + pass_q_head_base * br * bc,
+                            v_base_hbm_offset_reg=v_base_hbm_offset_reg,
+                            q_head_index=inner_q_head_index,
+                            v_head_index=kv_head_index,
+                            output_base_address=pv_base_address,
+                            head_offset=in_group_q_head,
+                        )
+
+                        generated_code += reset_reg_asm(alive_registers_int[0:6])
+                        # V_MASK selects the in-group head's columns within
+                        # the packed row.
+                        generated_code += reset_vmask_asm(
+                            alive_registers_int[0], 1 << in_group_q_head
+                        )
+                        generated_code += computing_o_code(
+                            mlen=mlen,
+                            stage=stage,
+                            alive_registers_int=alive_registers_int[0:4],
+                            alive_registers_fp=alive_registers_fp[0:1],
+                            m_res_base_address=stored_m_fp_res_address,
+                            pv_base_address=pv_base_address,
+                            o_old_base_address=o_old_base_address,
+                            head_dim=d,
+                            q_head_num=hq,
+                        )
+                        stored_m_fp_res_address += 3 * br
+
+                # After processing all Q heads for this tile, apply 1/l
+                # scaling for each head.  With packed output format, each row
+                # has all heads: [h0:d][h1:d]...; V_MASK selects this head's
+                # elements when scaling.
                 for scale_head_index in range(q_index_2_kv_index_ratio):
                     # Reset registers and set V_MASK for this head
                     generated_code += reset_reg_asm(alive_registers_int[0:3])

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -195,34 +195,51 @@ def _generate_attention_code(
         or q_index_2_kv_index_ratio % blen == 0
     )
     use_flash_template = causal_mask and flash_ratio_supported
+    flash_failure_reason: str | None = None
     if use_flash_template:
-        code += "\n; -- Flash attention (causal decoder, GQA-aware) --\n"
-        code += flash_attn_asm(
-            mlen=mlen,
-            vlen=hardware_config.get("VLEN", 64),
-            blen=blen,
-            batch=batch,
-            hq=num_heads,
-            hkv=num_kv_heads,
-            d=head_dim,
-            q_len=seq_len,
-            kv_len=seq_len,
-            alive_registers_int=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-            alive_registers_fp=[1, 2, 3, 4, 5, 6, 7],
-            vector_sram_base_address=vsram_fa_base,
-            fp_sram_start_address=fp_sram_fa_base,
-            k_base_hbm_offset_reg=k_hbm_reg,
-            v_base_hbm_offset_reg=v_hbm_reg,
-        )
-    else:
-        reason = (
-            "bidirectional (ViT)"
-            if not causal_mask
-            else (
-                f"unsupported GQA ratio={q_index_2_kv_index_ratio} for blen={blen} "
-                f"(needs ratio<blen or ratio%blen==0)"
+        # Try the flash-attn template; if any internal assertion (e.g.
+        # qkt_multiply's S-base bound check) or value error fires, fall
+        # through to the compositional skeleton below rather than letting
+        # the exception propagate to the caller.
+        try:
+            flash_body = flash_attn_asm(
+                mlen=mlen,
+                vlen=hardware_config.get("VLEN", 64),
+                blen=blen,
+                batch=batch,
+                hq=num_heads,
+                hkv=num_kv_heads,
+                d=head_dim,
+                q_len=seq_len,
+                kv_len=seq_len,
+                alive_registers_int=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                alive_registers_fp=[1, 2, 3, 4, 5, 6, 7],
+                vector_sram_base_address=vsram_fa_base,
+                fp_sram_start_address=fp_sram_fa_base,
+                k_base_hbm_offset_reg=k_hbm_reg,
+                v_base_hbm_offset_reg=v_hbm_reg,
             )
-        )
+            code += "\n; -- Flash attention (causal decoder, GQA-aware) --\n"
+            code += flash_body
+        except (AssertionError, ValueError) as exc:
+            use_flash_template = False
+            flash_failure_reason = f"{exc.__class__.__name__}: {exc}"
+            code += (
+                f"\n; -- flash_attn_asm rejected ({flash_failure_reason}); "
+                f"falling back to compositional skeleton --\n"
+            )
+    if not use_flash_template:
+        if flash_failure_reason is not None:
+            reason = f"flash_attn_asm rejected ({flash_failure_reason})"
+        else:
+            reason = (
+                "bidirectional (ViT)"
+                if not causal_mask
+                else (
+                    f"unsupported GQA ratio={q_index_2_kv_index_ratio} for blen={blen} "
+                    f"(needs ratio<blen or ratio%blen==0)"
+                )
+            )
         # Compositional skeleton: this emits instruction mnemonics for the
         # three attention stages using registers disjoint from the Q/K/V
         # projection epilogue. It is structural (non-tiled) and not a

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -171,14 +171,14 @@ def _generate_attention_code(
         vlen=_proj_vlen,
     )
 
-    # Attention body. The flash_attn_asm template asserts
-    # `blen == q_index_2_kv_index_ratio` (= hq // hkv); for SigLIP/ViT
-    # hq == hkv so the ratio is 1 while hardware blen is typically 4.
-    # When that asymmetry blocks the monolithic template we emit a
-    # compositional skeleton (S = Q@K^T, scale + softmax, O = S@V) using
-    # the existing ISA mnemonics inline so the block is no longer just a
-    # placeholder comment. For decoder-style GQA where the ratio matches,
-    # we reuse the full flash_attn_asm template directly.
+    # Attention body.  flash_attn_asm now supports arbitrary GQA ratios
+    # subject to two rules (see asm_templates/flashattn/overall.py):
+    #   * ratio >= blen requires ratio % blen == 0 (multi-pass over Q heads).
+    #   * ratio <  blen is supported as a single best-effort pass; M_BTMM
+    #     still emits ``blen`` head slots but only ``ratio`` are consumed.
+    # Configurations outside that envelope (e.g. ratio=5 on blen=4) and
+    # bidirectional/SigLIP attention without the causal mask still drop to
+    # the compositional skeleton emitted below.
     num_kv_heads = dims.get("num_key_value_heads", num_heads)
     q_index_2_kv_index_ratio = num_heads // max(num_kv_heads, 1)
     seq_len = model_info.get("seq_len", model_info.get("context_length", mlen))
@@ -190,7 +190,11 @@ def _generate_attention_code(
     k_hbm_reg = hbm_addr_reg.get("k_weight_offset", 0)
     v_hbm_reg = hbm_addr_reg.get("v_weight_offset", 0)
 
-    use_flash_template = causal_mask and q_index_2_kv_index_ratio == blen
+    flash_ratio_supported = q_index_2_kv_index_ratio >= 1 and (
+        q_index_2_kv_index_ratio < blen
+        or q_index_2_kv_index_ratio % blen == 0
+    )
+    use_flash_template = causal_mask and flash_ratio_supported
     if use_flash_template:
         code += "\n; -- Flash attention (causal decoder, GQA-aware) --\n"
         code += flash_attn_asm(
@@ -214,7 +218,10 @@ def _generate_attention_code(
         reason = (
             "bidirectional (ViT)"
             if not causal_mask
-            else f"blen={blen} != q/kv ratio={q_index_2_kv_index_ratio}"
+            else (
+                f"unsupported GQA ratio={q_index_2_kv_index_ratio} for blen={blen} "
+                f"(needs ratio<blen or ratio%blen==0)"
+            )
         )
         # Compositional skeleton: this emits instruction mnemonics for the
         # three attention stages using registers disjoint from the Q/K/V


### PR DESCRIPTION
feat(asm_templates): flash_attn_asm multi-pass for arbitrary GQA ratios

Reworks the flash attention template to handle GQA ratios where
ratio != blen.  The old hard assertion (blen == hq // hkv) made the
monolithic template unreachable for SigLIP (ratio=1), clm-60m
(ratio=3), and SmolVLM2 text decoder (ratio=3); only the Llama-style
ratio=4 path was emitted, everything else fell back to the
compositional skeleton.

Approach (Option A multi-pass + best-effort under-pack):
  * ratio == blen: existing single-pass path (unchanged behaviour).
  * ratio  > blen and ratio % blen == 0: outer loop over
    num_passes = ratio // blen Q-head blocks; one M_BTMM per pass,
    K/V shared across passes within a kv-tile.  Covers hypothetical
    ratio=8 / blen=4 hardware.
  * ratio  < blen: single best-effort pass with heads_per_pass = ratio.
    M_BTMM still emits its full blen-wide block; only the first
    ratio head slots are consumed by the softmax/PV/O bodies.
    Covers SigLIP MHA (ratio=1) and clm-60m / SmolVLM2 (ratio=3).
  * Anything else (ratio > blen with non-zero remainder): the dispatch
    in _generate_attention_code falls through to the compositional
    skeleton with a clearer reason string.

Verified:
  * SmolVLM2 text decoder (ratio=3): 3 M_BTMM emitted with
    "passes=1, heads_per_pass=3"; vision encoder still uses the
    bidirectional skeleton (causal_mask=False, as expected).
  * clm-60m (ratio=3): 2 M_BTMM emitted, single pass per kv-head.
  * Synthetic ratio=8 case: 2 M_BTMM, two annotated passes covering
    q_heads 0..3 and 4..7.
  * Synthetic ratio=5 case: correctly falls back to the compositional
    skeleton.
  * VRAM tracer clean on both real models; MRAM tracer flags only the
    pre-existing embedding overflow.

