### PR TITLE
docs: document both compilation pipelines + label code paths

### DIFF
--- a/asm_templates/__init__.py
+++ b/asm_templates/__init__.py
@@ -1,3 +1,19 @@
+"""
+Shared ISA instruction emitters -- used by BOTH compilation pipelines.
+
+These templates emit raw PLENA ISA instruction strings. They are
+called by:
+  - Pipeline 1 (ATen): via PlenaCompiler's op implementations in aten/ops/
+  - Pipeline 2 (Generator): via code_gen_pass's node dispatch in generator/passes/
+
+The templates are stateless -- they take dimensions, register indices,
+and addresses as parameters and return ISA strings. All hardware-specific
+state (VRAM layout, HBM offsets, FPRAM slots) is managed by the calling
+pipeline.
+
+See docs/COMPILATION_PIPELINES.md for the full architecture overview.
+"""
+
 from .batched_matmul_asm import batched_matmul_asm
 from .elementwise_add_asm import elementwise_add_asm
 from .embedding_asm import embedding_asm

--- a/aten/plena_compiler.py
+++ b/aten/plena_compiler.py
@@ -1,12 +1,18 @@
-"""PlenaCompiler — unified single-class PLENA ISA compiler.
+"""PlenaCompiler -- ATen Pipeline (Pipeline 1) compilation backend.
 
-Contains the full inheritance chain: TileCompiler (memory bookkeeping) →
-DeveloperCompiler (ISA emission, FP/FPRAM ops, interrupts) → PlenaCompiler
+Manages VRAM/MRAM/FPRAM allocation, HBM weight layout, and address
+register initialization (C_SET_ADDR_REG). Produces numerically verified
+ISA (98-100% allclose against PyTorch golden reference).
+
+Contains the full inheritance chain: TileCompiler (memory bookkeeping) ->
+DeveloperCompiler (ISA emission, FP/FPRAM ops, interrupts) -> PlenaCompiler
 (user-facing DSL). Tensor proxy classes (TensorVar, InputVar, VRAMMatrixVar,
 FPVar) and the unified Tensor type union / TensorKind enum are re-exported
 from the same module.
 
 Previously aliased as ``PLENAProgram``; that alias has been retired.
