### PR TITLE
fix(assembler): register M_MM_VV opcode

### DIFF
--- a/assembler/assembly_to_binary.py
+++ b/assembler/assembly_to_binary.py
@@ -107,6 +107,7 @@ class AssemblyToBinary:
             "M_TMV",
             "M_BTMM",
             "M_BTMV",
+            "M_MM_VV",
             # CSR: addr reg destination + 2 GP sources (a{N}, gp{X}, gp{Y} → rd, rs1, rs2)
             "C_SET_ADDR_REG",
         ]:

--- a/doc/operation.svh
+++ b/doc/operation.svh
@@ -173,7 +173,10 @@ typedef enum logic [instruction_pkg::OPCODE_WIDTH - 1:0] {
     V_SHIFT_V              = 6'h31,
     C_BREAK                = 6'h32,  // Rust emulator: 0x32 (V_SHFTL_V retired)
     V_PS_V                 = 6'h32,  // spec-only, not implemented in Rust emulator
-    C_HADAMARD_TRANSFORM   = 6'h33   // spec-only, not implemented in Rust emulator
+    C_HADAMARD_TRANSFORM   = 6'h33,  // spec-only, not implemented in Rust emulator
+
+    // Vector-Vector Matrix Multiply (compositional attention skeleton, e.g. SigLIP)
+    M_MM_VV                = 6'h34
 } CUSTOM_ISA_OPCODE;
 
 


### PR DESCRIPTION
## Why
The compositional attention skeleton (introduced in PR #13 for SigLIP bidirectional vision attention) emits `M_MM_VV` instructions in `compiler/generator/passes/code_gen.py`. The assembler at `compiler/assembler/assembly_to_binary.py` had no entry for this opcode → harness step 2 (assembly) fails for any vision-encoder ASM.

After PR #17 (flash GQA multipass) lands, only SigLIP / non-causal vision attention uses the skeleton path; clm-60m and Llama text decoders go through `flash_attn_asm`. But vision still needs to assemble cleanly.

## Scope
- `compiler/doc/operation.svh` — add `M_MM_VV = 6'h34` (next free slot after `C_HADAMARD_TRANSFORM = 6'h33`).
- `compiler/assembler/assembly_to_binary.py` — register `M_MM_VV` in the matrix-ops list using the standard `(rs2 << ...) + (rs1 << ...) + (rd << ...) + opcode` encoding.

## Caveat — emulator-side handler still missing
This PR makes the assembler accept `M_MM_VV`, but the Rust emulator (`transactional_emulator/src/op.rs` + `main.rs`) does not yet recognize opcode `0x34`. Step 4 (emulator) will panic on unknown opcode for any ASM containing `M_MM_VV`. A follow-up PR on PLENA_Simulator parent will add the decode + handler.

## Verified
- SmolVLM2 ASM now assembles cleanly (was failing on M_MM_VV).
- clm-60m regression OK.