### PR TITLE
fix(flash_attn): initialize l_old to zero in online softmax

### DIFF
--- a/asm_templates/flashattn/overall.py
+++ b/asm_templates/flashattn/overall.py
@@ -130,7 +130,7 @@ def flash_attn_asm(
                 alive_registers_int=alive_registers_int[0:4],
             )
 
-            # Reset l with zeros
+            # Reset l_old to zero (use hardware f0, not FP SRAM slot 0 which is -inf)
             generated_code += reset_fpsram_code(
                 reset_start_address=m_fp_sram_start_address + 2 * br,
                 per_stride_dim=br,
@@ -139,6 +139,7 @@ def flash_attn_asm(
                 reset_val_address=0,
                 alive_registers_fp=alive_registers_fp[0:1],
                 alive_registers_int=alive_registers_int[0:4],
+                use_zero_reg=True,
             )
 
             # Reset O_old with zeros

--- a/asm_templates/flashattn/reset.py
+++ b/asm_templates/flashattn/reset.py
@@ -11,6 +11,7 @@ def reset_fpsram_code(
     reset_val_address: int,
     alive_registers_fp: list[int],
     alive_registers_int: list[int],
+    use_zero_reg: bool = False,
 ) -> str:
     """
     Args:
@@ -18,9 +19,11 @@ def reset_fpsram_code(
     per_stride_dim: the dimension of the reset per stride
     stride_dist: the stride distance between two consecutive resets
     reset_amount: the amount of the consecutive resets
-    reset_val_address: the address of the reset value
+    reset_val_address: FP SRAM slot to load the fill value from
+    use_zero_reg: if True, use f0 (hardware zero = 0.0) instead of loading from FP SRAM
     """
-    generated_code = f"; Reset FPSRAM Code from {reset_start_address} to {reset_start_address + reset_amount * per_stride_dim} with value {reset_val_address}\n"
+    val_label = "f0(0.0)" if use_zero_reg else f"fp_sram[{reset_val_address}]"
+    generated_code = f"; Reset FPSRAM Code from {reset_start_address} to {reset_start_address + reset_amount * per_stride_dim} with value {val_label}\n"
 
     addr_register = alive_registers_int[0]
     outer_loop_register = alive_registers_int[1]
@@ -29,8 +32,11 @@ def reset_fpsram_code(
     fp_val_register = alive_registers_fp[0]
 
     generated_code += f"S_ADDI_INT gp{addr_register}, gp0, {reset_start_address} \n"
-    generated_code += f"S_ADDI_INT gp{offset_register}, gp0, {stride_dist} \n"
-    generated_code += f"S_LD_FP f{fp_val_register}, gp0, {reset_val_address} \n"
+    generated_code += f"S_ADDI_INT gp{offset_register}, gp0, {reset_start_address + stride_dist} \n"
+    if use_zero_reg:
+        fp_val_register = 0  # f0 = hardware zero
+    else:
+        generated_code += f"S_LD_FP f{fp_val_register}, gp0, {reset_val_address} \n"
 
     # Total iterations = reset_amount * per_stride_dim
     if reset_amount > 1:


### PR DESCRIPTION
## Problem

E2E harness reaches step 5 for clm-60m but emulator output is NaN.

## Root cause

`l_old` (running softmax denominator sum) was initialized by loading from FP SRAM slot 0. Slot 0 holds the `-inf` sentinel per `mem_layout_lib.json`. With `l_old = -inf`, the online softmax accumulation produces `l = -inf` every iteration → final `O / l = NaN`.

Secondary bug: `reset_fpsram_code` initialized stride offset to `stride_dist` instead of `reset_start_address + stride_dist`, misplacing l_old for GQA heads > 0 (ratio > 1 only; standard MHA unaffected).

## Fix

- `reset.py`: add `use_zero_reg` param — uses hardware `f0` (always 0.0) instead of `S_LD_FP` from slot 0. Fix stride offset to use absolute address.
- `overall.py`: pass `use_zero_reg=True` for l_old reset.

2 files, +12/-5 lines.

## Verified

- 78 `V_RED_SUM` instructions in generated clm-60m ASM (softmax row-sum active)
- Unit tests pass
- Codegen + assembly clean

Closes #23.