+
+See docs/COMPILATION_PIPELINES.md for the full architecture overview.
 """
 
 from __future__ import annotations

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,107 @@
+# PLENA Compiler Architecture
+
+## Directory Structure
+
+```
+compiler/
+|-- asm_templates/           # Shared ISA instruction emitters (used by BOTH pipelines)
+|   |-- flashattn/           #   Flash attention (qkt, pv, online_softmax, output, reset)
+|   |-- ffn_asm.py           #   FFN (gate/up/down with K-split)
+|   |-- projection_asm.py    #   Linear projections (Q/K/V/O)
+|   |-- normalization_asm.py #   RMSNorm / LayerNorm
+|   |-- embedding_asm.py     #   Token embedding DMA
+|   |-- rope_asm.py          #   Rotary position embedding
+|   |-- im2col_asm.py        #   Conv2d im2col (shift variant)
+|   |-- im2col_asm_no_shift.py # Conv2d im2col (no-shift variant)
+|   |-- batched_matmul_asm.py  # Batched matrix multiply
+|   |-- silu_asm.py          #   SiLU activation
+|   |-- gelu_asm.py          #   GELU activation
+|   |-- lm_head.py           #   LM head projection
+|   |-- gemv_asm.py          #   General matrix-vector multiply
+|   |-- _imm.py              #   Large immediate helpers
+|   |-- _k_split.py          #   K-split utilities
+|   |-- preload_act.py       #   VRAM preloading
+|   |-- preload_addr_reg.py  #   Address register preloading
+|   |-- store_act_asm.py     #   Activation store-back
+|   +-- reset_reg_asm.py     #   Register reset helpers
+|
+|-- aten/                    # Pipeline 1: ATen compilation backend
+|   |-- plena_compiler.py    #   PlenaCompiler class (VRAM/MRAM/FPRAM management)
+|   +-- ops/                 #   Registered ATen op implementations
+|       |-- registry.py      #     Op dispatch registry
+|       |-- plena/           #     PLENA backend (linear, attention, ffn, norm, conv, softmax, embedding)
+|       +-- cpu/             #     CPU reference implementations
+|
+|-- generator/               # Pipeline 2: Config-driven code generation
+|   |-- runner.py            #   CLI entry point (codegen, aten, utilization modes)
+|   |-- aten_runner.py       #   ATen backend bridge (wraps PlenaCompiler for E2E)
+|   |-- parser/              #   HF config -> symbolic graph
+|   |   |-- llm_parser.py    #     LLMModelParser (text decoder graphs)
+|   |   +-- hardware_parser.py #   configuration.svh / precision.svh reader
+|   |-- passes/              #   Compilation passes
+|   |   |-- code_gen.py      #     Symbolic graph -> ASM (generator backend)
+|   |   +-- utilization_report.py # PE utilization analysis
+|   |-- scheduler/           #   Memory layout + register assignment
+|   |   |-- scheduler.py     #     gen_scheduler entry point
+|   |   |-- mem_layout_lib.json  # Memory layout library
+|   |   +-- reg_assignment_lib.json # Register assignment library
+|   +-- tests/               #   Unit tests + E2E harness
+|       |-- test_llm_parser.py
+|       |-- test_generator_e2e.py
+|       |-- test_embedding_code_gen.py
+|       |-- test_attention_code_gen.py
+|       |-- test_vlm_parser.py
+|       +-- test_vlm_code_gen.py
+|
+|-- assembler/               # ASM text -> binary .mem
+|   |-- parser.py            #   Tokenizer
+|   +-- assembly_to_binary.py #  Instruction encoder
+|
+|-- sim_env_utils/           # Simulation environment builders
+|   |-- build_env.py         #   Build env for ATen pipeline
+|   +-- build_sys_tools.py   #   System-level build helpers
+|
+|-- doc/                     # ISA + hardware parameter definitions
+|   |-- operation.svh        #   Opcode definitions (the ISA)
+|   |-- configuration.svh    #   Hardware parameters (MLEN, VLEN, BLEN, SRAM sizes)
+|   |-- precision.svh        #   Floating-point format widths
+|   |-- plena_isa_spec.md    #   Full ISA specification
+|   |-- memory_layout.md     #   HBM/VRAM/MRAM memory map
+|   +-- Model_Lib/           #   Pre-characterized model configs
+|
++-- docs/                    # This directory -- architecture documentation
+    |-- ARCHITECTURE.md      #   This file
+    +-- COMPILATION_PIPELINES.md # Detailed pipeline comparison
+```
+
+## Compilation Flow Summary
+
+### Pipeline 1 (ATen) -- Numerically Verified
+
+```
+nn.Module
+  -> torch.export (FX graph of ATen ops)
+  -> op dispatch (aten/ops/registry.py)
+  -> PlenaCompiler (aten/plena_compiler.py)
+     - VRAM/MRAM/FPRAM allocation
+     - HBM weight layout + address register init
+     - calls asm_templates/* for ISA emission
+  -> assembler/ (ASM -> .mem binary)
+  -> emulator (run + compare against PyTorch golden)
+```
+
+### Pipeline 2 (Generator) -- ASM Analysis
+
+```
+HF config.json
+  -> LLMModelParser (generator/parser/llm_parser.py)
+  -> symbolic graph (nodes with dimensions, no weights)
+  -> gen_scheduler (memory layout + register assignment)
+  -> code_gen_pass (generator/passes/code_gen.py)
+     - dispatches each node to asm_templates/*
+  -> assembler/ (ASM -> .mem binary)
+  -> emulator (runs but numerically incorrect -- no addr reg init)
+```
+
+See `docs/COMPILATION_PIPELINES.md` for detailed comparison, known gaps,
+and guidance on when to use which pipeline.

--- a/docs/COMPILATION_PIPELINES.md
+++ b/docs/COMPILATION_PIPELINES.md
@@ -1,0 +1,220 @@
+# PLENA Compiler -- Compilation Pipelines
+
+## Overview
+
+The PLENA compiler has **two compilation pipelines** that share low-level
+ISA instruction templates (`asm_templates/`) but differ in their frontends,
+backends, and weight-handling strategies.
+
+```
+                    +------------------+
+                    |  HuggingFace     |
+                    |  Model / Config  |
+                    +--------+---------+
+                             |
+              +--------------+--------------+
+              |                             |
+     Pipeline 1 (ATen)            Pipeline 2 (Generator)
+              |                             |
+    torch.export -> FX graph      HF config -> LLMModelParser
+              |                             |
+    ATen op dispatch              symbolic graph -> code_gen_pass
+              |                             |
+    PlenaCompiler + ops.*         direct asm_template dispatch
+    (VRAM/MRAM/FPRAM mgmt)       (scheduler-driven registers)
+              |                             |
+              +----------- v ---------------+
+                           |
+                   asm_templates/*
+                   (shared ISA emitters)
+                           |
+                     assembler/
+                  (ASM -> binary .mem)
+```
+
+---
+
+## Pipeline 1: ATen Path
+
+**Status**: Production-ready, numerically verified (98-100% allclose)
+
+### How it works
+
+1. **Frontend**: A PyTorch `nn.Module` is traced via `torch.export`, producing
+   an FX graph of ATen operations (`aten.linear`, `aten.rms_norm`,
+   `aten.scaled_dot_product_attention`, etc.).
+
+2. **Op dispatch**: Each ATen node is matched against registered PLENA ops
+   in `aten/ops/plena/` (linear, attention, FFN, norm, conv, softmax,
+   embedding). A CPU fallback registry (`aten/ops/cpu/`) provides reference
+   implementations for ops not yet hardware-mapped.
+
+3. **Backend**: `PlenaCompiler` (`aten/plena_compiler.py`) manages all
+   hardware state -- VRAM allocation, MRAM tile scheduling, FPRAM slot
+   assignment, HBM weight layout, and address register initialization
+   (`C_SET_ADDR_REG`). It calls into `asm_templates/` to emit ISA strings.
+
+4. **Weight loading**: `sim_env_utils/build_env.py` and
+   `transactional_emulator/tools/create_sim_env.py` build the simulation
+   environment, applying MXFP8 quantization when writing weights to HBM.
+
+5. **Verification**: The emulator runs the assembled binary and output
+   activations are compared against a PyTorch golden reference.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `aten/plena_compiler.py` | PlenaCompiler class (VRAM/MRAM/FPRAM management, ISA emission) |
+| `aten/ops/plena/*.py` | Registered ATen op implementations (linear, attention, ffn, norm, conv, softmax, embedding) |
+| `aten/ops/cpu/*.py` | CPU reference fallbacks |
+| `aten/ops/registry.py` | Op dispatch registry |
+| `generator/aten_runner.py` | E2E harness: model load -> compile -> emulate -> verify |
+| `sim_env_utils/build_env.py` | Simulation environment builder |
+
+### Entry points
+
+- **Single-layer tests**: `model_layer_test_builder.py::build_and_run_decoder_test`
+- **Full-model E2E**: `generator/aten_runner.py::run_aten_e2e`
+- **CLI**: `python -m generator.runner aten <model> --seq-len 32 --num-layers 1`
+
+### Test suite
+
+Tests live in `transactional_emulator/testbench/aten/` and
+`transactional_emulator/testbench/models/`. As of this writing, 18/18
+pass with 98-100% allclose.
+
+---
+
+## Pipeline 2: Generator Path
+
+**Status**: Generates valid ISA for analysis. Numerically incomplete
+(HBM address registers uninitialized).
+
+### How it works
+
+1. **Frontend**: `LLMModelParser` (`generator/parser/llm_parser.py`) reads a
+   HuggingFace model config (local JSON or remote `config.json`) and builds
+   a **symbolic graph** from dimensions alone -- no weights are loaded.
+
+2. **Scheduling**: `gen_scheduler` (`generator/scheduler/scheduler.py`)
+   assigns memory layout and register mappings using library files
+   (`mem_layout_lib.json`, `reg_assignment_lib.json`).
+
+3. **Backend**: `code_gen_pass` (`generator/passes/code_gen.py`) walks the
+   symbolic graph and dispatches each node to the appropriate
+   `asm_templates/` function, passing scheduler-derived register and
+   address parameters.
+
+4. **Weight loading**: For E2E smoke tests, `test_generator_e2e.py` has a
+   `_build_hbm_from_hf_weights` helper that loads real weights. The
+   standard codegen path does not touch weights at all.
+
+5. **Output**: A `.asm` file that assembles cleanly and runs on the emulator
+   (the instructions are structurally valid), but produces numerically
+   incorrect results because HBM address registers (`C_SET_ADDR_REG`) are
+   not initialized.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `generator/parser/llm_parser.py` | HF config -> symbolic graph |
+| `generator/parser/hardware_parser.py` | `configuration.svh` / `precision.svh` reader |
+| `generator/scheduler/scheduler.py` | Memory layout + register assignment |
+| `generator/passes/code_gen.py` | Symbolic graph -> ASM via asm_template dispatch |
+| `generator/passes/utilization_report.py` | PE utilization analysis |
+| `generator/runner.py` | CLI entry point for codegen / utilization modes |
+
+### Entry points
+
+- **CLI**: `python -m generator.runner codegen <model> output.asm --seq-len 512`
+- **Utilization**: `python -m generator.runner utilization <model> dummy.asm`
+
+### Test suite
+
+Tests live in `generator/tests/`:
+- `test_llm_parser.py` -- parser unit tests
+- `test_embedding_code_gen.py`, `test_attention_code_gen.py` -- codegen unit tests
+- `test_generator_e2e.py` -- full-pipeline smoke tests
+- `test_vlm_parser.py`, `test_vlm_code_gen.py` -- vision/multimodal tests
+
+CI workflow: `.github/workflows/` runs these on push.
+
+---
+
+## Shared Infrastructure
+
+### `asm_templates/` -- ISA instruction emitters
+
+Stateless functions that take dimensions, register indices, and addresses
+as parameters and return PLENA ISA instruction strings. Both pipelines
+call into these.
+
+| Template | Operation |
+|----------|-----------|
+| `projection_asm.py` | Linear projections (Q/K/V/O), transposed variant |
+| `ffn_asm.py` | FFN (gate/up/down with K-split support) |
+| `flashattn/` | Flash attention (qkt, pv, online_softmax, output, reset) |
+| `normalization_asm.py` | RMSNorm, LayerNorm |
+| `embedding_asm.py` | Token embedding DMA from HBM |
+| `rope_asm.py` | Rotary position embedding |
+| `im2col_asm.py`, `im2col_asm_no_shift.py` | Conv2d im2col (shift and no-shift variants) |
+| `batched_matmul_asm.py` | Batched matrix multiply |
+| `silu_asm.py`, `gelu_asm.py` | Activation functions |
+| `lm_head.py` | LM head projection |
+| `gemv_asm.py` | General matrix-vector multiply |
+| `preload_act.py`, `preload_addr_reg.py` | VRAM/register preloading |
+| `store_act_asm.py` | Activation store-back to HBM |
+| `reset_reg_asm.py` | Register reset helpers |
+| `_imm.py`, `_k_split.py` | Large immediate + K-split utilities |
+
+### `assembler/` -- ASM text to binary
+
+- `parser.py` -- tokenizes `.asm` text
+- `assembly_to_binary.py` -- encodes instructions into `.mem` binary
+
+### `doc/` -- ISA and hardware definitions
+
+- `operation.svh` -- opcode definitions (the ISA)
+- `configuration.svh` -- hardware parameters (MLEN, VLEN, BLEN, SRAM sizes)
+- `precision.svh` -- floating-point format widths
+- `plena_isa_spec.md` -- full ISA specification
+- `memory_layout.md` -- HBM/VRAM/MRAM memory map
+- `Model_Lib/` -- pre-characterized model configs (JSON)
+
+---
+
+## When to Use Which
+
+| Use case | Recommended pipeline |
+|----------|---------------------|
+| Numerical verification of a layer/model | ATen (`runner.py aten`) |
+| ASM generation for profiling/analysis | Generator (`runner.py codegen`) |
+| New model bring-up | ATen first (verified), then Generator (analysis) |
+| RTL co-simulation | ATen (address registers set correctly) |
+| PE utilization estimation | Generator (`runner.py utilization`) |
+| CI smoke tests (assembly validity) | Generator (fast, no weights needed) |
+
+---
+
+## Known Gaps in Generator Path
+
+1. **HBM address registers**: `code_gen_pass` does not emit
+   `C_SET_ADDR_REG` instructions. The ATen path's `PlenaCompiler` handles
+   this via `preload_addr_reg_asm`.
+
+2. **Weight layout**: The generator does not manage HBM weight placement.
+   Weight offsets are symbolic, not physical addresses.
+
+3. **FPRAM slot conventions**: The generator does not initialize FPRAM
+   precious slots (attn_scale, -inf, eps, 1/hidden, 1.0). The ATen path
+   seeds these via `PlenaCompiler.fp_sram` and preserves them across ops.
+
+4. **K-split partial sums**: The generator does not handle K-dimension
+   splitting for large linear layers (K_col > 4*MLEN). The ATen path
+   implements this in `linear_ops.py`.
+
+5. **MXFP8 quantization**: Generator tests that do load weights
+   (`_build_hbm_from_hf_weights`) apply quantization, but the standard
+   codegen path has no weight awareness at all.

--- a/generator/passes/code_gen.py
+++ b/generator/passes/code_gen.py
@@ -1,8 +1,17 @@
 """
