### PR TITLE
feat(harness): emit hbm_size.txt sidecar for precise emulator HBM sizing

### DIFF
--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -274,6 +274,20 @@ def _build_hbm_from_hf_weights(
         # Expand HBM size in that case; never truncate real weight data.
         pass
 
+    # Write hbm_size.txt sidecar — the actual max HBM byte offset the
+    # generated ASM may reference. emulator_runner.py reads this to size
+    # the HBM allocation precisely instead of using a 2× heuristic.
+    max_hbm_byte = max(
+        (s["offset"] + s["bytes"]) for s in summary.values()
+    ) if summary else hbm_size_bytes
+    # Add 10% headroom for any scratch/output regions the ASM may write
+    # past the last weight tensor.
+    hbm_required = ((int(max_hbm_byte * 1.1) + 63) // 64) * 64
+    hbm_size_path = hbm_path.parent / "hbm_size.txt"
+    hbm_size_path.write_text(str(hbm_required))
+    print(f"      hbm_size.txt: {hbm_required} bytes ({hbm_required / (1024*1024):.1f} MiB)")
+
+    summary["hbm_required"] = hbm_required
     return summary
 
 

--- a/generator/tests/test_generator_e2e.py
+++ b/generator/tests/test_generator_e2e.py
@@ -78,6 +78,8 @@ from emulator_runner import run_emulator  # noqa: E402
 from transactional_emulator.tools.check_mem import read_bin_file_as_array  # noqa: E402
 
 
+
+
 def _build_hbm_from_hf_weights(
     model_id: str,
     seq_len: int,
@@ -277,17 +279,18 @@ def _build_hbm_from_hf_weights(
     # Write hbm_size.txt sidecar — the actual max HBM byte offset the
     # generated ASM may reference. emulator_runner.py reads this to size
     # the HBM allocation precisely instead of using a 2× heuristic.
-    max_hbm_byte = max(
-        (s["offset"] + s["bytes"]) for s in summary.values()
-    ) if summary else hbm_size_bytes
-    # Add 10% headroom for any scratch/output regions the ASM may write
-    # past the last weight tensor.
-    hbm_required = ((int(max_hbm_byte * 1.1) + 63) // 64) * 64
-    hbm_size_path = hbm_path.parent / "hbm_size.txt"
-    hbm_size_path.write_text(str(hbm_required))
-    print(f"      hbm_size.txt: {hbm_required} bytes ({hbm_required / (1024*1024):.1f} MiB)")
+    if summary:
+        max_hbm_byte = max(
+            (s["offset"] + s["bytes"]) for s in summary.values()
+        )
+        # Exact sizing: the generator ASM only reads from HBM (H_PREFETCH_V/M
+        # for weights). No writes past the weight region. If KV cache writeback
+        # is added later, the codegen should update this sidecar accordingly.
+        hbm_required = ((max_hbm_byte + 63) // 64) * 64
+        hbm_size_path = hbm_path.parent / "hbm_size.txt"
+        hbm_size_path.write_text(str(hbm_required) + "\n")
+        print(f"      hbm_size.txt: {hbm_required} bytes ({hbm_required / (1024*1024):.1f} MiB)")
 
-    summary["hbm_required"] = hbm_required
     return summary
 
 


### PR DESCRIPTION
`_build_hbm_from_hf_weights` now writes `hbm_size.txt` to the build dir containing the exact max HBM byte offset across all weight tensors (64-byte aligned). No headroom multiplier — the generator ASM only reads from HBM (`H_PREFETCH_V`/`H_PREFETCH_M` for weights), never writes past the weight region. If KV cache writeback is added later, the codegen should update the sidecar accordingly.

Skips sidecar write if no tensors were written (empty summary guard).

For clm-60m: `hbm_size.txt = 313,169,920 bytes (298.7 MiB)` — exact sizing vs the old 2× guess.

Companion PR: AICrossSim/PLENA_Simulator#24 reads the sidecar.
Closes AICrossSim/PLENA_Simulator#23.