-Code generation pass for LLM symbolic graph to assembly transformation.
+Code generation pass -- Generator Pipeline (Pipeline 2).
 
-This module transforms the symbolic graph representation of a LLM model
-into assembly code using predefined templates for different operation types.
+Transforms a symbolic graph (from LLMModelParser) into PLENA ISA by
+dispatching each node to the appropriate asm_template function. This is
+the generator's own compilation backend, separate from the ATen path's
+PlenaCompiler.
+
+NOTE: This pipeline generates structurally valid ISA but does not
+initialize HBM address registers (C_SET_ADDR_REG). For numerically
+correct end-to-end execution, use the ATen path via
+``generator.aten_runner.run_aten_e2e`` or ``generator.runner aten``.
+
+See docs/COMPILATION_PIPELINES.md for the full architecture overview.
 """
 
 from pathlib import Path

--- a/generator/runner.py
+++ b/generator/runner.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 """
-Generator runner — unified CLI for both codegen and ATen compilation modes.
+PLENA Generator Runner -- entry point for both compilation pipelines.
 
 Modes:
-    codegen   — generator's own symbolic-graph → ISA pipeline (ASM output only)
-    aten      — PlenaCompiler + ops.* numerically-verified e2e pipeline
-    utilization — PE utilization analysis (no ISA emitted)
+  codegen      -- Pipeline 2 (Generator): HF config -> symbolic graph ->
+                  code_gen_pass -> ASM. Valid ISA for analysis/profiling;
+                  numerically incomplete (HBM address registers not set).
+  aten         -- Pipeline 1 (ATen): HF model -> PlenaCompiler -> verified
+                  ISA. Numerically verified, 98-100% allclose.
+  utilization  -- PE utilization analysis report (no ISA emitted).
 
 Examples:
     python -m generator.runner codegen AICrossSim/clm-60m output.asm --seq-len 512
     python -m generator.runner aten AICrossSim/clm-60m --seq-len 32 --num-layers 1
-    python -m generator.runner utilization AICrossSim/clm-60m dummy.asm --seq-len 512
+
+See docs/COMPILATION_PIPELINES.md for the full architecture overview.
 """
 
 import argparse


### PR DESCRIPTION
## What

Documents both PLENA compilation pipelines and labels key source files.

## New files

- **`docs/COMPILATION_PIPELINES.md`** — detailed comparison of Pipeline 1 (ATen/PlenaCompiler) vs Pipeline 2 (Generator/code_gen_pass): flow diagrams, key files, entry points, verification status, known gaps, when to use which.
- **`docs/ARCHITECTURE.md`** — annotated directory tree + compilation flow summaries.

## Code labels added

| File | Label |
|---|---|
| `generator/runner.py` | Module docstring: modes, pipeline IDs, examples, link to docs |
| `generator/passes/code_gen.py` | Pipeline 2 backend, note about missing C_SET_ADDR_REG |
| `aten/plena_compiler.py` | Pipeline 1 backend, verification status |
| `asm_templates/__init__.py` | Shared layer used by both pipelines |

## Why

Two parallel compilation paths existed with no documentation explaining their relationship, tradeoffs, or verification status. This caused confusion about which path to use and what each path guarantees.