### PR TITLE
Native SmolVLM2/LLaDA support, multi-batch attention, configurable mlen/vlen/blen

### DIFF
--- a/asm_templates/_imm.py
+++ b/asm_templates/_imm.py
@@ -1,8 +1,9 @@
-"""Helpers for loading large integer immediates into GP registers.
+"""Helpers for loading and adding large integer immediates with GP registers.
 
 S_ADDI_INT only encodes 18-bit immediates (0..2^18-1). Anything larger needs
 S_LUI_INT (which writes `imm << 12` into the destination) optionally followed
-by an S_ADDI_INT for the lower 12 bits.
+by an S_ADDI_INT for the lower 12 bits. Relative adds can either use a caller-
+provided temporary register or a register-safe chunked ADDI fallback.
 
 These helpers were previously duplicated in projection_asm, ffn_asm and
 preload_act with subtly different signatures and thresholds; this module is
@@ -31,17 +32,45 @@ def load_large_int(reg: int, value: int) -> list[str]:
     return lines
 
 
-def addi_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> list[str]:
+def add_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int | None = None) -> list[str]:
     """Return ASM lines for `gp{dest_reg} = gp{src_reg} + value`.
 
-    For values < 2^18 a single S_ADDI_INT is enough. Larger values are first
-    materialised into `gp{temp_reg}` via load_large_int, then added.
+    For values < 2^18 a single S_ADDI_INT is enough.
+
+    When `temp_reg` is supplied, larger values are materialised into that
+    register via load_large_int, then added with S_ADD_INT. The temp register
+    must not alias src_reg, because loading the immediate would clobber the
+    source value before the add.
+
+    When `temp_reg` is omitted, larger values are emitted as a sequence of
+    bounded S_ADDI_INT chunks. This fallback is less compact but is safe in a
+    compiler-wide legalization pass because it requires no scratch register.
     """
+    if value < 0:
+        raise ValueError(f"large immediate helpers only support non-negative values, got {value}")
     if value < IMM2_BOUND:
         return [f"S_ADDI_INT gp{dest_reg}, gp{src_reg}, {value}"]
-    lines = load_large_int(temp_reg, value)
-    lines.append(f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}")
+
+    if temp_reg is not None and temp_reg != src_reg:
+        lines = load_large_int(temp_reg, value)
+        lines.append(f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}")
+        return lines
+
+    lines: list[str] = []
+    remaining = value
+    source = src_reg
+    chunk = IMM2_BOUND - 1
+    while remaining:
+        step = min(remaining, chunk)
+        lines.append(f"S_ADDI_INT gp{dest_reg}, gp{source}, {step}")
+        remaining -= step
+        source = dest_reg
     return lines
+
+
+def addi_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> list[str]:
+    """Backward-compatible alias for add_large_int with an explicit temp register."""
+    return add_large_int(dest_reg, src_reg, value, temp_reg=temp_reg)
 
 
 def load_large_int_str(reg: int, value: int) -> str:
@@ -49,6 +78,11 @@ def load_large_int_str(reg: int, value: int) -> str:
     return "".join(line + "\n" for line in load_large_int(reg, value))
 
 
+def add_large_int_str(dest_reg: int, src_reg: int, value: int, temp_reg: int | None = None) -> str:
+    """String variant of add_large_int."""
+    return "".join(line + "\n" for line in add_large_int(dest_reg, src_reg, value, temp_reg=temp_reg))
+
+
 def addi_large_int_str(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> str:
     """String variant of addi_large_int."""
-    return "".join(line + "\n" for line in addi_large_int(dest_reg, src_reg, value, temp_reg))
+    return add_large_int_str(dest_reg, src_reg, value, temp_reg=temp_reg)

--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._imm import addi_large_int_str as _addi_large_int
 from ._imm import load_large_int_str as _load_large_int
 from ._k_split import k_chunks as _k_chunks

--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -22,12 +22,18 @@ def ffn_asm(
     use_loop_instructions: bool = False,
     use_fused_up_gate: bool = False,
     matrix_sram_size: int = 1024,
+    workspace_base_address: int = 0,
 ) -> str:
     """
     Generates assembly code for a FFN operation.
 
     Set use_loop_instructions=True to use C_LOOP_START/END for compact code.
     Set use_fused_up_gate=True to fuse upsize and gate projections (requires 12 registers).
+
+    ``workspace_base_address`` is the VRAM base for FFN temporaries. The default
+    preserves the historical direct_emit layout at low VRAM addresses. Compiler
+    lowering should pass an allocator-managed base so FFN temporaries cannot
+    clobber persistent tensors such as RoPE tables.
 
     ``matrix_sram_size`` is the MRAM capacity (element-units-per-tile * tiles). When
     a projection's K dimension exceeds ``matrix_sram_size // mlen`` tiles, the template
@@ -51,6 +57,7 @@ def ffn_asm(
             down_weight_hbm_offset_reg,
             const_one_fp_address,
             activation_base_address,
+            workspace_base_address=workspace_base_address,
         )
     elif use_loop_instructions:
         return _ffn_asm_with_loops(
@@ -67,6 +74,7 @@ def ffn_asm(
             down_weight_hbm_offset_reg,
             const_one_fp_address,
             activation_base_address,
+            workspace_base_address=workspace_base_address,
         )
     else:
         return _ffn_asm_unrolled(
@@ -84,7 +92,21 @@ def ffn_asm(
             const_one_fp_address,
             activation_base_address,
             matrix_sram_size=matrix_sram_size,
+            workspace_base_address=workspace_base_address,
         )
+
+
+def _ffn_workspace_layout(
+    batch: int,
+    seq_len: int,
+    intermediate_size: int,
+    workspace_base_address: int,
+) -> tuple[int, int, int]:
+    rows = batch * seq_len
+    up_result_base = workspace_base_address
+    gate_result_base = up_result_base + rows * intermediate_size
+    scratch_base = gate_result_base + rows * intermediate_size
+    return up_result_base, gate_result_base, scratch_base
 
 
 def _ffn_asm_unrolled(
@@ -102,6 +124,7 @@ def _ffn_asm_unrolled(
     const_one_fp_address: int,
     activation_base_address: int,
     matrix_sram_size: int = 1024,
+    workspace_base_address: int = 0,
 ) -> str:
     """Unrolled FFN: up + gate + SiLU + down projections.
 
@@ -112,10 +135,9 @@ def _ffn_asm_unrolled(
     ``aten/ops/plena/linear_ops.py::linear_plena``.
     """
 
-    # memory assignment
-    # 0 -> activation
-    # b * s * hidden_size -> upsize intermediate results
-    # b * s * (hidden_size + intermediate_size) -> gate projection results
+    up_result_base, gate_result_base, scratch_base = _ffn_workspace_layout(
+        batch, seq_len, intermediate_size, workspace_base_address
+    )
 
     w_actual_register = alive_registers[0]
     w_temp_register = alive_registers[1]
@@ -136,20 +158,17 @@ def _ffn_asm_unrolled(
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
     # Set the address for on-chip sram
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
 
     # K-split config: when K tile count > MRAM tile capacity, we split K and
     # accumulate partial sums. `activation` region (used as input) starts at
-    # `activation_base_address`; the K-split scratch region for up/gate lives
-    # *after* the up+gate output regions at
-    # `batch*seq_len*(hidden_size+2*intermediate_size)` (hidden_size chunk for
-    # activation, intermediate_size each for up and gate results).
+    # `activation_base_address`; the K-split scratch region lives after the
+    # allocator-managed up/gate output regions.
     MAX_K_TILES = max(1, matrix_sram_size // mlen)
 
     # --- FFN Upsize Linear (K = hidden_size) ---
-    hidden_size // mlen
-    up_scratch_base = batch * seq_len * (hidden_size + 2 * intermediate_size)
+    up_num_k_tiles = hidden_size // mlen
     generated_code += _emit_ffn_projection_unrolled(
         mlen=mlen,
         vlen=vlen,
@@ -161,7 +180,7 @@ def _ffn_asm_unrolled(
         weight_stride=intermediate_size,
         weight_hbm_offset_reg=up_weight_hbm_offset_reg,
         result_base_register=up_result_register,
-        result_base_value=batch * seq_len * hidden_size,
+        result_base_value=up_result_base,
         activation_base_address=activation_base_address,
         activation_base_register=None,
         max_k_tiles=MAX_K_TILES,
@@ -170,12 +189,11 @@ def _ffn_asm_unrolled(
         a_actual_register=a_actual_register,
         intermediate_register=intermediate_register,
         w_hbm_offset_register=w_hbm_offset_register,
-        scratch_base_value=up_scratch_base,
+        scratch_base_value=scratch_base,
         section_comment="FFN Upsize Linear Generation",
     )
 
     generated_code += " ; FFN Gate Projection Generation \n"
-    gate_scratch_base = batch * seq_len * (hidden_size + 2 * intermediate_size)
     generated_code += _emit_ffn_projection_unrolled(
         mlen=mlen,
         vlen=vlen,
@@ -187,7 +205,7 @@ def _ffn_asm_unrolled(
         weight_stride=intermediate_size,
         weight_hbm_offset_reg=gate_weight_hbm_offset_reg,
         result_base_register=gate_result_register,
-        result_base_value=batch * seq_len * (hidden_size + intermediate_size),
+        result_base_value=gate_result_base,
         activation_base_address=activation_base_address,
         activation_base_register=None,
         max_k_tiles=MAX_K_TILES,
@@ -196,14 +214,14 @@ def _ffn_asm_unrolled(
         a_actual_register=a_actual_register,
         intermediate_register=intermediate_register,
         w_hbm_offset_register=w_hbm_offset_register,
-        scratch_base_value=gate_scratch_base,
+        scratch_base_value=scratch_base,
         section_comment="FFN Gate Projection (inlined)",
     )
 
     generated_code += "; SILU Generation \n"
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address} \n"
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
     generated_code += _load_large_int(intermediate_register, activation_base_address)
 
     # SiLU: sigmoid(x) * x * gate, using activation region as scratchpad
@@ -232,10 +250,8 @@ def _ffn_asm_unrolled(
     # Storing the results to the activation base region
     act_result_register = gate_result_register
     # Down projection: K = intermediate_size. Activation input is at
-    # VRAM address batch*seq_len*hidden_size (up_result region, post-SiLU).
-    # Scratch for K-split lives past the gate region so it never collides
-    # with input (up_result) or output (activation_base_address).
-    down_scratch_base = batch * seq_len * (hidden_size + 2 * intermediate_size)
+    # VRAM address up_result_base (post-SiLU). Scratch for K-split lives past
+    # the gate region so it never collides with input or output.
     generated_code += _emit_ffn_projection_unrolled(
         mlen=mlen,
         vlen=vlen,
@@ -250,14 +266,14 @@ def _ffn_asm_unrolled(
         result_base_value=activation_base_address,
         activation_base_address=None,
         activation_base_register=up_result_register,
-        activation_base_register_value=batch * seq_len * hidden_size,
+        activation_base_register_value=up_result_base,
         max_k_tiles=max(1, matrix_sram_size // mlen),
         w_actual_register=w_actual_register,
         w_temp_register=w_temp_register,
         a_actual_register=a_actual_register,
         intermediate_register=intermediate_register,
         w_hbm_offset_register=w_hbm_offset_register,
-        scratch_base_value=down_scratch_base,
+        scratch_base_value=scratch_base,
         section_comment="FFN Downsize Linear (inlined)",
     )
     return generated_code
@@ -309,7 +325,7 @@ def _emit_ffn_projection_unrolled(
     assert k_size % mlen == 0, f"K ({k_size}) must be a multiple of MLEN ({mlen})"
     assert out_size % mlen == 0, f"out_size ({out_size}) must be a multiple of MLEN ({mlen})"
     num_k_tiles = k_size // mlen
-    (batch * seq_len) // blen
+    num_act_cols = (batch * seq_len) // blen
 
     lines: list[str] = [f" ; {section_comment} (k_size={k_size}, out_size={out_size})\n"]
 
@@ -387,11 +403,15 @@ def _emit_ffn_projection_unrolled(
         if not is_first:
             # V_ADD_VV output += scratch  for the entire output region.
             # Use w_actual_register as output pointer, w_temp_register as scratch ptr.
-            lines.append(f" ; K-split accumulate: output[0..{output_elements}] += scratch[0..{output_elements}]\n")
+            lines.append(
+                f" ; K-split accumulate: output[0..{output_elements}] += scratch[0..{output_elements}]\n"
+            )
             lines.append(_load_large_int(w_actual_register, result_base_value))
             lines.append(_load_large_int(w_temp_register, scratch_base_value))
             for _ in range(per_vlen_adds):
-                lines.append(f"V_ADD_VV gp{w_actual_register}, gp{w_actual_register}, gp{w_temp_register}, 0 \n")
+                lines.append(
+                    f"V_ADD_VV gp{w_actual_register}, gp{w_actual_register}, gp{w_temp_register}, 0 \n"
+                )
                 lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {vlen} \n")
                 lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {vlen} \n")
 
@@ -490,11 +510,15 @@ def _emit_ffn_projection_chunk(
                 )
                 lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n")
                 lines.append(
-                    _addi_large_int(w_hbm_offset_register, w_hbm_offset_register, mlen * weight_stride, w_temp_register)
+                    _addi_large_int(
+                        w_hbm_offset_register, w_hbm_offset_register, mlen * weight_stride, w_temp_register
+                    )
                 )
             lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n")
         else:
-            lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} \n")
+            lines.append(
+                f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} \n"
+            )
             lines.append(
                 f"S_ADDI_INT gp{intermediate_register}, gp{result_base_register}, {(weight_row % (mlen // blen)) * blen} \n"
             )
@@ -522,12 +546,16 @@ def _emit_ffn_projection_chunk(
             for _ in range(k_tile_count):
                 lines.append(f"M_MM 0, gp{w_temp_register}, gp{a_actual_register} \n")
                 lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} \n")
-                lines.append(f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n")
+                lines.append(
+                    f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
+                )
             lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 \n")
             lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n")
 
         if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_size // blen - 1:
-            lines.append(f"S_ADDI_INT gp{result_base_register}, gp{result_base_register}, {mlen * batch * seq_len} \n")
+            lines.append(
+                f"S_ADDI_INT gp{result_base_register}, gp{result_base_register}, {mlen * batch * seq_len} \n"
+            )
 
     return "".join(lines)
 
@@ -544,6 +572,7 @@ def ffn_up_silu_asm(
     up_weight_hbm_offset_reg: int,
     const_one_fp_address: int,
     activation_base_address: int,
+    workspace_base_address: int = 0,
 ) -> str:
     """Up projection + SiLU only (no gate/down). Uses C_LOOP instructions."""
     # Register allocation
@@ -570,7 +599,8 @@ def ffn_up_silu_asm(
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base address for up result
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    up_result_base, _, _ = _ffn_workspace_layout(batch, seq_len, intermediate_size, workspace_base_address)
+    generated_code += _load_large_int(up_result_register, up_result_base)
 
     # Upsize linear (loop)
     generated_code += "; FFN Upsize Linear Generation (Loop)\n"
@@ -667,6 +697,7 @@ def ffn_intermediate_asm(
     up_weight_hbm_offset_reg: int,
     const_one_fp_address: int,
     activation_base_address: int,
+    workspace_base_address: int = 0,
 ) -> str:
     """Up + gate + SiLU (no down projection). Uses C_LOOP instructions."""
     # Register allocation
@@ -684,6 +715,9 @@ def ffn_intermediate_asm(
     loop_inner2_reg = alive_registers[9]
 
     generated_code = "; FFN Intermediate Generation (Up + Gate + SILU only)\n"
+    up_result_base, gate_result_base, _ = _ffn_workspace_layout(
+        batch, seq_len, intermediate_size, workspace_base_address
+    )
 
     # Setup: scale/stride registers
     generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
@@ -693,8 +727,8 @@ def ffn_intermediate_asm(
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base addresses for results
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
 
     # Upsize linear (loop)
     generated_code += "; FFN Upsize Linear Generation (Loop)\n"
@@ -773,8 +807,8 @@ def ffn_intermediate_asm(
     generated_code += "; FFN Gate Projection Generation (Loop)\n"
 
     # Reset base addresses
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
     generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, 0\n"
 
     generated_code += f"; Outer loop: {num_mlen_blocks} MLEN blocks\n"
@@ -844,8 +878,8 @@ def ffn_intermediate_asm(
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address}\n"
 
     # Reset addresses
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
     generated_code += _load_large_int(intermediate_register, activation_base_address)
 
     # Loop over batch * seq_len * (intermediate_size // vlen)
@@ -865,7 +899,7 @@ def ffn_intermediate_asm(
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    # Note: Result is stored in up_result_register at base address batch * seq_len * hidden_size
+    # Note: Result is stored in up_result_register at up_result_base
     generated_code += "; Intermediate result (up + gate + SILU) stored at up_result_register location\n"
 
     return generated_code
@@ -885,6 +919,7 @@ def _ffn_asm_with_loops(
     down_weight_hbm_offset_reg: int,
     const_one_fp_address: int,
     activation_base_address: int,
+    workspace_base_address: int = 0,
 ) -> str:
     """Full FFN (up + gate + SiLU + down) using C_LOOP instructions."""
 
@@ -903,6 +938,9 @@ def _ffn_asm_with_loops(
     loop_inner2_reg = alive_registers[9]
 
     generated_code = "; FFN Generation (Loop-Optimized)\n"
+    up_result_base, gate_result_base, _ = _ffn_workspace_layout(
+        batch, seq_len, intermediate_size, workspace_base_address
+    )
 
     # Setup: scale/stride registers
     generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
@@ -912,8 +950,8 @@ def _ffn_asm_with_loops(
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base addresses for results
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
 
     # Upsize linear (loop)
     generated_code += "; FFN Upsize Linear Generation (Loop)\n"
@@ -992,8 +1030,8 @@ def _ffn_asm_with_loops(
     generated_code += "; FFN Gate Projection Generation (Loop)\n"
 
     # Reset base addresses
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
     generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, 0\n"
 
     generated_code += f"; Outer loop: {num_mlen_blocks} MLEN blocks\n"
@@ -1063,8 +1101,8 @@ def _ffn_asm_with_loops(
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address}\n"
 
     # Reset addresses
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
     generated_code += _load_large_int(intermediate_register, activation_base_address)
 
     # Loop over batch * seq_len * (intermediate_size // vlen)
@@ -1097,7 +1135,7 @@ def _ffn_asm_with_loops(
     # Result goes to activation base region
     act_result_register = gate_result_register
     generated_code += _load_large_int(act_result_register, activation_base_address)
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(up_result_register, up_result_base)
 
     # Downsize: (b*s, intermediate_size) @ (intermediate_size, hidden_size) -> (b*s, hidden_size)
     num_down_mlen_blocks = hidden_size // mlen
@@ -1127,7 +1165,7 @@ def _ffn_asm_with_loops(
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen}\n"
 
     # Reset activation base; up_result_register recomputed here (used as temp below)
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(up_result_register, up_result_base)
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
     num_down_act_cols = (batch * seq_len) // blen
     generated_code += f"; Inner loop: {num_down_act_cols} activation columns\n"
@@ -1185,6 +1223,7 @@ def _ffn_asm_fused_up_gate(
     down_weight_hbm_offset_reg: int,
     const_one_fp_address: int,
     activation_base_address: int,
+    workspace_base_address: int = 0,
 ) -> str:
     """Fused FFN: overlaps up/gate prefetch to reduce HBM traffic. Requires 12 registers."""
 
@@ -1206,6 +1245,9 @@ def _ffn_asm_fused_up_gate(
     w_gate_base_register = alive_registers[11]  # Gate weight base in MRAM
 
     generated_code = "; FFN Generation (Fused Up+Gate Optimized)\n"
+    up_result_base, gate_result_base, _ = _ffn_workspace_layout(
+        batch, seq_len, intermediate_size, workspace_base_address
+    )
 
     # Setup: scale/stride registers
     generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
@@ -1215,8 +1257,8 @@ def _ffn_asm_fused_up_gate(
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base addresses for results
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
 
     # Fused up + gate linear with overlapped prefetch
     generated_code += "; Fused Up+Gate Linear (overlapped prefetch optimization)\n"
@@ -1377,8 +1419,8 @@ def _ffn_asm_fused_up_gate(
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
 
     # Initialize SILU pointers
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
-    generated_code += _load_large_int(gate_result_register, batch * seq_len * (hidden_size + intermediate_size))
+    generated_code += _load_large_int(up_result_register, up_result_base)
+    generated_code += _load_large_int(gate_result_register, gate_result_base)
     generated_code += _load_large_int(intermediate_register, activation_base_address)
 
     # Initialize DOWN prefetch pointers (w_actual_register=MRAM offset, a_actual_register=HBM offset)
@@ -1420,7 +1462,7 @@ def _ffn_asm_fused_up_gate(
 
     act_result_register = gate_result_register
     generated_code += _load_large_int(act_result_register, activation_base_address)
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(up_result_register, up_result_base)
 
     down_act_col_advance = mlen * blen
 
@@ -1435,7 +1477,7 @@ def _ffn_asm_fused_up_gate(
     # First block computation
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen_down}\n"
 
-    generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+    generated_code += _load_large_int(up_result_register, up_result_base)
     generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
     num_down_act_cols = (batch * seq_len) // blen
 
@@ -1485,7 +1527,7 @@ def _ffn_asm_fused_up_gate(
         generated_code += f"; Middle loop: {tiles_per_mlen_down} tiles per MLEN block\n"
         generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen_down}\n"
 
-        generated_code += _load_large_int(up_result_register, batch * seq_len * hidden_size)
+        generated_code += _load_large_int(up_result_register, up_result_base)
         generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
 
         generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_down_act_cols}\n"

--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -152,7 +152,9 @@ def _ffn_asm_unrolled(
     generated_code = "; FFN Generation \n"
 
     # Settings for up and gate weight matrices prefetching
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
     generated_code += _load_large_int(w_actual_register, intermediate_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
@@ -228,25 +230,31 @@ def _ffn_asm_unrolled(
     for b in range(batch * seq_len):
         for i in range(intermediate_size // vlen):
             generated_code += f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1 \n"
-            generated_code += f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0 \n"
+            generated_code += (
+                f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0 \n"
+            )
             generated_code += f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0 \n"
-            generated_code += f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0 \n"
             generated_code += (
-                f"V_MUL_VV gp{intermediate_register}, gp{intermediate_register}, gp{up_result_register}, 0 \n"
+                f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0 \n"
             )
-            generated_code += (
-                f"V_MUL_VV gp{up_result_register}, gp{intermediate_register}, gp{gate_result_register}, 0 \n"
-            )
+            generated_code += f"V_MUL_VV gp{intermediate_register}, gp{intermediate_register}, gp{up_result_register}, 0 \n"
+            generated_code += f"V_MUL_VV gp{up_result_register}, gp{intermediate_register}, gp{gate_result_register}, 0 \n"
             generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {vlen} \n"
-            generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen} \n"
+            generated_code += (
+                f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen} \n"
+            )
 
     generated_code += "; FFN Downsize Linear Generation \n"
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register} \n"
     generated_code += _load_large_int(w_actual_register, hidden_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register} \n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n"
-    generated_code += f"S_ADDI_INT gp{m_stride_register}, gp0, {((batch * seq_len) // blen)} \n"
+    generated_code += (
+        f"S_ADDI_INT gp{m_stride_register}, gp0, {((batch * seq_len) // blen)} \n"
+    )
     # Storing the results to the activation base region
     act_result_register = gate_result_register
     # Down projection: K = intermediate_size. Activation input is at
@@ -323,14 +331,20 @@ def _emit_ffn_projection_unrolled(
     """
 
     assert k_size % mlen == 0, f"K ({k_size}) must be a multiple of MLEN ({mlen})"
-    assert out_size % mlen == 0, f"out_size ({out_size}) must be a multiple of MLEN ({mlen})"
+    assert (
+        out_size % mlen == 0
+    ), f"out_size ({out_size}) must be a multiple of MLEN ({mlen})"
     num_k_tiles = k_size // mlen
     num_act_cols = (batch * seq_len) // blen
 
-    lines: list[str] = [f" ; {section_comment} (k_size={k_size}, out_size={out_size})\n"]
+    lines: list[str] = [
+        f" ; {section_comment} (k_size={k_size}, out_size={out_size})\n"
+    ]
 
     if num_k_tiles <= max_k_tiles:
-        lines.append(f" ; K-split inactive: num_k_tiles={num_k_tiles} <= MAX_K_TILES={max_k_tiles}\n")
+        lines.append(
+            f" ; K-split inactive: num_k_tiles={num_k_tiles} <= MAX_K_TILES={max_k_tiles}\n"
+        )
         lines.append(
             _emit_ffn_projection_chunk(
                 mlen=mlen,
@@ -370,7 +384,9 @@ def _emit_ffn_projection_unrolled(
     per_vlen_adds = output_elements // vlen
 
     for chunk_idx, (k_start, k_count) in enumerate(chunks):
-        lines.append(f" ; K-chunk {chunk_idx}/{len(chunks)}: k_start_tile={k_start}, k_count={k_count}\n")
+        lines.append(
+            f" ; K-chunk {chunk_idx}/{len(chunks)}: k_start_tile={k_start}, k_count={k_count}\n"
+        )
         is_first = chunk_idx == 0
         target_base_value = None if is_first else scratch_base_value
         lines.append(
@@ -412,8 +428,12 @@ def _emit_ffn_projection_unrolled(
                 lines.append(
                     f"V_ADD_VV gp{w_actual_register}, gp{w_actual_register}, gp{w_temp_register}, 0 \n"
                 )
-                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {vlen} \n")
-                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {vlen} \n")
+                lines.append(
+                    f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {vlen} \n"
+                )
+                lines.append(
+                    f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {vlen} \n"
+                )
 
     # After the K-split loop the result_base_register value has been advanced
     # by the chunk helper (per MLEN-block, inside the chunk). Restore it for
@@ -481,7 +501,11 @@ def _emit_ffn_projection_chunk(
     # Target base: first chunk writes to real output, subsequent chunks write to scratch.
     # Both cases load result_base_register with the appropriate base value so the
     # MLEN-block advancement steps (S_ADDI_INT result_base_register, ...) work uniformly.
-    target_base_value = result_base_value if target_base_value_override is None else target_base_value_override
+    target_base_value = (
+        result_base_value
+        if target_base_value_override is None
+        else target_base_value_override
+    )
 
     lines: list[str] = []
     lines.append(_load_large_int(result_base_register, target_base_value))
@@ -491,7 +515,9 @@ def _emit_ffn_projection_chunk(
     # chunk so `+ chunk_act_base_offset` lands in the right spot.
     if reset_act_base_register and activation_base_register is not None:
         assert activation_base_register_value is not None
-        lines.append(_load_large_int(activation_base_register, activation_base_register_value))
+        lines.append(
+            _load_large_int(activation_base_register, activation_base_register_value)
+        )
 
     for weight_row in range(out_size // blen):
         if weight_row % (mlen // blen) == 0:
@@ -499,19 +525,31 @@ def _emit_ffn_projection_chunk(
             lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n")
             # HBM offset = chunk_hbm_base_offset + weight_row*blen
             lines.append(
-                _addi_large_int(w_hbm_offset_register, 0, chunk_hbm_base_offset + weight_row * blen, w_temp_register)
+                _addi_large_int(
+                    w_hbm_offset_register,
+                    0,
+                    chunk_hbm_base_offset + weight_row * blen,
+                    w_temp_register,
+                )
                 if chunk_hbm_base_offset + weight_row * blen >= (1 << 18)
                 else f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {chunk_hbm_base_offset + weight_row * blen} \n"
             )
-            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{result_base_register}, 0 \n")
+            lines.append(
+                f"S_ADDI_INT gp{intermediate_register}, gp{result_base_register}, 0 \n"
+            )
             for _ in range(k_tile_count):
                 lines.append(
                     f"H_PREFETCH_M gp{w_actual_register}, gp{w_hbm_offset_register}, a{weight_hbm_offset_reg}, 1, 0 \n"
                 )
-                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n")
+                lines.append(
+                    f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen} \n"
+                )
                 lines.append(
                     _addi_large_int(
-                        w_hbm_offset_register, w_hbm_offset_register, mlen * weight_stride, w_temp_register
+                        w_hbm_offset_register,
+                        w_hbm_offset_register,
+                        mlen * weight_stride,
+                        w_temp_register,
                     )
                 )
             lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n")
@@ -526,7 +564,11 @@ def _emit_ffn_projection_chunk(
         for act_col in range(num_act_cols):
             # Set activation pointer for this act_col + chunk.
             if activation_base_address is not None:
-                addr = activation_base_address + act_col * mlen * blen + chunk_act_base_offset
+                addr = (
+                    activation_base_address
+                    + act_col * mlen * blen
+                    + chunk_act_base_offset
+                )
                 lines.append(
                     _addi_large_int(a_actual_register, 0, addr, w_temp_register)
                     if addr >= (1 << 18)
@@ -537,7 +579,12 @@ def _emit_ffn_projection_chunk(
                 # a_actual = activation_base_register + act_col*mlen*blen + chunk_act_base_offset
                 offset = act_col * mlen * blen + chunk_act_base_offset
                 lines.append(
-                    _addi_large_int(a_actual_register, activation_base_register, offset, w_temp_register)
+                    _addi_large_int(
+                        a_actual_register,
+                        activation_base_register,
+                        offset,
+                        w_temp_register,
+                    )
                     if offset >= (1 << 18)
                     else f"S_ADDI_INT gp{a_actual_register}, gp{activation_base_register}, {offset} \n"
                 )
@@ -545,14 +592,20 @@ def _emit_ffn_projection_chunk(
             lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0 \n")
             for _ in range(k_tile_count):
                 lines.append(f"M_MM 0, gp{w_temp_register}, gp{a_actual_register} \n")
-                lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} \n")
+                lines.append(
+                    f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} \n"
+                )
                 lines.append(
                     f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len} \n"
                 )
             lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 \n")
-            lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n")
+            lines.append(
+                f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} \n"
+            )
 
-        if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_size // blen - 1:
+        if (weight_row + 1) % (
+            mlen // blen
+        ) == 0 and weight_row != out_size // blen - 1:
             lines.append(
                 f"S_ADDI_INT gp{result_base_register}, gp{result_base_register}, {mlen * batch * seq_len} \n"
             )
@@ -583,7 +636,9 @@ def ffn_up_silu_asm(
     intermediate_register = alive_registers[4]
     w_hbm_offset_register = alive_registers[5]
 
-    assert len(alive_registers) >= 10, "Loop version requires 10 registers (9 minimum + 1 temp)"
+    assert (
+        len(alive_registers) >= 10
+    ), "Loop version requires 10 registers (9 minimum + 1 temp)"
     loop_outer_reg = alive_registers[6]
     loop_inner_reg = alive_registers[7]
     loop_inner2_reg = alive_registers[8]
@@ -592,14 +647,18 @@ def ffn_up_silu_asm(
     generated_code = "; FFN Up Projection + SILU Generation\n"
 
     # Setup: scale/stride registers
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += _load_large_int(w_actual_register, intermediate_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
 
     # Set base address for up result
-    up_result_base, _, _ = _ffn_workspace_layout(batch, seq_len, intermediate_size, workspace_base_address)
+    up_result_base, _, _ = _ffn_workspace_layout(
+        batch, seq_len, intermediate_size, workspace_base_address
+    )
     generated_code += _load_large_int(up_result_register, up_result_base)
 
     # Upsize linear (loop)
@@ -618,19 +677,26 @@ def ffn_up_silu_asm(
 
     # Prefetch weights for this MLEN block
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    )
     for weight_col in range(num_weight_tiles):
+        generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         generated_code += (
-            f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         generated_code += _addi_large_int(
-            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+            a_actual_register,
+            a_actual_register,
+            mlen * intermediate_size,
+            w_temp_register,
         )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    )
 
     # Middle loop: tiles within MLEN block
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
@@ -649,7 +715,9 @@ def ffn_up_silu_asm(
     # Innermost accumulation (unrolled)
     for inner_loop_index in range(num_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_loop_index < num_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
@@ -659,27 +727,37 @@ def ffn_up_silu_asm(
 
     # Restore a_actual_register and advance to next activation column
     act_col_advance = mlen * blen
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{temp_save_reg}, {act_col_advance}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{temp_save_reg}, {act_col_advance}\n"
+    )
 
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
     # After inner loop: advance weight offset within MLEN block
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
     # Reset intermediate back for next tile row
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    )
     # Add offset for current tile
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
     # After middle loop: advance w_hbm_offset_register for next MLEN block
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    )
     # Advance up_result_register for next MLEN block
     generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {mlen * batch * seq_len}\n"
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
-    generated_code += "; Result (up projection only) stored at up_result_register location\n"
+    generated_code += (
+        "; Result (up projection only) stored at up_result_register location\n"
+    )
 
     return generated_code
 
@@ -720,7 +798,9 @@ def ffn_intermediate_asm(
     )
 
     # Setup: scale/stride registers
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += _load_large_int(w_actual_register, intermediate_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
@@ -745,19 +825,26 @@ def ffn_intermediate_asm(
 
     # Prefetch weights for this MLEN block
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    )
     for weight_col in range(num_weight_tiles):
+        generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         generated_code += (
-            f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         generated_code += _addi_large_int(
-            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+            a_actual_register,
+            a_actual_register,
+            mlen * intermediate_size,
+            w_temp_register,
         )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    )
 
     # Middle loop: tiles within MLEN block
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
@@ -775,7 +862,9 @@ def ffn_intermediate_asm(
     # Innermost accumulation (unrolled)
     for inner_loop_index in range(num_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_loop_index < num_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
@@ -788,16 +877,22 @@ def ffn_intermediate_asm(
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
     # After inner loop: advance weight offset within MLEN block
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
     # Reset intermediate back for next tile row
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    )
     # Add offset for current tile
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
     # After middle loop: advance w_hbm_offset_register for next MLEN block
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    )
     # Advance up_result_register for next MLEN block
     generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {mlen * batch * seq_len}\n"
 
@@ -816,19 +911,26 @@ def ffn_intermediate_asm(
 
     # Prefetch weights for this MLEN block
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    )
     for weight_col in range(num_weight_tiles):
+        generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
         generated_code += (
-            f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         generated_code += _addi_large_int(
-            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+            a_actual_register,
+            a_actual_register,
+            mlen * intermediate_size,
+            w_temp_register,
         )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    )
 
     # Middle loop: tiles within MLEN block
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
@@ -846,28 +948,38 @@ def ffn_intermediate_asm(
     # Innermost accumulation (unrolled)
     for inner_loop_index in range(num_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_loop_index < num_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
     generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen}\n"
     # Restore a_actual_register and advance to next activation column
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, {act_col_advance}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, {act_col_advance}\n"
+    )
 
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
     # After inner loop: advance weight offset within MLEN block
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
     # Reset intermediate back for next tile row
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    )
     # Add offset for current tile
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
     # After middle loop: advance w_hbm_offset_register for next MLEN block
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    )
     # Advance gate_result_register for next MLEN block
     generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {mlen * batch * seq_len}\n"
 
@@ -888,14 +1000,26 @@ def ffn_intermediate_asm(
     generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_silu_iters}\n"
 
     # SILU computation: sigmoid(x) * x * gate
-    generated_code += f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1\n"
-    generated_code += f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
-    generated_code += f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0\n"
-    generated_code += f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+    generated_code += (
+        f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1\n"
+    )
+    generated_code += (
+        f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+    )
+    generated_code += (
+        f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0\n"
+    )
+    generated_code += (
+        f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+    )
     generated_code += f"V_MUL_VV gp{intermediate_register}, gp{intermediate_register}, gp{up_result_register}, 0\n"
     generated_code += f"V_MUL_VV gp{up_result_register}, gp{intermediate_register}, gp{gate_result_register}, 0\n"
-    generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {vlen}\n"
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {vlen}\n"
+    )
+    generated_code += (
+        f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen}\n"
+    )
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
@@ -943,7 +1067,9 @@ def _ffn_asm_with_loops(
     )
 
     # Setup: scale/stride registers
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += _load_large_int(w_actual_register, intermediate_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
@@ -968,19 +1094,26 @@ def _ffn_asm_with_loops(
 
     # Prefetch weights for this MLEN block
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    )
     for weight_col in range(num_weight_tiles):
+        generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         generated_code += (
-            f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         generated_code += _addi_large_int(
-            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+            a_actual_register,
+            a_actual_register,
+            mlen * intermediate_size,
+            w_temp_register,
         )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    )
 
     # Middle loop: tiles within MLEN block
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
@@ -998,7 +1131,9 @@ def _ffn_asm_with_loops(
     # Innermost accumulation (unrolled)
     for inner_loop_index in range(num_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_loop_index < num_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
@@ -1011,16 +1146,22 @@ def _ffn_asm_with_loops(
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
     # After inner loop: advance weight offset within MLEN block
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
     # Reset intermediate back for next tile row
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    )
     # Add offset for current tile
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
     # After middle loop: advance w_hbm_offset_register for next MLEN block
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    )
     # Advance up_result_register for next MLEN block
     generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {mlen * batch * seq_len}\n"
 
@@ -1039,19 +1180,26 @@ def _ffn_asm_with_loops(
 
     # Prefetch weights for this MLEN block
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    )
     for weight_col in range(num_weight_tiles):
+        generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
         generated_code += (
-            f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         generated_code += _addi_large_int(
-            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+            a_actual_register,
+            a_actual_register,
+            mlen * intermediate_size,
+            w_temp_register,
         )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    )
 
     # Middle loop: tiles within MLEN block
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
@@ -1069,28 +1217,38 @@ def _ffn_asm_with_loops(
     # Innermost accumulation (unrolled)
     for inner_loop_index in range(num_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_loop_index < num_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
     generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0\n"
     generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen}\n"
     # Restore a_actual_register and advance to next activation column
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, {act_col_advance}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, {act_col_advance}\n"
+    )
 
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
     # After inner loop: advance weight offset within MLEN block
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
     # Reset intermediate back for next tile row
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    )
     # Add offset for current tile
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
     # After middle loop: advance w_hbm_offset_register for next MLEN block
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    )
     # Advance gate_result_register for next MLEN block
     generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {mlen * batch * seq_len}\n"
 
@@ -1111,14 +1269,26 @@ def _ffn_asm_with_loops(
     generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_silu_iters}\n"
 
     # SILU computation: sigmoid(x) * x * gate
-    generated_code += f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1\n"
-    generated_code += f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
-    generated_code += f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0\n"
-    generated_code += f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+    generated_code += (
+        f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1\n"
+    )
+    generated_code += (
+        f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+    )
+    generated_code += (
+        f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0\n"
+    )
+    generated_code += (
+        f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+    )
     generated_code += f"V_MUL_VV gp{intermediate_register}, gp{intermediate_register}, gp{up_result_register}, 0\n"
     generated_code += f"V_MUL_VV gp{up_result_register}, gp{intermediate_register}, gp{gate_result_register}, 0\n"
-    generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {vlen}\n"
-    generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {vlen}\n"
+    )
+    generated_code += (
+        f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen}\n"
+    )
 
     generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"
 
@@ -1126,7 +1296,9 @@ def _ffn_asm_with_loops(
     generated_code += "; FFN Downsize Linear Generation (Loop)\n"
 
     # Setup scale and stride for downsize
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += _load_large_int(w_actual_register, hidden_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
@@ -1148,17 +1320,21 @@ def _ffn_asm_with_loops(
 
     # Prefetch weights for this MLEN block
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    )
     for weight_col in range(num_down_weight_tiles):
+        generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
         generated_code += (
-            f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * hidden_size}\n"
+        generated_code += _load_large_int(a_actual_register, mlen * hidden_size)
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    )
 
     # Middle loop: tiles within MLEN block
     generated_code += f"; Middle loop: {tiles_per_mlen} tiles per MLEN block\n"
@@ -1179,7 +1355,9 @@ def _ffn_asm_with_loops(
     # Innermost accumulation (unrolled)
     for inner_loop_index in range(num_down_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_loop_index < num_down_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
@@ -1191,16 +1369,22 @@ def _ffn_asm_with_loops(
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
     # After inner loop: advance weight offset within MLEN block
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
     # Reset intermediate back for next tile row
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    )
     # Add offset for current tile
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
     # After middle loop: advance w_hbm_offset_register for next MLEN block
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    )
     # Advance act_result_register for next MLEN block
     generated_code += f"S_ADDI_INT gp{act_result_register}, gp{act_result_register}, {mlen * batch * seq_len}\n"
 
@@ -1250,7 +1434,9 @@ def _ffn_asm_fused_up_gate(
     )
 
     # Setup: scale/stride registers
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += _load_large_int(w_actual_register, intermediate_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
@@ -1268,7 +1454,9 @@ def _ffn_asm_fused_up_gate(
     num_weight_tiles = hidden_size // mlen
     num_act_cols = (batch * seq_len) // blen
     act_col_advance = mlen * blen
-    gate_mram_offset = num_weight_tiles * mlen * mlen  # Gate weights start after up weights in MRAM
+    gate_mram_offset = (
+        num_weight_tiles * mlen * mlen
+    )  # Gate weights start after up weights in MRAM
 
     # Calculate how to spread GATE prefetches across UP computation
     # UP projection has tiles_per_mlen * num_act_cols iterations of inner work
@@ -1282,16 +1470,21 @@ def _ffn_asm_fused_up_gate(
 
     # Prefetch UP weights only (GATE will be prefetched during UP compute)
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+    )
 
     # Prefetch up weights (to MRAM at offset 0)
     for weight_col in range(num_weight_tiles):
+        generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
         generated_code += (
-            f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{up_weight_hbm_offset_reg}, 1, 0\n"
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         generated_code += _addi_large_int(
-            a_actual_register, a_actual_register, mlen * intermediate_size, w_temp_register
+            a_actual_register,
+            a_actual_register,
+            mlen * intermediate_size,
+            w_temp_register,
         )
 
     # Setup for UP compute and GATE prefetch overlap
@@ -1299,7 +1492,9 @@ def _ffn_asm_fused_up_gate(
 
     # Reset for UP compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+    )
 
     # Up projection with interleaved gate prefetch
     generated_code += f"; Up projection for MLEN block (with GATE prefetch every {gate_prefetch_interval} iters)\n"
@@ -1318,37 +1513,44 @@ def _ffn_asm_fused_up_gate(
             iter_num = tile_idx * num_act_cols + act_col
 
             # Check if we should insert a GATE prefetch
-            if iter_num % gate_prefetch_interval == 0 and gate_prefetch_count < num_weight_tiles:
+            if (
+                iter_num % gate_prefetch_interval == 0
+                and gate_prefetch_count < num_weight_tiles
+            ):
                 generated_code += f"; Prefetch GATE weight tile {gate_prefetch_count} during UP compute\n"
                 # Save current a_actual_register (activation pointer) to w_temp_register
-                generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{a_actual_register}, 0\n"
+                generated_code += (
+                    f"S_ADDI_INT gp{w_temp_register}, gp{a_actual_register}, 0\n"
+                )
                 # Compute GATE HBM offset directly: base_offset + prefetch_count * stride
                 gate_hbm_offset = gate_prefetch_count * mlen * intermediate_size
                 # Set MRAM destination
                 generated_code += _load_large_int(a_actual_register, gate_mram_ptr)
                 # Set HBM source: w_hbm_offset_register + gate_hbm_offset
                 generated_code += f"S_ADDI_INT gp{a_save_register}, gp{w_hbm_offset_register}, {gate_hbm_offset}\n"
-                generated_code += (
-                    f"H_PREFETCH_M gp{a_actual_register}, gp{a_save_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
-                )
+                generated_code += f"H_PREFETCH_M gp{a_actual_register}, gp{a_save_register}, a{gate_weight_hbm_offset_reg}, 1, 0\n"
                 gate_mram_ptr += mlen * mlen
                 gate_prefetch_count += 1
                 # Restore activation pointer
-                generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_temp_register}, 0\n"
+                generated_code += (
+                    f"S_ADDI_INT gp{a_actual_register}, gp{w_temp_register}, 0\n"
+                )
 
             # Save activation column base before weight tile loop modifies a_actual_register
-            generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{a_actual_register}, 0\n"
+            generated_code += (
+                f"S_ADDI_INT gp{w_temp_register}, gp{a_actual_register}, 0\n"
+            )
 
             # UP weight accumulation
             generated_code += f"S_ADDI_INT gp{a_save_register}, gp{w_actual_register}, 0\n"  # save weight offset
 
             for inner_idx in range(num_weight_tiles):
-                generated_code += f"M_MM 0, gp{a_save_register}, gp{a_actual_register}\n"
+                generated_code += (
+                    f"M_MM 0, gp{a_save_register}, gp{a_actual_register}\n"
+                )
                 generated_code += f"S_ADDI_INT gp{a_save_register}, gp{a_save_register}, {mlen * mlen}\n"
                 if inner_idx < num_weight_tiles - 1:
-                    generated_code += (
-                        f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
-                    )
+                    generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
             generated_code += f"M_MM_WO gp{intermediate_register}, gp0, 0\n"
             generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen}\n"
@@ -1358,15 +1560,25 @@ def _ffn_asm_fused_up_gate(
                 generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_temp_register}, {act_col_advance}\n"
 
         # After all act_cols for this tile, advance weight offset
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
-        generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+        )
+        generated_code += (
+            f"S_ADDI_INT gp{intermediate_register}, gp{up_result_register}, 0\n"
+        )
         generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     # Gate projection (weights already prefetched)
-    generated_code += "; Gate projection for MLEN block (weights pre-fetched during UP)\n"
-    generated_code += f"S_ADDI_INT gp{a_save_register}, gp0, 0\n"  # tile offset tracker for output
+    generated_code += (
+        "; Gate projection for MLEN block (weights pre-fetched during UP)\n"
+    )
+    generated_code += (
+        f"S_ADDI_INT gp{a_save_register}, gp0, 0\n"  # tile offset tracker for output
+    )
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_gate_base_register}, 0\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    )
 
     generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen}\n"
 
@@ -1379,7 +1591,9 @@ def _ffn_asm_fused_up_gate(
 
     for inner_idx in range(num_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_idx < num_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
@@ -1390,15 +1604,21 @@ def _ffn_asm_fused_up_gate(
 
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
     generated_code += f"S_ADDI_INT gp{a_save_register}, gp{a_save_register}, {blen}\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{gate_result_register}, 0\n"
+    )
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{a_save_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
     # Advance for next MLEN block
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+    )
     generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {mlen * batch * seq_len}\n"
     generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {mlen * batch * seq_len}\n"
 
@@ -1413,7 +1633,9 @@ def _ffn_asm_fused_up_gate(
     generated_code += f"S_LD_FP f1, gp0, {const_one_fp_address}\n"
 
     # Set up DOWN weight prefetch parameters
-    generated_code += _load_large_int(w_actual_register, hidden_size * intermediate_size)
+    generated_code += _load_large_int(
+        w_actual_register, hidden_size * intermediate_size
+    )
     generated_code += f"C_SET_SCALE_REG gp{w_actual_register}\n"
     generated_code += _load_large_int(w_actual_register, hidden_size)
     generated_code += f"C_SET_STRIDE_REG gp{w_actual_register}\n"
@@ -1433,32 +1655,46 @@ def _ffn_asm_fused_up_gate(
     prefetch_interval = max(1, num_silu_iters // num_down_weight_tiles)
 
     generated_code += f"; SILU loop: {num_silu_iters} iterations (prefetch every {prefetch_interval} iters)\n"
-    generated_code += f"; Prefetching {num_down_weight_tiles} DOWN weight tiles during SILU\n"
+    generated_code += (
+        f"; Prefetching {num_down_weight_tiles} DOWN weight tiles during SILU\n"
+    )
 
     # Unroll SILU loop to interleave prefetch operations
     for silu_iter in range(num_silu_iters):
         # SILU computation
-        generated_code += f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1\n"
-        generated_code += f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
-        generated_code += f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0\n"
-        generated_code += f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+        generated_code += (
+            f"V_SUB_VF gp{intermediate_register}, gp{up_result_register}, f0, 0, 1\n"
+        )
+        generated_code += (
+            f"V_EXP_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+        )
+        generated_code += (
+            f"V_ADD_VF gp{intermediate_register}, gp{intermediate_register}, f1, 0\n"
+        )
+        generated_code += (
+            f"V_RECI_V  gp{intermediate_register}, gp{intermediate_register}, 0\n"
+        )
         generated_code += f"V_MUL_VV gp{intermediate_register}, gp{intermediate_register}, gp{up_result_register}, 0\n"
         generated_code += f"V_MUL_VV gp{up_result_register}, gp{intermediate_register}, gp{gate_result_register}, 0\n"
-        generated_code += f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {vlen}\n"
-        generated_code += f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{gate_result_register}, gp{gate_result_register}, {vlen}\n"
+        )
+        generated_code += (
+            f"S_ADDI_INT gp{up_result_register}, gp{up_result_register}, {vlen}\n"
+        )
 
         # Insert prefetch at appropriate intervals
         prefetch_idx = silu_iter // prefetch_interval
         if silu_iter % prefetch_interval == 0 and prefetch_idx < num_down_weight_tiles:
             generated_code += f"; Prefetch DOWN weight tile {prefetch_idx}\n"
-            generated_code += (
-                f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
-            )
+            generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-            generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * hidden_size}\n"
+            generated_code += _load_large_int(a_actual_register, mlen * hidden_size)
 
     # Downsize linear (first block already prefetched)
-    generated_code += "; FFN Downsize Linear Generation (first block pre-fetched during SILU)\n"
+    generated_code += (
+        "; FFN Downsize Linear Generation (first block pre-fetched during SILU)\n"
+    )
 
     act_result_register = gate_result_register
     generated_code += _load_large_int(act_result_register, activation_base_address)
@@ -1469,9 +1705,13 @@ def _ffn_asm_fused_up_gate(
     # First block: weights already prefetched, just do computation
     generated_code += "; First DOWN block (weights pre-fetched during SILU)\n"
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-    generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {mlen}\n"  # Next block HBM offset
+    generated_code += (
+        f"S_ADDI_INT gp{w_hbm_offset_register}, gp0, {mlen}\n"  # Next block HBM offset
+    )
 
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    )
     tiles_per_mlen_down = mlen // blen
 
     # First block computation
@@ -1488,7 +1728,9 @@ def _ffn_asm_fused_up_gate(
 
     for inner_idx in range(num_down_weight_tiles):
         generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-        generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+        )
         if inner_idx < num_down_weight_tiles - 1:
             generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
@@ -1498,8 +1740,12 @@ def _ffn_asm_fused_up_gate(
 
     generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
-    generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
-    generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    generated_code += (
+        f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+    )
+    generated_code += (
+        f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+    )
     generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
     generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
@@ -1510,34 +1756,44 @@ def _ffn_asm_fused_up_gate(
     # Remaining blocks (if any) - standard prefetch then compute
     if num_down_mlen_blocks > 1:
         generated_code += f"; Remaining {num_down_mlen_blocks - 1} DOWN blocks\n"
-        generated_code += f"C_LOOP_START gp{loop_outer_reg}, {num_down_mlen_blocks - 1}\n"
+        generated_code += (
+            f"C_LOOP_START gp{loop_outer_reg}, {num_down_mlen_blocks - 1}\n"
+        )
 
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+        generated_code += (
+            f"S_ADDI_INT gp{a_actual_register}, gp{w_hbm_offset_register}, 0\n"
+        )
         for weight_col in range(num_down_weight_tiles):
-            generated_code += (
-                f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
-            )
+            generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-            generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * hidden_size}\n"
+            generated_code += _load_large_int(a_actual_register, mlen * hidden_size)
 
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
-        generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+        generated_code += (
+            f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+        )
 
         generated_code += f"; Middle loop: {tiles_per_mlen_down} tiles per MLEN block\n"
         generated_code += f"C_LOOP_START gp{loop_inner_reg}, {tiles_per_mlen_down}\n"
 
         generated_code += _load_large_int(up_result_register, up_result_base)
-        generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
+        generated_code += (
+            f"S_ADDI_INT gp{a_actual_register}, gp{up_result_register}, 0\n"
+        )
 
         generated_code += f"C_LOOP_START gp{loop_inner2_reg}, {num_down_act_cols}\n"
 
         generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_actual_register}, 0\n"
-        generated_code += f"S_ADDI_INT gp{up_result_register}, gp{a_actual_register}, 0\n"
+        generated_code += (
+            f"S_ADDI_INT gp{up_result_register}, gp{a_actual_register}, 0\n"
+        )
 
         for inner_idx in range(num_down_weight_tiles):
             generated_code += f"M_MM 0, gp{w_temp_register}, gp{a_actual_register}\n"
-            generated_code += f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+            generated_code += (
+                f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen}\n"
+            )
             if inner_idx < num_down_weight_tiles - 1:
                 generated_code += f"S_ADDI_INT gp{a_actual_register}, gp{a_actual_register}, {mlen * batch * seq_len}\n"
 
@@ -1547,13 +1803,19 @@ def _ffn_asm_fused_up_gate(
 
         generated_code += f"C_LOOP_END gp{loop_inner2_reg}\n"
 
-        generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
-        generated_code += f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {blen}\n"
+        )
+        generated_code += (
+            f"S_ADDI_INT gp{intermediate_register}, gp{act_result_register}, 0\n"
+        )
         generated_code += f"S_ADD_INT gp{intermediate_register}, gp{intermediate_register}, gp{w_actual_register}\n"
 
         generated_code += f"C_LOOP_END gp{loop_inner_reg}\n"
 
-        generated_code += f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+        generated_code += (
+            f"S_ADDI_INT gp{w_hbm_offset_register}, gp{w_hbm_offset_register}, {mlen}\n"
+        )
         generated_code += f"S_ADDI_INT gp{act_result_register}, gp{act_result_register}, {mlen * batch * seq_len}\n"
 
         generated_code += f"C_LOOP_END gp{loop_outer_reg}\n"

--- a/asm_templates/flashattn/online_softmax.py
+++ b/asm_templates/flashattn/online_softmax.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Online softmax assembly code generation for Flash Attention."""
 
 IMM2_BOUND = 2**18 - 1
@@ -19,6 +21,7 @@ def online_softmax_code(
     m_start_address: int,
     qk_scale_address: int = 5,
     causal_mask: bool = True,
+    rows: int | None = None,
 ) -> str:
     """
     Args:
@@ -63,8 +66,9 @@ def online_softmax_code(
         # Load qk_scale from FP SRAM (preloaded at FP SRAM address 5)
         generated_code += f"S_LD_FP f{qk_scale_register}, gp0, {qk_scale_address} \n"
 
-        # Hardware loop over mlen rows
-        generated_code += f"C_LOOP_START gp{loop_register}, {mlen} \n"
+        # Hardware loop over the valid query rows in this tile.
+        loop_rows = mlen if rows is None else rows
+        generated_code += f"C_LOOP_START gp{loop_register}, {loop_rows} \n"
 
         # Scale S row by qk_scale: S = S * qk_scale
         generated_code += f"V_MUL_VF gp{s_address_register}, gp{s_address_register}, f{qk_scale_register}, 0 \n"

--- a/asm_templates/flashattn/online_softmax.py
+++ b/asm_templates/flashattn/online_softmax.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """Online softmax assembly code generation for Flash Attention."""
 
+from .._imm import load_large_int_str as _load_large_int
+
 IMM2_BOUND = 2**18 - 1
 
 """
@@ -22,6 +24,8 @@ def online_softmax_code(
     qk_scale_address: int = 5,
     causal_mask: bool = True,
     rows: int | None = None,
+    valid_cols: int | None = None,
+    mask_unit: int | None = None,
 ) -> str:
     """
     Args:
@@ -57,21 +61,29 @@ def online_softmax_code(
     if stage == "prefill":
         # Presettings
         # Load the starting address of S, which is the QKT result of the current head, in shape of (MLEN, MLEN)
-        assert m_start_address < IMM2_BOUND, f"m_start_address must be less than {IMM2_BOUND}"
-        generated_code += f"S_ADDI_INT gp{s_address_register}, gp0, {s_address} \n"
-        generated_code += f"S_ADDI_INT gp{m_last_address_register}, gp0, {m_start_address} \n"
+        generated_code += _load_large_int(s_address_register, s_address)
+        generated_code += _load_large_int(m_last_address_register, m_start_address)
         generated_code += f"S_ADDI_INT gp{m_res_address_register}, gp{m_last_address_register}, {mlen} \n"
         generated_code += f"S_ADDI_INT gp{l_old_address_register}, gp{m_res_address_register}, {mlen} \n"
 
         # Load qk_scale from FP SRAM (preloaded at FP SRAM address 5)
         generated_code += f"S_LD_FP f{qk_scale_register}, gp0, {qk_scale_address} \n"
 
+        mask_en = 0
+        if valid_cols is not None and valid_cols < mlen:
+            lane_width = mask_unit or mlen
+            valid_lanes = max(1, (valid_cols + lane_width - 1) // lane_width)
+            mask_bits = (1 << valid_lanes) - 1
+            generated_code += f"S_ADDI_INT gp{loop_register}, gp0, {mask_bits} \n"
+            generated_code += f"C_SET_V_MASK_REG gp{loop_register} \n"
+            mask_en = 1
+
         # Hardware loop over the valid query rows in this tile.
         loop_rows = mlen if rows is None else rows
         generated_code += f"C_LOOP_START gp{loop_register}, {loop_rows} \n"
 
         # Scale S row by qk_scale: S = S * qk_scale
-        generated_code += f"V_MUL_VF gp{s_address_register}, gp{s_address_register}, f{qk_scale_register}, 0 \n"
+        generated_code += f"V_MUL_VF gp{s_address_register}, gp{s_address_register}, f{qk_scale_register}, {mask_en} \n"
 
         # load m_last (using indirect addressing with offset 0)
         # Note: m_last is already in scaled space from previous tiles (or -inf for first tile)
@@ -81,7 +93,7 @@ def online_softmax_code(
 
         # m_curr = max(S_scaled[row], m_last) and store at m_curr
         m_curr_register = m_last_register
-        generated_code += f"V_RED_MAX f{m_curr_register}, gp{s_address_register}, 0 \n"
+        generated_code += f"V_RED_MAX f{m_curr_register}, gp{s_address_register}, {mask_en} \n"
 
         # m_res = m_last - m_curr
         m_res_register = tmp_fp_register
@@ -97,17 +109,17 @@ def online_softmax_code(
         generated_code += f"S_ST_FP f{m_curr_register}, gp{m_last_address_register}, 0 \n"
 
         # # S' = S - m_curr
-        generated_code += f"V_SUB_VF gp{s_address_register}, gp{s_address_register}, f{m_curr_register}, 0, 0 \n"
+        generated_code += f"V_SUB_VF gp{s_address_register}, gp{s_address_register}, f{m_curr_register}, {mask_en}, 0 \n"
 
         # P = exp(S')
-        generated_code += f"V_EXP_V gp{s_address_register}, gp{s_address_register}, 0 \n"
+        generated_code += f"V_EXP_V gp{s_address_register}, gp{s_address_register}, {mask_en} \n"
 
         # load l_old (using indirect addressing with offset 0)
         generated_code += f"S_LD_FP f{l_old_register}, gp{l_old_address_register}, 0 \n"
 
         # P = sum(P)
         generated_code += f"S_ADD_FP  f{sum_p_register}, f0, f0 \n"
-        generated_code += f"V_RED_SUM f{sum_p_register}, gp{s_address_register} \n"
+        generated_code += f"V_RED_SUM f{sum_p_register}, gp{s_address_register}, {mask_en} \n"
 
         # l_s = l_old * exp(m_res)
         generated_code += f"S_MUL_FP f{l_old_register}, f{l_old_register}, f{tmp_fp_register} \n"
@@ -130,9 +142,8 @@ def online_softmax_code(
     else:
         # Presettings
         # Load the starting address of S, which is the QKT result of the current head, in shape of (MLEN, MLEN)
-        assert m_start_address < IMM2_BOUND, f"m_start_address must be less than {IMM2_BOUND}"
-        generated_code += f"S_ADDI_INT gp{s_address_register}, gp0, {s_address} \n"
-        generated_code += f"S_ADDI_INT gp{m_last_address_register}, gp0, {m_start_address} \n"
+        generated_code += _load_large_int(s_address_register, s_address)
+        generated_code += _load_large_int(m_last_address_register, m_start_address)
         generated_code += f"S_ADDI_INT gp{m_res_address_register}, gp{m_last_address_register}, {1} \n"
         generated_code += f"S_ADDI_INT gp{l_old_address_register}, gp{m_res_address_register}, {1} \n"
 

--- a/asm_templates/flashattn/output.py
+++ b/asm_templates/flashattn/output.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """Output computation assembly code generation for Flash Attention."""
 
+from .._imm import load_large_int_str as _load_large_int
+
 IMM2_BOUND = 2**18 - 1
 
 
@@ -42,13 +44,13 @@ def computing_o_code(
     # break diag(MLEN) * (MLEN * Head_dim) into diag(MLEN) * [(MLEN * MLEN) ... (MLEN * MLEN)]
 
     # load o_old base address
-    generated_code += f"S_ADDI_INT gp{o_old_vector_address_register}, gp0, {o_old_base_address} \n"
+    generated_code += _load_large_int(o_old_vector_address_register, o_old_base_address)
 
     # reload m_res base address
-    generated_code += f"S_ADDI_INT gp{m_res_vector_address_register}, gp0, {m_res_base_address} \n"
+    generated_code += _load_large_int(m_res_vector_address_register, m_res_base_address)
 
     # load pv base address
-    generated_code += f"S_ADDI_INT gp{pv_vector_address_register}, gp0, {pv_base_address} \n"
+    generated_code += _load_large_int(pv_vector_address_register, pv_base_address)
 
     if stage == "prefill":
         # loop over different row of m_res using hardware loop
@@ -112,9 +114,9 @@ def computing_row_wise_scaling_code(
 
     generated_code = "; Row-wise Scaling Code (1/l normalization) \n"
     # load l_old base address
-    generated_code += f"S_ADDI_INT gp{l_old_vector_address_register}, gp0, {l_old_base_address} \n"
+    generated_code += _load_large_int(l_old_vector_address_register, l_old_base_address)
     # load o_old base address
-    generated_code += f"S_ADDI_INT gp{o_old_vector_address_register}, gp0, {o_old_base_address} \n"
+    generated_code += _load_large_int(o_old_vector_address_register, o_old_base_address)
 
     if stage == "prefill":
         # loop over different row of Br using hardware loop

--- a/asm_templates/flashattn/output.py
+++ b/asm_templates/flashattn/output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Output computation assembly code generation for Flash Attention."""
 
 IMM2_BOUND = 2**18 - 1
@@ -13,6 +15,7 @@ def computing_o_code(
     o_old_base_address: int,
     head_dim: int,
     q_head_num: int,
+    rows: int | None = None,
 ) -> str:
     """
     Args:
@@ -39,20 +42,18 @@ def computing_o_code(
     # break diag(MLEN) * (MLEN * Head_dim) into diag(MLEN) * [(MLEN * MLEN) ... (MLEN * MLEN)]
 
     # load o_old base address
-    assert o_old_base_address < IMM2_BOUND, f"o_old_base_address must be less than {IMM2_BOUND}"
     generated_code += f"S_ADDI_INT gp{o_old_vector_address_register}, gp0, {o_old_base_address} \n"
 
     # reload m_res base address
-    assert m_res_base_address < IMM2_BOUND, f"m_res_base_address must be less than {IMM2_BOUND}"
     generated_code += f"S_ADDI_INT gp{m_res_vector_address_register}, gp0, {m_res_base_address} \n"
 
     # load pv base address
-    assert pv_base_address < IMM2_BOUND, f"pv_base_address must be less than {IMM2_BOUND}"
     generated_code += f"S_ADDI_INT gp{pv_vector_address_register}, gp0, {pv_base_address} \n"
 
     if stage == "prefill":
         # loop over different row of m_res using hardware loop
-        generated_code += f"C_LOOP_START gp{loop_register}, {mlen} \n"
+        loop_rows = mlen if rows is None else rows
+        generated_code += f"C_LOOP_START gp{loop_register}, {loop_rows} \n"
         # load m_res (using indirect addressing)
         generated_code += f"S_LD_FP f{m_res_fp_register}, gp{m_res_vector_address_register}, 0 \n"
         # boardcast m_res to multiply with a row of a block of O_old and write to o_old
@@ -90,6 +91,7 @@ def computing_row_wise_scaling_code(
     l_old_base_address: int,
     o_row_stride: int,
     use_mask: bool = True,
+    rows: int | None = None,
 ) -> str:
     """
     line 12 in flash attention algorithm
@@ -116,7 +118,8 @@ def computing_row_wise_scaling_code(
 
     if stage == "prefill":
         # loop over different row of Br using hardware loop
-        generated_code += f"C_LOOP_START gp{loop_register}, {mlen} \n"
+        loop_rows = mlen if rows is None else rows
+        generated_code += f"C_LOOP_START gp{loop_register}, {loop_rows} \n"
         # load l_old (using indirect addressing through l_old_vector_address_register)
         generated_code += f"S_LD_FP f{l_old_fp_register}, gp{l_old_vector_address_register}, 0 \n"
         # compute the inverse of l_old

--- a/asm_templates/flashattn/overall.py
+++ b/asm_templates/flashattn/overall.py
@@ -247,9 +247,11 @@ def flash_attn_asm(
                     # ``scheduler["memory_layout"]["fp_sram"]["attn_scale"]``
                     # so this template no longer hardcodes the QK-scale slot.
                     #
-                    # For batched path: S tiles are at s_base + head * br * bc.
+                    # For batched path M_BMM_WO writes each broadcast result
+                    # as a full physical MLEN x MLEN tile, even when the
+                    # logical br/bc for a short sequence is smaller.
                     # For per-head path: S tile is always at s_base (offset 0).
-                    s_softmax_addr = s_base_address + (inner_q_head_index * br * bc if use_batched else 0)
+                    s_softmax_addr = s_base_address + (inner_q_head_index * mlen * mlen if use_batched else 0)
                     generated_code += online_softmax_code(
                         mlen=mlen,
                         stage=stage,

--- a/asm_templates/flashattn/overall.py
+++ b/asm_templates/flashattn/overall.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Main Flash Attention assembly code generation - orchestrates all components."""
 
 from ..reset_reg_asm import reset_fpreg_asm, reset_reg_asm, reset_vmask_asm
@@ -29,6 +31,12 @@ def flash_attn_asm(
     attn_scale_fp_address: int = 5,
     inf_fp_address: int = 0,
     causal_mask: bool = True,
+    broadcast_amount: int | None = None,
+    q_group_stride: int | None = None,
+    o_group_stride: int | None = None,
+    scratch_base_address: int | None = None,
+    output_base_address: int | None = None,
+    packed_group_layout: bool = False,
 ) -> str:
     """
     Args:
@@ -54,16 +62,20 @@ def flash_attn_asm(
     q_seq_iteration_number = (q_len + mlen - 1) // mlen
     k_seq_iteration_number = (kv_len + mlen - 1) // mlen
     q_index_2_kv_index_ratio = hq // hkv
+    broadcast_amount = blen if broadcast_amount is None else broadcast_amount
 
     stage = "decode" if q_len == 1 else "prefill"
     br = min(mlen, q_len)
     bc = min(mlen, kv_len)
 
-    # Batched path (M_BTMM) when ratio == blen — maximum throughput.
-    # Per-head path (M_TMM) for all other ratios — avoids M_BTMM over-read
-    # panic when ratio < blen (the extra blen-ratio "dummy" heads would read
-    # Q past the kv-group allocation).
-    use_batched = q_index_2_kv_index_ratio == blen
+    # Batched path (M_BTMM) when the Q heads for one KV group occupy hardware
+    # lanes inside one MLEN row. Legacy callers used BLEN as the broadcast
+    # amount; packed ATen callers pass the simulator BROADCAST_AMOUNT/HW HLEN
+    # explicitly and may have ratio < broadcast_amount.
+    if packed_group_layout:
+        use_batched = q_index_2_kv_index_ratio <= broadcast_amount
+    else:
+        use_batched = q_index_2_kv_index_ratio == blen
 
     # Memory Layout:
     # -- FP SRAM --
@@ -87,14 +99,25 @@ def flash_attn_asm(
     # Batched path: M_BMM_WO writes blen tiles; allocate blen tiles even though
     # only ratio are consumed by softmax/PV (harmless dead writes).
     # Per-head path: only 1 S tile needed at a time (reused per head).
-    s_tile_count = blen if use_batched else 1
-    s_base_address = q_base_address + q_len * hq * d  # Q size = seq_len * num_q_heads * head_dim
+    s_tile_count = broadcast_amount if use_batched else 1
+    # Q size = seq_len * num_q_heads * head_dim for legacy row-packed layout.
+    # Packed group layout stores each KV group as a separate MLEN-wide column
+    # block, so the caller passes an explicit scratch base.
+    s_base_address = (
+        scratch_base_address
+        if scratch_base_address is not None
+        else q_base_address + q_len * hq * d
+    )
     print(f"S Base Address: {s_base_address}")
     # PV (q_index_2_kv_index_ratio, mlen, mlen)
     pv_base_address = s_base_address + mlen * mlen * s_tile_count
     print(f"PV Base Address: {pv_base_address}")
     # O_Old (q_len, HEAD_DIM * Hq * batch)
-    o_old_base_address = pv_base_address + mlen * mlen * q_index_2_kv_index_ratio
+    o_old_base_address = (
+        output_base_address
+        if output_base_address is not None
+        else pv_base_address + mlen * mlen * q_index_2_kv_index_ratio
+    )
     print(f"O_Old Base Address: {o_old_base_address}")
 
     generated_code = "; Flash Attention Generation \n"
@@ -109,6 +132,13 @@ def flash_attn_asm(
 
     # loop over kv heads
     for kv_head_index in range(hkv):
+        group_q_base_address = q_base_address + kv_head_index * (
+            q_group_stride if q_group_stride is not None else q_index_2_kv_index_ratio * d
+        )
+        group_o_base_address = o_old_base_address + kv_head_index * (
+            o_group_stride if o_group_stride is not None else 0
+        )
+
         # loop over per kv head kv_len // MLEN
         for _ in range(k_seq_iteration_number):
             print(f" Computing {q_index_2_kv_index_ratio} Q heads for KV head {kv_head_index} in GQA mode")
@@ -144,15 +174,27 @@ def flash_attn_asm(
                 use_zero_reg=True,
             )
 
-            # Reset O_old with zeros
-            generated_code += reset_vssram_code(
-                reset_start_address=o_old_base_address,
-                vect_dim=vlen,
-                per_stride_dim=d,
-                reset_stride=q_index_2_kv_index_ratio * br,
-                reset_amount=q_index_2_kv_index_ratio,
-                alive_registers_int=alive_registers_int[0:3],
-            )
+            # Reset O_old with zeros. Packed group layout stores one KV group's
+            # active Q heads in HLEN-sized lanes of an MLEN-wide row, so zero
+            # the valid rows once instead of using the legacy head-stride reset.
+            if packed_group_layout:
+                generated_code += reset_vssram_code(
+                    reset_start_address=group_o_base_address,
+                    vect_dim=vlen,
+                    per_stride_dim=br,
+                    reset_stride=br,
+                    reset_amount=1,
+                    alive_registers_int=alive_registers_int[0:3],
+                )
+            else:
+                generated_code += reset_vssram_code(
+                    reset_start_address=o_old_base_address,
+                    vect_dim=vlen,
+                    per_stride_dim=d,
+                    reset_stride=q_index_2_kv_index_ratio * br,
+                    reset_amount=q_index_2_kv_index_ratio,
+                    alive_registers_int=alive_registers_int[0:3],
+                )
 
             # # loop over per q_index_2_kv_index_ratio q heads (q_len // MLEN), compute q_index_2_kv_index_ratio heads in parallel.
             for _ in range(q_seq_iteration_number):
@@ -166,9 +208,9 @@ def flash_attn_asm(
                         mlen=mlen,
                         stage=stage,
                         alive_registers=alive_registers_int[0:2],
-                        q_base_address=q_base_address + kv_head_index * q_index_2_kv_index_ratio * d,
+                        q_base_address=group_q_base_address,
                         k_base_hbm_offset_reg=k_base_hbm_offset_reg,
-                        q_head_index=kv_head_index * q_index_2_kv_index_ratio,
+                        q_head_index=0 if packed_group_layout else kv_head_index * q_index_2_kv_index_ratio,
                         k_head_index=kv_head_index,
                         s_base_address=s_base_address,
                         s_head_offset=0,
@@ -189,9 +231,9 @@ def flash_attn_asm(
                             mlen=mlen,
                             stage=stage,
                             alive_registers=alive_registers_int[0:9],
-                            q_base_address=q_base_address + kv_head_index * q_index_2_kv_index_ratio * d,
+                            q_base_address=group_q_base_address,
                             k_base_hbm_offset_reg=k_base_hbm_offset_reg,
-                            q_head_index=abs_q_head,
+                            q_head_index=inner_q_head_index if packed_group_layout else abs_q_head,
                             k_head_index=kv_head_index,
                             s_base_address=s_base_address,
                             s_head_offset=0,  # single S tile, always at offset 0
@@ -217,6 +259,7 @@ def flash_attn_asm(
                         m_start_address=m_fp_sram_start_address,
                         qk_scale_address=attn_scale_fp_address,
                         causal_mask=causal_mask,
+                        rows=br,
                     )
                     # P is stored in s_base_address (per-head) or
                     # s_base_address + inner_q_head_index * mlen * mlen (batched)
@@ -240,6 +283,7 @@ def flash_attn_asm(
                         v_head_index=kv_head_index,
                         output_base_address=pv_base_address,
                         head_offset=inner_q_head_index,  # This head's position within the row
+                        rows=br,
                     )
 
                     generated_code += reset_reg_asm(alive_registers_int[0:6])
@@ -252,9 +296,10 @@ def flash_attn_asm(
                         alive_registers_fp=alive_registers_fp[0:1],
                         m_res_base_address=stored_m_fp_res_address,
                         pv_base_address=pv_base_address,
-                        o_old_base_address=o_old_base_address,
+                        o_old_base_address=group_o_base_address if packed_group_layout else o_old_base_address,
                         head_dim=d,
-                        q_head_num=hq,
+                        q_head_num=(broadcast_amount if packed_group_layout else hq),
+                        rows=br,
                     )
                     stored_m_fp_res_address += 3 * br
 
@@ -278,9 +323,10 @@ def flash_attn_asm(
                         stage=stage,
                         alive_registers_int=alive_registers_int[0:3],
                         alive_registers_fp=alive_registers_fp[0:1],
-                        o_old_base_address=o_old_base_address,
+                        o_old_base_address=group_o_base_address if packed_group_layout else o_old_base_address,
                         l_old_base_address=l_old_base_address,
-                        o_row_stride=hq * d,  # Row stride is total width of all heads
+                        o_row_stride=(mlen if packed_group_layout else hq * d),
                         use_mask=True,
+                        rows=br,
                     )
     return generated_code

--- a/asm_templates/flashattn/pv.py
+++ b/asm_templates/flashattn/pv.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """PV multiplication assembly code generation for Flash Attention."""
 
+from .._imm import load_large_int_str as _load_large_int
+
 IMM2_BOUND = 2**18 - 1
 
 
@@ -54,21 +56,21 @@ def computing_pv_code(
     # NOTE: We ALWAYS prefetch V because K prefetch in qkt_multiply uses MSRAM 0,
     # which overwrites any previously prefetched V. Even though all heads share
     # the same V data (same KV head), we must re-prefetch after each K prefetch.
-    generated_code += f"S_ADDI_INT gp{v_base_register}, gp0, {v_head_index * head_dim} \n"
+    generated_code += _load_large_int(v_base_register, v_head_index * head_dim)
     # Use v_msram_base as MSRAM destination (can be 0 since K was already used)
-    generated_code += f"S_ADDI_INT gp{out_base_register}, gp0, {v_msram_base} \n"
+    generated_code += _load_large_int(out_base_register, v_msram_base)
     # Use stride_en=0 for contiguous prefetch to avoid 64-byte alignment issues
     generated_code += f"H_PREFETCH_M gp{out_base_register}, gp{v_base_register}, a{v_base_hbm_offset_reg}, 0, 1 \n"
 
     # P address for this head's softmax scores
     p_start_address = p_base_address + q_head_index * mlen * mlen
-    generated_code += f"S_ADDI_INT gp{p_base_register}, gp0, {p_start_address} \n"
+    generated_code += _load_large_int(p_base_register, p_start_address)
 
     # V is prefetched to MSRAM at v_msram_base
-    generated_code += f"S_ADDI_INT gp{v_base_register}, gp0, {v_msram_base} \n"
+    generated_code += _load_large_int(v_base_register, v_msram_base)
 
     # Output starts at output_base + head_offset (for this head's column position)
-    generated_code += f"S_ADDI_INT gp{out_base_register}, gp0, {output_base_address + head_offset * head_dim} \n"
+    generated_code += _load_large_int(out_base_register, output_base_address + head_offset * head_dim)
 
     if stage == "prefill":
         # Loop structure:
@@ -77,7 +79,7 @@ def computing_pv_code(
         outer_loop_count = head_dim // blen  # Number of column blocks
         valid_rows = mlen if rows is None else rows
         inner_loop_count = (valid_rows + blen - 1) // blen  # Number of valid row blocks
-        generated_code += f"S_ADDI_INT gp{out_col_register}, gp0, {output_base_address + head_offset * head_dim} \n"
+        generated_code += _load_large_int(out_col_register, output_base_address + head_offset * head_dim)
         generated_code += f"C_LOOP_START gp{outer_loop_register}, {outer_loop_count} \n"
         generated_code += f"C_LOOP_START gp{inner_loop_register}, {inner_loop_count} \n"
 
@@ -94,7 +96,7 @@ def computing_pv_code(
         generated_code += f"C_LOOP_END gp{inner_loop_register} \n"
 
         # After inner loop: reset P, advance to next column block
-        generated_code += f"S_ADDI_INT gp{p_base_register}, gp0, {p_start_address} \n"
+        generated_code += _load_large_int(p_base_register, p_start_address)
         # Move to next column position (blen elements to the right)
         generated_code += f"S_ADDI_INT gp{out_col_register}, gp{out_col_register}, {blen} \n"
         generated_code += f"S_ADDI_INT gp{out_base_register}, gp{out_col_register}, 0 \n"

--- a/asm_templates/flashattn/pv.py
+++ b/asm_templates/flashattn/pv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """PV multiplication assembly code generation for Flash Attention."""
 
 IMM2_BOUND = 2**18 - 1
@@ -17,6 +19,7 @@ def computing_pv_code(
     output_base_address: int,
     head_offset: int,
     v_msram_base: int = 0,  # MSRAM base address for V (can be 0, prefetched after K is used)
+    rows: int | None = None,
 ) -> str:
     """
     Compute PV = P @ V and write directly to packed output format.
@@ -47,11 +50,6 @@ def computing_pv_code(
     inner_loop_register = alive_registers[4]
     out_col_register = alive_registers[5]
 
-    assert p_base_address + q_head_index * mlen * mlen < IMM2_BOUND, f"p_base_address must be less than {IMM2_BOUND}"
-    assert v_head_index * head_dim < IMM2_BOUND, f"v_base_address must be less than {IMM2_BOUND}"
-    assert output_base_address < IMM2_BOUND, f"output_base_address must be less than {IMM2_BOUND}"
-    assert v_msram_base < IMM2_BOUND, f"v_msram_base must be less than {IMM2_BOUND}"
-
     # Prefetch V from HBM (MLEN, head_dim) to MSRAM at v_msram_base
     # NOTE: We ALWAYS prefetch V because K prefetch in qkt_multiply uses MSRAM 0,
     # which overwrites any previously prefetched V. Even though all heads share
@@ -77,7 +75,8 @@ def computing_pv_code(
         # - outer loop over column blocks of V (head_dim // blen iterations)
         # - inner loop over row blocks (mlen // blen iterations)
         outer_loop_count = head_dim // blen  # Number of column blocks
-        inner_loop_count = mlen // blen  # Number of row blocks
+        valid_rows = mlen if rows is None else rows
+        inner_loop_count = (valid_rows + blen - 1) // blen  # Number of valid row blocks
         generated_code += f"S_ADDI_INT gp{out_col_register}, gp0, {output_base_address + head_offset * head_dim} \n"
         generated_code += f"C_LOOP_START gp{outer_loop_register}, {outer_loop_count} \n"
         generated_code += f"C_LOOP_START gp{inner_loop_register}, {inner_loop_count} \n"

--- a/asm_templates/flashattn/qkt.py
+++ b/asm_templates/flashattn/qkt.py
@@ -70,11 +70,11 @@ def qkt_multiply(
         # s_head_offset is the relative head offset (0..ratio-1) for S writeback.
         # q_head_index is absolute and used only for Q VRAM read addressing above.
         if stage == "prefill":
-            generated_code += f"M_BTMM 0, gp{q_base_register}, gp0 \n"
+            generated_code += f"M_BTMM 0, gp0, gp{q_base_register} \n"
             generated_code += f"S_ADDI_INT gp{s_base_register}, gp0, {s_base_address + s_head_offset * mlen * mlen} \n"
             generated_code += f"M_BMM_WO gp{s_base_register}, 0 \n"
         else:
-            generated_code += f"M_BTMV 0, gp{q_base_register}, gp0 \n"
+            generated_code += f"M_BTMV 0, gp0, gp{q_base_register} \n"
             generated_code += f"S_ADDI_INT gp{s_base_register}, gp0, {s_base_address + s_head_offset * mlen} \n"
             generated_code += f"M_BMV_WO gp{s_base_register}, 0 \n"
     else:

--- a/asm_templates/flashattn/qkt.py
+++ b/asm_templates/flashattn/qkt.py
@@ -71,12 +71,10 @@ def qkt_multiply(
         # q_head_index is absolute and used only for Q VRAM read addressing above.
         if stage == "prefill":
             generated_code += f"M_BTMM 0, gp{q_base_register}, gp0 \n"
-            assert s_base_address + s_head_offset * mlen * mlen < IMM2_BOUND, "S base address is too large"
             generated_code += f"S_ADDI_INT gp{s_base_register}, gp0, {s_base_address + s_head_offset * mlen * mlen} \n"
             generated_code += f"M_BMM_WO gp{s_base_register}, 0 \n"
         else:
             generated_code += f"M_BTMV 0, gp{q_base_register}, gp0 \n"
-            assert s_base_address + s_head_offset * mlen < IMM2_BOUND, "S base address is too large"
             generated_code += f"S_ADDI_INT gp{s_base_register}, gp0, {s_base_address + s_head_offset * mlen} \n"
             generated_code += f"M_BMV_WO gp{s_base_register}, 0 \n"
     else:

--- a/asm_templates/flashattn/reset.py
+++ b/asm_templates/flashattn/reset.py
@@ -1,5 +1,7 @@
 """Reset/initialization assembly code generation for Flash Attention."""
 
+from .._imm import load_large_int_str as _load_large_int
+
 IMM2_BOUND = 2**18 - 1
 
 
@@ -28,11 +30,9 @@ def reset_fpsram_code(
     addr_register = alive_registers_int[0]
     outer_loop_register = alive_registers_int[1]
     inner_loop_register = alive_registers_int[2]
-    offset_register = alive_registers_int[3]
     fp_val_register = alive_registers_fp[0]
 
-    generated_code += f"S_ADDI_INT gp{addr_register}, gp0, {reset_start_address} \n"
-    generated_code += f"S_ADDI_INT gp{offset_register}, gp0, {reset_start_address + stride_dist} \n"
+    generated_code += _load_large_int(addr_register, reset_start_address)
     if use_zero_reg:
         fp_val_register = 0  # f0 = hardware zero
     else:
@@ -49,9 +49,9 @@ def reset_fpsram_code(
         else:
             generated_code += f"S_ST_FP f{fp_val_register}, gp{addr_register}, 0 \n"
             generated_code += f"S_ADDI_INT gp{addr_register}, gp{addr_register}, 1 \n"
-
-        generated_code += f"S_ADDI_INT gp{offset_register}, gp{offset_register}, {stride_dist} \n"
-        generated_code += f"S_ADD_INT gp{addr_register}, gp0, gp{offset_register} \n"
+        stride_advance = stride_dist - per_stride_dim
+        if stride_advance != 0:
+            generated_code += f"S_ADDI_INT gp{addr_register}, gp{addr_register}, {stride_advance} \n"
         generated_code += f"C_LOOP_END gp{outer_loop_register} \n"
     else:
         if per_stride_dim > 1:
@@ -88,7 +88,7 @@ def reset_vssram_code(
     outer_loop_register = alive_registers_int[1]
     inner_loop_register = alive_registers_int[2]
 
-    generated_code += f"S_ADDI_INT gp{addr_register}, gp0, {reset_start_address} \n"
+    generated_code += _load_large_int(addr_register, reset_start_address)
 
     total_iterations = reset_amount * per_stride_dim
     if total_iterations > 0:
@@ -111,17 +111,15 @@ def reset_kv_prefetch(
     alive_registers_int: list[int],
 ) -> str:
     generated_code = "; Reset KV Prefetch Code \n"
-    assert hkv * d * kv_len * batch < IMM2_BOUND, f"hkv * d * kv_len * batch must be less than {IMM2_BOUND}"
-    assert hkv * d * kv_len * batch < IMM2_BOUND, f"hkv * d * kv_len * batch must be less than {IMM2_BOUND}"
 
     if hkv * d < mlen:
-        generated_code += f"S_ADDI_INT gp{alive_registers_int[0]}, gp0, {mlen * kv_len * batch} \n"
+        generated_code += _load_large_int(alive_registers_int[0], mlen * kv_len * batch)
         generated_code += f"C_SET_SCALE_REG gp{alive_registers_int[0]} \n"
-        generated_code += f"S_ADDI_INT gp{alive_registers_int[0]}, gp0, {mlen} \n"
+        generated_code += _load_large_int(alive_registers_int[0], mlen)
         generated_code += f"C_SET_STRIDE_REG gp{alive_registers_int[0]} \n"
     else:
-        generated_code += f"S_ADDI_INT gp{alive_registers_int[0]}, gp0, {hkv * d * kv_len * batch} \n"
+        generated_code += _load_large_int(alive_registers_int[0], hkv * d * kv_len * batch)
         generated_code += f"C_SET_SCALE_REG gp{alive_registers_int[0]} \n"
-        generated_code += f"S_ADDI_INT gp{alive_registers_int[0]}, gp0, {hkv * d * batch} \n"
+        generated_code += _load_large_int(alive_registers_int[0], hkv * d * batch)
         generated_code += f"C_SET_STRIDE_REG gp{alive_registers_int[0]} \n"
     return generated_code

--- a/asm_templates/gemv_asm.py
+++ b/asm_templates/gemv_asm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._imm import addi_large_int as _addi_large_int_list
 from ._imm import load_large_int as _load_large_int_list
 

--- a/asm_templates/im2col_asm.py
+++ b/asm_templates/im2col_asm.py
@@ -31,6 +31,8 @@ is in 0..OW-1 and may not be 64-aligned.  This template requires that
 should route to ``im2col_asm_no_shift`` when this cannot be guaranteed.
 """
 
+from __future__ import annotations
+
 from ._imm import load_large_int as _load_large_int_list
 
 PREFETCH_V_AMOUNT = 4  # H_PREFETCH_V always loads this many VRAM rows

--- a/asm_templates/im2col_asm.py
+++ b/asm_templates/im2col_asm.py
@@ -53,6 +53,7 @@ def im2col_asm(
     mask_vec_vram_addr: int,
     scratch_vram_addr: int,
     output_vram_base: int,
+    output_physical_rows: int | None = None,
     W_padded: int | None = None,
     fp_one_reg: int = 1,  # FP register holding 1.0 (must be in fp_preload[fp_one_reg])
     fp_sram_precious_slots: list | None = None,  # fp_sram slots to save before mask construction
@@ -88,6 +89,9 @@ def im2col_asm(
             elements = 4 * 64 = 256 slots).
         output_vram_base:
             VRAM base address for the M im2col output rows.
+        output_physical_rows:
+            Physical row stride for column-block-major output storage.  Defaults
+            to M for legacy direct callers.
         stride:
             Convolution stride (default 1).  Every ``ow * stride`` must be a
             multiple of 64 for HBM alignment.  When this cannot be guaranteed,
@@ -106,6 +110,10 @@ def im2col_asm(
 
     K_col = C_in * K * K  # number of columns in im2col output row
     num_tiles = (K_col + vlen - 1) // vlen
+    output_row_stride = M if output_physical_rows is None else output_physical_rows
+    assert output_row_stride >= M, (
+        f"output_physical_rows={output_row_stride} cannot be smaller than logical M={M}"
+    )
     if num_tiles > 1:
         assert vlen % K == 0, (
             f"multi-tile im2col with V_SHIFT_V requires K ({K}) | VLEN ({vlen}); "
@@ -143,7 +151,10 @@ def im2col_asm(
     lines.append("; im2col (with V_SHIFT_V): NCHW input in HBM -> im2col matrix in VRAM")
     lines.append(f";   input shape : (1, {C_in}, {H}, {W})  in HBM (W_padded={W_padded})")
     lines.append(f";   kernel      : {K}x{K},  OH={OH}, OW={OW}, stride={stride}")
-    lines.append(f";   output      : ({M}, {K_col}) in VRAM starting at {output_vram_base}")
+    lines.append(
+        f";   output      : ({M}, {K_col}) in VRAM starting at {output_vram_base} "
+        f"(physical_rows={output_row_stride})"
+    )
     lines.append(f"; Requires: f0=0.0 (hw const), fp_preload[{fp_one_reg}]=1.0")
     lines.append("; ============================================================")
 
@@ -201,7 +212,7 @@ def im2col_asm(
 
     # ── main loop: iterate over tiles × M output positions ───────────
     # VRAM is column-block-major (matches no_shift template):
-    #   vram_addr(m, t) = output_vram_base + t*M*vlen + m*vlen
+    #   vram_addr(m, t) = output_vram_base + t*physical_rows*vlen + m*vlen
     for tile_t in range(num_tiles):
         tile_start = tile_t * vlen
         tile_end = min(tile_start + vlen, K_col)
@@ -212,7 +223,7 @@ def im2col_asm(
         for m in range(M):
             oh = m // OW
             ow = m % OW
-            out_vram_addr = output_vram_base + tile_t * M * vlen + m * vlen
+            out_vram_addr = output_vram_base + tile_t * output_row_stride * vlen + m * vlen
 
             # Stride-aware pixel column (guaranteed 64-aligned by assertion above).
             pixel_col = ow * stride

--- a/asm_templates/im2col_asm_no_shift.py
+++ b/asm_templates/im2col_asm_no_shift.py
@@ -9,6 +9,8 @@ Algorithm per output row m:
 Requires: f0=0.0 (hw const), fp_preload[fp_one_reg]=1.0.
 """
 
+from __future__ import annotations
+
 from ._imm import load_large_int as _load_large_int_list
 
 PREFETCH_V_AMOUNT = 4  # H_PREFETCH_V always loads this many VRAM rows

--- a/asm_templates/im2col_asm_no_shift.py
+++ b/asm_templates/im2col_asm_no_shift.py
@@ -32,6 +32,7 @@ def im2col_asm_no_shift(
     scratch_vram_addr: int,
     temp_vram_addr: int,
     output_vram_base: int,
+    output_physical_rows: int | None = None,
     W_padded: int | None = None,
     fp_one_reg: int = 1,  # FP register holding 1.0 (must be pre-loaded via fp_preload)
     fp_ex_reg: int = 2,  # FP register used as V_RED_SUM accumulator
@@ -68,6 +69,9 @@ def im2col_asm_no_shift(
             VRAM addr of temp mul-result row (vlen elements).
         output_vram_base:
             VRAM base for M im2col output rows.
+        output_physical_rows:
+            Physical row stride for column-block-major output storage.  Defaults
+            to M for legacy direct callers.
         W_padded:
             Input row width in HBM (padded for 64-element alignment). Default=W.
         fp_one_reg:
@@ -104,6 +108,10 @@ def im2col_asm_no_shift(
     )
     assert K <= vlen, f"K={K} > vlen={vlen}; basis-vector extraction requires K <= vlen"
     num_tiles = (K_col + vlen - 1) // vlen
+    output_row_stride = M if output_physical_rows is None else output_physical_rows
+    assert output_row_stride >= M, (
+        f"output_physical_rows={output_row_stride} cannot be smaller than logical M={M}"
+    )
 
     if W_padded is None:
         W_padded = W
@@ -128,7 +136,10 @@ def im2col_asm_no_shift(
     lines.append("; im2col (no-shift): NCHW input in HBM -> im2col matrix in VRAM")
     lines.append(f";   input  : (1,{C_in},{H},{W})  W_padded={W_padded}")
     lines.append(f";   kernel : {K}x{K}  OH={OH}  OW={OW}")
-    lines.append(f";   output : ({M},{K_col}) @ VRAM base {output_vram_base}")
+    lines.append(
+        f";   output : ({M},{K_col}) @ VRAM base {output_vram_base} "
+        f"(physical_rows={output_row_stride})"
+    )
     lines.append("; ISA: H_PREFETCH_V V_MUL_VV V_RED_SUM S_ST_FP S_MAP_V_FP")
     lines.append("; Requires: f0=0.0 (hw const), fp_preload[1]=1.0")
     lines.append("; ============================================================")
@@ -193,7 +204,7 @@ def im2col_asm_no_shift(
     lines.append(f"C_SET_SCALE_REG gp{basis_reg}")
 
     # Main loop: tiles × output positions. VRAM is column-block-major:
-    #   vram_addr(m, t) = output_vram_base + t*M*vlen + m*vlen
+    #   vram_addr(m, t) = output_vram_base + t*physical_rows*vlen + m*vlen
     for tile_t in range(num_tiles):
         tile_start = tile_t * vlen
         tile_end = min(tile_start + vlen, K_col)
@@ -206,7 +217,7 @@ def im2col_asm_no_shift(
             oh = m // OW
             ow = m % OW
 
-            out_vram_addr = output_vram_base + tile_t * M * vlen + m * vlen
+            out_vram_addr = output_vram_base + tile_t * output_row_stride * vlen + m * vlen
 
             lines.append("")
             lines.append(f"; ==== tile={tile_t} output row m={m}  oh={oh}  ow={ow}  vram={out_vram_addr} ====")

--- a/asm_templates/store_act_asm.py
+++ b/asm_templates/store_act_asm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 from ._imm import load_large_int_str as _load_large_int

--- a/asm_templates/store_act_asm.py
+++ b/asm_templates/store_act_asm.py
@@ -35,6 +35,11 @@ def store_act_asm(
     generated_code += _load_large_int(vram_reg, act_vram_offset)
     # Initialize HBM offset to 0
     generated_code += f"S_ADDI_INT gp{hbm_offset_reg}, gp0, 0\n"
+    # HBM MX formats store scale bytes after the element payload.  H_STORE_V
+    # uses C_SET_SCALE_REG as the scale-section base offset; do not inherit a
+    # stale value from a previous HBM load/store.
+    generated_code += _load_large_int(set_stride_register, batch * hidden_size)
+    generated_code += f"C_SET_SCALE_REG gp{set_stride_register}\n"
 
     if batch == 1:
         # Simple case: no stride needed, store sequentially

--- a/asm_templates/tests/test_large_immediate.py
+++ b/asm_templates/tests/test_large_immediate.py
@@ -10,6 +10,7 @@ helper used inside ffn_asm is exercised indirectly via ffn_asm().
 import unittest
 from typing import ClassVar
 
+from asm_templates._imm import add_large_int as _add_large_int
 from asm_templates._imm import load_large_int as _load_large_int
 from asm_templates.projection_asm import projection_asm, projection_T_asm
 
@@ -79,6 +80,23 @@ class TestLoadLargeInt(unittest.TestCase):
         # 4096 < 2^18, so single S_ADDI_INT from gp0 (no LUI needed)
         self.assertIn("S_ADDI_INT gp1, gp0, 4096", asm)
         self.assertNotIn("S_LUI_INT", asm)
+
+    def test_large_add_with_temp(self):
+        """Relative large adds can use caller-provided temp registers."""
+        result = _add_large_int(5, 3, 300000, temp_reg=7)
+        asm = "\n".join(result)
+        self.assertIn("S_LUI_INT gp7, 73", asm)
+        self.assertIn("S_ADDI_INT gp7, gp7, 992", asm)
+        self.assertIn("S_ADD_INT gp5, gp3, gp7", asm)
+
+    def test_large_add_without_temp_chunks(self):
+        """Compiler-wide fallback must not need a scratch register."""
+        result = _add_large_int(5, 3, 300000, temp_reg=None)
+        asm = "\n".join(result)
+        self.assertIn("S_ADDI_INT gp5, gp3, 262143", asm)
+        self.assertIn("S_ADDI_INT gp5, gp5, 37857", asm)
+        self.assertNotIn("S_ADDI_INT gp5, gp3, 300000", asm)
+        _check_all_addi_immediates(self, asm, "add_large_int(no temp)")
 
 
 class TestProjectionAsmLargeMatrix(unittest.TestCase):

--- a/asm_templates/tests/test_large_immediate.py
+++ b/asm_templates/tests/test_large_immediate.py
@@ -286,6 +286,29 @@ class TestFfnAsmLargeMatrix(unittest.TestCase):
         asm = ffn_asm(hidden_size=128, intermediate_size=256, use_loop_instructions=True, **args)
         _check_all_addi_immediates(self, asm, "ffn_asm(loop,128,256)")
 
+    def test_workspace_base_offsets_loop_path(self):
+        """Production loop path must place FFN temps at the explicit workspace base."""
+        ffn_asm = self._import_ffn_asm()
+        args = dict(self.BASE_ARGS)
+        args["alive_registers"] = list(range(10))
+        workspace_base = 1_000_000
+        rows = args["batch"] * args["seq_len"]
+        gate_base = workspace_base + rows * 256
+
+        asm = ffn_asm(
+            hidden_size=128,
+            intermediate_size=256,
+            use_loop_instructions=True,
+            workspace_base_address=workspace_base,
+            **args,
+        )
+
+        self.assertIn(f"S_LUI_INT gp3, {workspace_base >> 12}", asm)
+        self.assertIn(f"S_ADDI_INT gp3, gp3, {workspace_base & 0xFFF}", asm)
+        self.assertIn(f"S_LUI_INT gp5, {gate_base >> 12}", asm)
+        self.assertIn(f"S_ADDI_INT gp5, gp5, {gate_base & 0xFFF}", asm)
+        _check_all_addi_immediates(self, asm, "ffn_asm(loop,workspace)")
+
 
 def _check_all_addi_immediates(test_case, asm: str, label: str) -> None:
     """Assert every S_ADDI_INT immediate in asm is < 2^18."""

--- a/asm_templates/vram_sub_projection_asm.py
+++ b/asm_templates/vram_sub_projection_asm.py
@@ -28,6 +28,7 @@ def vram_sub_projection_asm_impl(
     transposed: bool,
     gp_regs: list[int],
     caller_name: str,
+    row_loop_count: int | None = None,
 ) -> str:
     """
     Shared implementation kernel for vram_sub_projection_asm and
@@ -42,7 +43,7 @@ def vram_sub_projection_asm_impl(
         vram_row_start_addr -- VRAM address of the first activation block
         mram_start_addr   -- MRAM address of the first weight block
         result_vram_addr  -- VRAM destination address for the (mlen, mlen) result
-        full_batch        -- full batch dimension of the activation VRAM matrix
+        full_batch        -- physical batch stride of the activation VRAM matrix
         num_hidden_blocks -- number of K-blocks to accumulate over
         mat_col_stride    -- MRAM outer-column stride (blen for M_MM, blen*mlen for M_TMM)
         transposed        -- True → emit M_TMM with (act, mat) operand order;
@@ -71,7 +72,10 @@ def vram_sub_projection_asm_impl(
     mram_hidden_block_stride = mlen * mlen
     output_row_stride = blen * mlen
     # Middle loop: for sub-mlen batch only iterate the real row groups.
-    row_loop_count = min(tiles_per_mlen, math.ceil(full_batch / blen))
+    if row_loop_count is None:
+        row_loop_count = min(tiles_per_mlen, math.ceil(full_batch / blen))
+    else:
+        row_loop_count = min(tiles_per_mlen, row_loop_count)
 
     do_unroll = unroll_loops
 

--- a/aten/isa_builder.py
+++ b/aten/isa_builder.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Protocol, Union
 
 
 class Renderable(Protocol):
@@ -37,7 +37,7 @@ def addr(index: int) -> Register:
     return Register("a", index)
 
 
-AsmArg = str | int | Register
+AsmArg = Union[str, int, Register]
 
 
 def render_arg(arg: AsmArg) -> str:
@@ -68,7 +68,7 @@ class Comment:
         return f"; {text}"
 
 
-AsmItem = str | Instr | Comment
+AsmItem = Union[str, Instr, Comment]
 IMM2_BOUND = 1 << 18
 
 
@@ -98,7 +98,7 @@ class IsaBuilder:
         return "\n".join(render_item(item) for item in legalize_large_immediates(self.items)) + "\n"
 
 
-AsmInput = str | Renderable
+AsmInput = Union[str, Renderable]
 
 
 def render_item(item: AsmItem) -> str:

--- a/aten/isa_builder.py
+++ b/aten/isa_builder.py
@@ -10,6 +10,9 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Protocol, Union
 
+from asm_templates._imm import add_large_int as _add_large_int_lines
+from asm_templates._imm import load_large_int as _load_large_int_lines
+
 
 class Renderable(Protocol):
     def render(self) -> str:
@@ -118,22 +121,30 @@ def is_gp_zero(arg: AsmArg) -> bool:
 
 
 def legalize_large_immediates(items: Iterable[AsmItem]) -> list[AsmItem]:
-    """Split typed absolute S_ADDI_INT loads that exceed the immediate field.
+    """Split typed S_ADDI_INT instructions that exceed the immediate field.
 
-    This is the typed equivalent of plena_frontend._fix_large_immediates.
-    Raw string items are intentionally left alone until those call sites move
-    onto typed instructions.
+    This is the typed equivalent of plena_frontend._fix_large_immediates. Raw
+    string items are intentionally left alone until those call sites move onto
+    typed instructions.
     """
     legalized: list[AsmItem] = []
     for item in items:
         if isinstance(item, Instr) and item.opcode == "S_ADDI_INT" and len(item.args) == 3:
             rd, rs, imm = item.args
-            if isinstance(rd, Register) and is_gp_zero(rs) and isinstance(imm, int) and imm >= IMM2_BOUND:
-                upper = imm >> 12
-                lower = imm & 0xFFF
-                legalized.append(Instr("S_LUI_INT", (rd, upper)))
-                if lower:
-                    legalized.append(Instr("S_ADDI_INT", (rd, rd, lower)))
+            if (
+                isinstance(rd, Register)
+                and isinstance(rs, Register)
+                and rd.prefix == "gp"
+                and rs.prefix == "gp"
+                and isinstance(imm, int)
+                and imm >= IMM2_BOUND
+            ):
+                replacement = (
+                    _load_large_int_lines(rd.index, imm)
+                    if is_gp_zero(rs)
+                    else _add_large_int_lines(rd.index, rs.index, imm, temp_reg=None)
+                )
+                legalized.extend(replacement)
                 continue
         legalized.append(item)
     return legalized

--- a/aten/model_extract.py
+++ b/aten/model_extract.py
@@ -70,6 +70,100 @@ class LayerWeights:
         return entries
 
 
+@dataclass(frozen=True)
+class VisionConfig:
+    """Vision encoder dimensions needed by the PLENA ATen frontend."""
+
+    hidden_size: int
+    inter_dim: int
+    num_heads: int
+    head_dim: int
+    eps: float
+    image_size: int
+    patch_size: int
+    num_channels: int
+    model_type: str
+
+    @property
+    def total_q_dim(self) -> int:
+        return self.num_heads * self.head_dim
+
+
+@dataclass(frozen=True)
+class VisionPatchWeights:
+    """Patch embedding weights in PLENA im2col convention."""
+
+    weight_2d: torch.Tensor
+    bias: torch.Tensor
+
+
+@dataclass(frozen=True)
+class VisionLayerWeights:
+    """One SigLIP/ViT vision layer in PLENA's (in, out) convention."""
+
+    w_q: torch.Tensor
+    w_k: torch.Tensor
+    w_v: torch.Tensor
+    w_o: torch.Tensor
+    b_q: torch.Tensor
+    b_k: torch.Tensor
+    b_v: torch.Tensor
+    b_o: torch.Tensor
+    w_fc1: torch.Tensor
+    w_fc2: torch.Tensor
+    b_fc1: torch.Tensor
+    b_fc2: torch.Tensor
+    ln1_weight: torch.Tensor
+    ln1_bias: torch.Tensor
+    ln2_weight: torch.Tensor
+    ln2_bias: torch.Tensor
+    eps: float
+
+    def tensor_entries(self, layer_idx: int) -> list[tuple[str, torch.Tensor]]:
+        return [
+            (f"V_W_q_{layer_idx}", self.w_q),
+            (f"V_W_k_{layer_idx}", self.w_k),
+            (f"V_W_v_{layer_idx}", self.w_v),
+            (f"V_W_o_{layer_idx}", self.w_o),
+            (f"V_B_q_{layer_idx}", self.b_q),
+            (f"V_B_k_{layer_idx}", self.b_k),
+            (f"V_B_v_{layer_idx}", self.b_v),
+            (f"V_B_o_{layer_idx}", self.b_o),
+            (f"V_W_fc1_{layer_idx}", self.w_fc1),
+            (f"V_W_fc2_{layer_idx}", self.w_fc2),
+            (f"V_B_fc1_{layer_idx}", self.b_fc1),
+            (f"V_B_fc2_{layer_idx}", self.b_fc2),
+            (f"V_LN1_weight_{layer_idx}", self.ln1_weight),
+            (f"V_LN1_bias_{layer_idx}", self.ln1_bias),
+            (f"V_LN2_weight_{layer_idx}", self.ln2_weight),
+            (f"V_LN2_bias_{layer_idx}", self.ln2_bias),
+        ]
+
+
+@dataclass(frozen=True)
+class VisionPostNormWeights:
+    weight: torch.Tensor
+    bias: torch.Tensor
+    eps: float
+
+    def tensor_entries(self) -> list[tuple[str, torch.Tensor]]:
+        return [
+            ("V_POST_LN_weight", self.weight),
+            ("V_POST_LN_bias", self.bias),
+        ]
+
+
+@dataclass(frozen=True)
+class VisionConnectorWeights:
+    """SmolVLM-style vision-to-text connector projection."""
+
+    weight: torch.Tensor
+    bias: torch.Tensor | None
+    scale_factor: int
+    input_dim: int
+    output_dim: int
+
+
 def find_model_root(model: Any) -> Any:
     """Find the transformer backbone (model.model or model.model.text_model).
 
@@ -86,7 +180,9 @@ def find_model_root(model: Any) -> Any:
             if hasattr(candidate, "layers"):
                 return candidate
             # LLaDA-style: transformer.blocks instead of layers
-            if hasattr(candidate, "transformer") and hasattr(candidate.transformer, "blocks"):
+            if hasattr(candidate, "transformer") and hasattr(
+                candidate.transformer, "blocks"
+            ):
                 # Create a wrapper that exposes .layers for compatibility
                 class LayersWrapper:
                     def __init__(self, obj):
@@ -106,16 +202,46 @@ def embedding_module(root: Any) -> Any | None:
     return getattr(root, "embed_tokens", getattr(root, "wte", None))
 
 
+def find_vision_model(model: Any) -> Any:
+    """Find the HF vision tower on a multimodal wrapper."""
+    for candidate in [
+        getattr(model, "vision_model", None),
+        getattr(getattr(model, "model", None), "vision_model", None),
+    ]:
+        if candidate is not None:
+            return candidate
+    raise ValueError(f"Cannot find vision_model on {type(model).__name__}")
+
+
+def find_vision_connector(model: Any) -> Any | None:
+    """Find an optional VLM connector after the vision tower."""
+    for candidate in [
+        getattr(model, "connector", None),
+        getattr(getattr(model, "model", None), "connector", None),
+    ]:
+        if candidate is not None:
+            return candidate
+    return None
+
+
 def extract_model_config(model: Any) -> ModelConfig:
     """Extract decoder dimensions, resolving text_config for VLM wrappers."""
     config = getattr(model.config, "text_config", model.config)
     hidden = config.hidden_size
     num_heads = config.num_attention_heads
+    inter_dim = getattr(config, "intermediate_size", None)
+    if inter_dim is None:
+        inter_dim = getattr(config, "mlp_hidden_size", None)
+    if inter_dim is None:
+        inter_dim = 4 * hidden
+    num_kv_heads = getattr(config, "num_key_value_heads", None)
+    if num_kv_heads is None:
+        num_kv_heads = getattr(config, "n_kv_heads", num_heads)
     return ModelConfig(
         hidden_size=hidden,
-        inter_dim=getattr(config, "intermediate_size", 4 * hidden),
+        inter_dim=inter_dim,
         num_heads=num_heads,
-        num_kv_heads=getattr(config, "num_key_value_heads", num_heads),
+        num_kv_heads=num_kv_heads,
         head_dim=hidden // num_heads,
         eps=getattr(config, "rms_norm_eps", 1e-5),
         rope_theta=getattr(config, "rope_theta", 10000.0),
@@ -124,19 +250,120 @@ def extract_model_config(model: Any) -> ModelConfig:
     )
 
 
+def extract_vision_config(model: Any) -> VisionConfig:
+    """Extract SigLIP/ViT vision dimensions from a VLM wrapper."""
+    config = getattr(model.config, "vision_config", None)
+    if config is None:
+        vision_model = find_vision_model(model)
+        config = getattr(vision_model, "config", None)
+    if config is None:
+        raise ValueError(f"Cannot find vision_config on {type(model).__name__}")
+
+    hidden = int(config.hidden_size)
+    num_heads = int(config.num_attention_heads)
+    head_dim = int(getattr(config, "head_dim", hidden // num_heads))
+    return VisionConfig(
+        hidden_size=hidden,
+        inter_dim=int(getattr(config, "intermediate_size", 4 * hidden)),
+        num_heads=num_heads,
+        head_dim=head_dim,
+        eps=float(getattr(config, "layer_norm_eps", getattr(config, "norm_eps", 1e-6))),
+        image_size=int(getattr(config, "image_size", 224)),
+        patch_size=int(getattr(config, "patch_size", 16)),
+        num_channels=int(getattr(config, "num_channels", 3)),
+        model_type=str(getattr(config, "model_type", "vision")),
+    )
+
+
 def extract_layer_weights(layer: Any, config: ModelConfig) -> LayerWeights:
     """Extract one decoder layer in PLENA's (in, out) convention.
-
+    
     Supports both standard Llama layers (with self_attn and mlp) and
     LLaDA-style layers (with direct projections).
     """
     # Detect layer type
     is_llada = hasattr(layer, "q_proj") and not hasattr(layer, "self_attn")
-
+    
     if is_llada:
         return _extract_llada_layer_weights(layer, config)
     else:
         return _extract_llama_layer_weights(layer, config)
+
+
+def extract_vision_patch_weights(vision_model: Any, config: VisionConfig) -> VisionPatchWeights:
+    """Extract Conv2d patch embedding as im2col weight + bias."""
+    patch = vision_model.embeddings.patch_embedding
+    weight = patch.weight.detach().float().reshape(config.hidden_size, -1).T.contiguous()
+    bias = _linear_bias(patch, config.hidden_size)
+    return VisionPatchWeights(weight_2d=weight, bias=bias)
+
+
+def extract_vision_layer_weights(layer: Any, config: VisionConfig) -> VisionLayerWeights:
+    """Extract one SigLIP/ViT encoder layer."""
+    hidden = config.hidden_size
+    inter = config.inter_dim
+    attn = layer.self_attn
+    mlp = layer.mlp
+    return VisionLayerWeights(
+        w_q=_linear_weight(attn.q_proj, hidden, config.total_q_dim),
+        w_k=_linear_weight(attn.k_proj, hidden, config.total_q_dim),
+        w_v=_linear_weight(attn.v_proj, hidden, config.total_q_dim),
+        w_o=_linear_weight(attn.out_proj, config.total_q_dim, hidden),
+        b_q=_linear_bias(attn.q_proj, config.total_q_dim),
+        b_k=_linear_bias(attn.k_proj, config.total_q_dim),
+        b_v=_linear_bias(attn.v_proj, config.total_q_dim),
+        b_o=_linear_bias(attn.out_proj, hidden),
+        w_fc1=_linear_weight(mlp.fc1, hidden, inter),
+        w_fc2=_linear_weight(mlp.fc2, inter, hidden),
+        b_fc1=_linear_bias(mlp.fc1, inter),
+        b_fc2=_linear_bias(mlp.fc2, hidden),
+        ln1_weight=layer.layer_norm1.weight.detach().float().contiguous()[:hidden],
+        ln1_bias=layer.layer_norm1.bias.detach().float().contiguous()[:hidden],
+        ln2_weight=layer.layer_norm2.weight.detach().float().contiguous()[:hidden],
+        ln2_bias=layer.layer_norm2.bias.detach().float().contiguous()[:hidden],
+        eps=float(getattr(layer.layer_norm1, "eps", config.eps)),
+    )
+
+
+def extract_vision_post_norm_weights(vision_model: Any, config: VisionConfig) -> VisionPostNormWeights:
+    norm = vision_model.post_layernorm
+    hidden = config.hidden_size
+    return VisionPostNormWeights(
+        weight=norm.weight.detach().float().contiguous()[:hidden],
+        bias=norm.bias.detach().float().contiguous()[:hidden],
+        eps=float(getattr(norm, "eps", config.eps)),
+    )
+
+
+def extract_vision_connector_weights(model: Any, config: VisionConfig) -> VisionConnectorWeights | None:
+    connector = find_vision_connector(model)
+    if connector is None:
+        return None
+
+    projection = getattr(getattr(connector, "modality_projection", None), "proj", None)
+    if projection is None:
+        projection = getattr(connector, "modality_projection", None)
+    if projection is None or not hasattr(projection, "weight"):
+        raise ValueError(f"Unsupported vision connector on {type(model).__name__}: missing modality projection")
+
+    scale_factor = int(getattr(connector, "scale_factor", 1))
+    input_dim = int(getattr(projection, "in_features", config.hidden_size * scale_factor * scale_factor))
+    output_dim = int(getattr(projection, "out_features", config.hidden_size))
+    expected_input = config.hidden_size * scale_factor * scale_factor
+    if input_dim != expected_input:
+        raise ValueError(
+            f"Unsupported vision connector input dim {input_dim}; expected "
+            f"hidden_size({config.hidden_size}) * scale_factor({scale_factor})^2 = {expected_input}"
+        )
+
+    bias = getattr(projection, "bias", None)
+    return VisionConnectorWeights(
+        weight=_linear_weight(projection, input_dim, output_dim),
+        bias=None if bias is None else bias.detach().float().contiguous()[:output_dim],
+        scale_factor=scale_factor,
+        input_dim=input_dim,
+        output_dim=output_dim,
+    )
 
 
 def _extract_llama_layer_weights(layer: Any, config: ModelConfig) -> LayerWeights:
@@ -161,7 +388,7 @@ def _extract_llama_layer_weights(layer: Any, config: ModelConfig) -> LayerWeight
 
 def _extract_llada_layer_weights(layer: Any, config: ModelConfig) -> LayerWeights:
     """Extract LLaDA-style layer weights.
-
+    
     LLaDA uses ff_proj and up_proj both mapping to intermediate dimension,
     with ff_out as the down projection. We treat ff_proj as gate and up_proj
     as the traditional up projection for compatibility with PLENA's FFN ops.
@@ -170,7 +397,7 @@ def _extract_llada_layer_weights(layer: Any, config: ModelConfig) -> LayerWeight
     total_kv_dim = config.num_kv_heads * config.head_dim
     w_k_full = _linear_weight(layer.k_proj, hidden, total_kv_dim)
     w_v_full = _linear_weight(layer.v_proj, hidden, total_kv_dim)
-
+    
     # Get epsilon from either attn_norm or ff_norm
     norm = getattr(layer, "attn_norm", getattr(layer, "ff_norm", None))
 
@@ -191,5 +418,18 @@ def _linear_weight(module: Any, rows: int, cols: int) -> torch.Tensor:
     return module.weight.detach().T.contiguous()[:rows, :cols]
 
 
-def _split_heads(weight: torch.Tensor, head_dim: int, num_heads: int) -> list[torch.Tensor]:
-    return [weight[:, h * head_dim : (h + 1) * head_dim].contiguous() for h in range(num_heads)]
+def _linear_bias(module: Any, cols: int) -> torch.Tensor:
+    """Return a linear/conv bias vector, or zeros for bias-free modules."""
+    bias = getattr(module, "bias", None)
+    if bias is None:
+        return torch.zeros(cols)
+    return bias.detach().float().contiguous()[:cols]
+
+
+def _split_heads(
+    weight: torch.Tensor, head_dim: int, num_heads: int
+) -> list[torch.Tensor]:
+    return [
+        weight[:, h * head_dim : (h + 1) * head_dim].contiguous()
+        for h in range(num_heads)
+    ]

--- a/aten/model_extract.py
+++ b/aten/model_extract.py
@@ -167,14 +167,17 @@ class VisionConnectorWeights:
 def find_model_root(model: Any) -> Any:
     """Find the transformer backbone (model.model or model.model.text_model).
 
-    Handles standard CausalLM models, VLMs like SmolVLM2, and diffusion models like LLaDA.
-    For LLaDA-style models, wraps transformer.blocks under a .layers attribute for compatibility.
+    Handles standard CausalLM models, VLMs like SmolVLM2, diffusion models like LLaDA,
+    and direct-wrapper models like Fast_dLLM_QwenModel.
     """
-    for candidate in [
+    # Check the model itself first, then common nested attributes
+    candidates = [
+        model,  # Direct wrapper models (e.g., Fast_dLLM_QwenModel)
         getattr(model, "model", None),
         getattr(getattr(model, "model", None), "text_model", None),
         getattr(model, "language_model", getattr(model, "text_model", None)),
-    ]:
+    ]
+    for candidate in candidates:
         if candidate is not None:
             # Standard case: .layers attribute
             if hasattr(candidate, "layers"):
@@ -226,7 +229,16 @@ def find_vision_connector(model: Any) -> Any | None:
 
 def extract_model_config(model: Any) -> ModelConfig:
     """Extract decoder dimensions, resolving text_config for VLM wrappers."""
-    config = getattr(model.config, "text_config", model.config)
+    # Robust config lookup for custom wrappers
+    cfg = getattr(model, "config", None)
+    if cfg is None:
+        cfg = getattr(getattr(model, "model", None), "config", None)
+    if cfg is None:
+        raise ValueError(
+            f"Cannot find .config on {type(model).__name__} or its submodules"
+        )
+
+    config = getattr(cfg, "text_config", cfg)
     hidden = config.hidden_size
     num_heads = config.num_attention_heads
     inter_dim = getattr(config, "intermediate_size", None)
@@ -277,28 +289,34 @@ def extract_vision_config(model: Any) -> VisionConfig:
 
 def extract_layer_weights(layer: Any, config: ModelConfig) -> LayerWeights:
     """Extract one decoder layer in PLENA's (in, out) convention.
-    
-    Supports both standard Llama layers (with self_attn and mlp) and
+
+    Supports both standard Llama/Qwen layers (with self_attn and mlp) and
     LLaDA-style layers (with direct projections).
     """
     # Detect layer type
     is_llada = hasattr(layer, "q_proj") and not hasattr(layer, "self_attn")
-    
+
     if is_llada:
         return _extract_llada_layer_weights(layer, config)
     else:
         return _extract_llama_layer_weights(layer, config)
 
 
-def extract_vision_patch_weights(vision_model: Any, config: VisionConfig) -> VisionPatchWeights:
+def extract_vision_patch_weights(
+    vision_model: Any, config: VisionConfig
+) -> VisionPatchWeights:
     """Extract Conv2d patch embedding as im2col weight + bias."""
     patch = vision_model.embeddings.patch_embedding
-    weight = patch.weight.detach().float().reshape(config.hidden_size, -1).T.contiguous()
+    weight = (
+        patch.weight.detach().float().reshape(config.hidden_size, -1).T.contiguous()
+    )
     bias = _linear_bias(patch, config.hidden_size)
     return VisionPatchWeights(weight_2d=weight, bias=bias)
 
 
-def extract_vision_layer_weights(layer: Any, config: VisionConfig) -> VisionLayerWeights:
+def extract_vision_layer_weights(
+    layer: Any, config: VisionConfig
+) -> VisionLayerWeights:
     """Extract one SigLIP/ViT encoder layer."""
     hidden = config.hidden_size
     inter = config.inter_dim
@@ -325,7 +343,9 @@ def extract_vision_layer_weights(layer: Any, config: VisionConfig) -> VisionLaye
     )
 
 
-def extract_vision_post_norm_weights(vision_model: Any, config: VisionConfig) -> VisionPostNormWeights:
+def extract_vision_post_norm_weights(
+    vision_model: Any, config: VisionConfig
+) -> VisionPostNormWeights:
     norm = vision_model.post_layernorm
     hidden = config.hidden_size
     return VisionPostNormWeights(
@@ -335,7 +355,9 @@ def extract_vision_post_norm_weights(vision_model: Any, config: VisionConfig) ->
     )
 
 
-def extract_vision_connector_weights(model: Any, config: VisionConfig) -> VisionConnectorWeights | None:
+def extract_vision_connector_weights(
+    model: Any, config: VisionConfig
+) -> VisionConnectorWeights | None:
     connector = find_vision_connector(model)
     if connector is None:
         return None
@@ -344,10 +366,16 @@ def extract_vision_connector_weights(model: Any, config: VisionConfig) -> Vision
     if projection is None:
         projection = getattr(connector, "modality_projection", None)
     if projection is None or not hasattr(projection, "weight"):
-        raise ValueError(f"Unsupported vision connector on {type(model).__name__}: missing modality projection")
+        raise ValueError(
+            f"Unsupported vision connector on {type(model).__name__}: missing modality projection"
+        )
 
     scale_factor = int(getattr(connector, "scale_factor", 1))
-    input_dim = int(getattr(projection, "in_features", config.hidden_size * scale_factor * scale_factor))
+    input_dim = int(
+        getattr(
+            projection, "in_features", config.hidden_size * scale_factor * scale_factor
+        )
+    )
     output_dim = int(getattr(projection, "out_features", config.hidden_size))
     expected_input = config.hidden_size * scale_factor * scale_factor
     if input_dim != expected_input:
@@ -367,7 +395,7 @@ def extract_vision_connector_weights(model: Any, config: VisionConfig) -> Vision
 
 
 def _extract_llama_layer_weights(layer: Any, config: ModelConfig) -> LayerWeights:
-    """Extract standard Llama layer weights."""
+    """Extract standard Llama/Qwen layer weights."""
     hidden = config.hidden_size
     total_kv_dim = config.num_kv_heads * config.head_dim
     w_k_full = _linear_weight(layer.self_attn.k_proj, hidden, total_kv_dim)
@@ -388,7 +416,7 @@ def _extract_llama_layer_weights(layer: Any, config: ModelConfig) -> LayerWeight
 
 def _extract_llada_layer_weights(layer: Any, config: ModelConfig) -> LayerWeights:
     """Extract LLaDA-style layer weights.
-    
+
     LLaDA uses ff_proj and up_proj both mapping to intermediate dimension,
     with ff_out as the down projection. We treat ff_proj as gate and up_proj
     as the traditional up projection for compatibility with PLENA's FFN ops.
@@ -397,7 +425,7 @@ def _extract_llada_layer_weights(layer: Any, config: ModelConfig) -> LayerWeight
     total_kv_dim = config.num_kv_heads * config.head_dim
     w_k_full = _linear_weight(layer.k_proj, hidden, total_kv_dim)
     w_v_full = _linear_weight(layer.v_proj, hidden, total_kv_dim)
-    
+
     # Get epsilon from either attn_norm or ff_norm
     norm = getattr(layer, "attn_norm", getattr(layer, "ff_norm", None))
 
@@ -409,7 +437,11 @@ def _extract_llada_layer_weights(layer: Any, config: ModelConfig) -> LayerWeight
         w_gate=_linear_weight(layer.ff_proj, hidden, config.inter_dim),
         w_up=_linear_weight(layer.up_proj, hidden, config.inter_dim),
         w_down=_linear_weight(layer.ff_out, config.inter_dim, hidden),
-        eps=getattr(norm, "variance_epsilon", getattr(norm, "eps", 1e-5)) if norm else 1e-5,
+        eps=(
+            getattr(norm, "variance_epsilon", getattr(norm, "eps", 1e-5))
+            if norm
+            else 1e-5
+        ),
     )
 
 

--- a/aten/model_extract.py
+++ b/aten/model_extract.py
@@ -49,7 +49,11 @@ class LayerWeights:
             (f"W_q_{layer_idx}", self.w_q),
             (f"W_o_{layer_idx}", self.w_o),
         ]
-        for kv_h, (w_k, w_v) in enumerate(zip(self.w_k_heads, self.w_v_heads, strict=True)):
+        if len(self.w_k_heads) != len(self.w_v_heads):
+            raise ValueError(
+                f"w_k_heads/w_v_heads length mismatch: {len(self.w_k_heads)} != {len(self.w_v_heads)}"
+            )
+        for kv_h, (w_k, w_v) in enumerate(zip(self.w_k_heads, self.w_v_heads)):
             entries.extend(
                 [
                     (f"W_k_{layer_idx}_h{kv_h}", w_k),

--- a/aten/native_ops.yaml
+++ b/aten/native_ops.yaml
@@ -87,7 +87,7 @@
     uses_mram: true
   doc: "FFN with SiLU gate: w_down @ (silu(w_gate @ x) * (w_up @ x))"
 
-- func: "flash_attention(Tensor Q, Tensor K, Tensor V, float scale, int hq=1, int hkv=1, int h_qkv=0) -> Tensor"
+- func: "flash_attention(Tensor Q, Tensor K, Tensor V, float scale, int hq=1, int hkv=1, int h_qkv=0, int batch_size=1, int seq_len=0, int kv_seq_len=0) -> Tensor"
   category: composite
   in_place: false
   dispatch:

--- a/aten/native_stage_trace_compare.py
+++ b/aten/native_stage_trace_compare.py
@@ -1,0 +1,297 @@
+"""Compare native decoder checkpoints against a propagated scheduled reference.
+
+The existing VRAM stage checker validates most kernels using checkpointed
+emulator inputs. That is useful for isolating local kernel bugs, but it can
+miss chain-level errors. This diagnostic starts from the original build inputs,
+propagates the scheduled reference stage by stage, and compares each saved
+checkpoint to that propagated tensor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import torch
+
+_COMPILER_ROOT = Path(__file__).resolve().parents[1]
+_SIM_ROOT = _COMPILER_ROOT.parent
+for _path in (_SIM_ROOT, _SIM_ROOT / "tools", _COMPILER_ROOT):
+    _path_str = str(_path)
+    if _path_str not in sys.path:
+        sys.path.insert(0, _path_str)
+
+from compiler.aten.model_extract import LayerWeights
+from compiler.aten.reference import (  # noqa: E402
+    ReferencePrecision,
+    ScheduledReferenceConfig,
+    _flash_attn_scheduled_ref,
+    _hbm_round_ref,
+    _linear_scheduled_ref,
+    _pad_cols_ref,
+    _residual_add_ref,
+    _rms_norm_scheduled_ref,
+    _rope_scheduled_ref,
+    _round,
+    _silu_gate_scheduled_ref,
+    _vram_load_ref,
+)
+from aten.vram_stage_compare import _read_checkpoint  # noqa: E402
+
+
+def _load_json(path: Path) -> dict:
+    with path.open() as f:
+        return json.load(f)
+
+
+def _load_tensor(build: Path, name: str) -> torch.Tensor:
+    return torch.load(build / name, map_location="cpu", weights_only=True).float()
+
+
+def _load_layer(build: Path, layer_idx: int, num_kv_heads: int) -> LayerWeights:
+    return LayerWeights(
+        w_q=_load_tensor(build, f"W_q_{layer_idx}.pt"),
+        w_o=_load_tensor(build, f"W_o_{layer_idx}.pt"),
+        w_k_heads=[_load_tensor(build, f"W_k_{layer_idx}_h{h}.pt") for h in range(num_kv_heads)],
+        w_v_heads=[_load_tensor(build, f"W_v_{layer_idx}_h{h}.pt") for h in range(num_kv_heads)],
+        w_gate=_load_tensor(build, f"W_gate_{layer_idx}.pt"),
+        w_up=_load_tensor(build, f"W_up_{layer_idx}.pt"),
+        w_down=_load_tensor(build, f"W_down_{layer_idx}.pt"),
+        eps=1e-5,
+    )
+
+
+def _lookup(metadata: dict) -> dict[tuple[int | None, str], dict]:
+    return {
+        (entry.get("layer_idx"), entry["stage"]): entry
+        for entry in metadata.get("checkpoints", [])
+    }
+
+
+def _pad_to_actual(expected: torch.Tensor, actual: torch.Tensor) -> torch.Tensor:
+    if expected.shape == actual.shape:
+        return expected
+    if expected.shape[0] > actual.shape[0] or expected.shape[1] > actual.shape[1]:
+        raise ValueError(f"Expected shape {tuple(expected.shape)} exceeds actual {tuple(actual.shape)}")
+    out = torch.zeros_like(actual)
+    out[: expected.shape[0], : expected.shape[1]] = expected
+    return out
+
+
+def _metrics(expected: torch.Tensor, actual: torch.Tensor, active_rows: int, active_cols: int) -> dict:
+    expected = _pad_to_actual(expected, actual)
+    exp = expected[:active_rows, :active_cols].bfloat16()
+    act = actual[:active_rows, :active_cols].bfloat16()
+    close = torch.isclose(act, exp, atol=0.2, rtol=0.2)
+    diff = (act.float() - exp.float()).abs()
+    return {
+        "active_allclose": float(close.float().mean().item() * 100.0),
+        "mse": float(((act.float() - exp.float()) ** 2).mean().item()),
+        "mae": float(diff.mean().item()),
+        "max_error": float(diff.max().item()),
+    }
+
+
+def _compare(
+    results: list[dict],
+    lookup: dict[tuple[int | None, str], dict],
+    vram_path: Path,
+    mlen: int,
+    layer_idx: int | None,
+    stage: str,
+    expected: torch.Tensor,
+) -> torch.Tensor | None:
+    entry = lookup.get((layer_idx, stage))
+    if entry is None:
+        return None
+    actual = _read_checkpoint(vram_path, entry, mlen)
+    active_rows, active_cols = entry["active_shape"]
+    row = {
+        "layer_idx": layer_idx,
+        "stage": stage,
+        **_metrics(expected, actual, int(active_rows), int(active_cols)),
+    }
+    results.append(row)
+    return actual
+
+
+def _packed_attention_expected(
+    q_full: torch.Tensor,
+    x_normed: torch.Tensor,
+    layer: LayerWeights,
+    config: ScheduledReferenceConfig,
+    rope: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    precision: ReferencePrecision,
+) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
+    if config.head_slot_dim is None or config.broadcast_amount is None:
+        raise ValueError("packed attention config requires head_slot_dim and broadcast_amount")
+
+    rows = q_full.shape[0]
+    group_width = config.packed_group_width
+    head_slot_dim = config.head_slot_dim
+    ratio = config.head_ratio
+    scale = 1.0 / (config.head_dim ** 0.5)
+    out = torch.zeros((rows, config.attention_width), dtype=q_full.dtype)
+
+    k_proj = []
+    v_proj = []
+    k_rope = []
+    for kv_h in range(config.num_kv_heads):
+        k_h = _linear_scheduled_ref(x_normed, layer.w_k_heads[kv_h], config, precision)
+        v_h = _linear_scheduled_ref(x_normed, layer.w_v_heads[kv_h], config, precision)
+        k_proj.append(k_h)
+        v_proj.append(v_h)
+        k_h_full = _pad_cols_ref(k_h, group_width)
+        v_h_full = _pad_cols_ref(v_h, group_width)
+        k_h_full = _rope_scheduled_ref(k_h_full, rope, cos, sin, config, precision)
+        k_rope.append(k_h_full)
+        k_for_attn = _hbm_round_ref(k_h_full, precision)
+        v_for_attn = _hbm_round_ref(v_h_full, precision)
+
+        group_start = kv_h * group_width
+        q_group = q_full[:, group_start:group_start + group_width]
+        q_group = _rope_scheduled_ref(q_group, rope, cos, sin, config, precision)
+        for lane in range(ratio):
+            lane_start = lane * head_slot_dim
+            lane_end = lane_start + head_slot_dim
+            o_h = _flash_attn_scheduled_ref(
+                q_group[:, lane_start:lane_end],
+                k_for_attn[:, :head_slot_dim],
+                v_for_attn[:, :head_slot_dim],
+                scale,
+                precision,
+                causal=True,
+                matmul_scale=0.25,
+            )
+            out[:, group_start + lane_start:group_start + lane_end] = o_h
+
+    return _round(out, precision), k_proj, v_proj, k_rope
+
+
+def compare_trace(build_dir: Path, vram_path: Path) -> dict:
+    info = _load_json(build_dir / "compile_info.json")
+    metadata = _load_json(build_dir / "stage_checkpoints.json")
+    lookup = _lookup(metadata)
+
+    precision = ReferencePrecision.from_mode(info.get("golden_precision", "hardware"))
+    config = ScheduledReferenceConfig(
+        seq_len=int(info["seq_len"]),
+        padded_seq_len=int(info["padded_seq_len"]),
+        hidden_size=int(info["hidden_size"]),
+        padded_hidden_size=int(info["padded_hidden_size"]),
+        inter_dim=int(info["inter_dim"]),
+        padded_inter_dim=int(info["padded_inter_dim"]),
+        head_dim=int(info["head_dim"]),
+        padded_head_dim=int(info["padded_head_dim"]),
+        num_heads=int(info["num_heads"]),
+        num_kv_heads=int(info["num_kv_heads"]),
+        mlen=int(info["mlen"]),
+        blen=int(info["blen"]),
+        max_k_tiles=int(info.get("mram_tile_capacity", 4)),
+        attention_head_packing=bool(info.get("attention_head_packing", False)),
+        head_slot_dim=info.get("attention_head_slot_dim"),
+        broadcast_amount=info.get("attention_broadcast_amount"),
+        total_q_dim=info.get("attention_broadcast_amount") and int(info["num_kv_heads"]) * int(info["mlen"]),
+        batch_size=int(info.get("batch_size", 1)),
+        rows_per_batch=int(info.get("rows_per_batch", info["padded_seq_len"])),
+    )
+
+    x = _vram_load_ref(_load_tensor(build_dir, "X.pt").clone(), precision)
+    pos = _vram_load_ref(_load_tensor(build_dir, "POS.pt"), precision)
+    x = _round(x + pos, precision)
+    rope = _load_tensor(build_dir, "R_rope.pt")
+    cos = _vram_load_ref(_load_tensor(build_dir, "COS.pt"), precision)
+    sin = _vram_load_ref(_load_tensor(build_dir, "SIN.pt"), precision)
+
+    results: list[dict] = []
+    _compare(results, lookup, vram_path, config.mlen, None, "embedding_add", x)
+
+    for layer_idx in range(int(info["num_layers"])):
+        layer = _load_layer(build_dir, layer_idx, config.num_kv_heads)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "attn_input", x)
+        residual = x.clone()
+        x_normed = _rms_norm_scheduled_ref(x, config.hidden_size, layer.eps, config.mlen, precision)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "attn_norm", x_normed)
+        q_full = _linear_scheduled_ref(x_normed, layer.w_q, config, precision)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "q_full", q_full)
+
+        if not config.attention_head_packing:
+            raise NotImplementedError("native_stage_trace_compare currently handles packed attention only")
+        o_full, k_proj, v_proj, k_rope = _packed_attention_expected(
+            q_full,
+            x_normed,
+            layer,
+            config,
+            rope,
+            cos,
+            sin,
+            precision,
+        )
+        for kv_h in range(config.num_kv_heads):
+            _compare(results, lookup, vram_path, config.mlen, layer_idx, f"k_proj_h{kv_h}", k_proj[kv_h])
+            _compare(results, lookup, vram_path, config.mlen, layer_idx, f"v_proj_h{kv_h}", v_proj[kv_h])
+            _compare(results, lookup, vram_path, config.mlen, layer_idx, f"k_rope_h{kv_h}", k_rope[kv_h])
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "o_full", o_full)
+
+        o_proj = _linear_scheduled_ref(o_full, layer.w_o, config, precision)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "o_proj", o_proj)
+        x = _residual_add_ref(o_proj, residual, precision)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "attn_residual", x)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "ffn_input", x)
+
+        residual = x.clone()
+        x_normed = _rms_norm_scheduled_ref(x, config.hidden_size, layer.eps, config.mlen, precision)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "ffn_norm", x_normed)
+        up = _linear_scheduled_ref(x_normed, layer.w_up, config, precision)
+        gate = _linear_scheduled_ref(x_normed, layer.w_gate, config, precision)
+        ffn_mid = _silu_gate_scheduled_ref(up, gate, precision)
+        ffn_out = _linear_scheduled_ref(ffn_mid, layer.w_down, config, precision)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "ffn_out", ffn_out)
+        x = _residual_add_ref(ffn_out, residual, precision)
+        _compare(results, lookup, vram_path, config.mlen, layer_idx, "ffn_residual", x)
+
+    final_norm = _rms_norm_scheduled_ref(x, config.hidden_size, layer.eps, config.mlen, precision)
+    _compare(results, lookup, vram_path, config.mlen, int(info["num_layers"]) - 1, "final_norm", final_norm)
+
+    first_bad = next((r for r in results if r["active_allclose"] < 99.0), None)
+    return {
+        "build_dir": str(build_dir),
+        "vram_path": str(vram_path),
+        "first_bad": first_bad,
+        "results": results,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("vram_path", type=Path)
+    parser.add_argument("build_dir", type=Path)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    report = compare_trace(args.build_dir, args.vram_path)
+    for row in report["results"]:
+        prefix = "global" if row["layer_idx"] is None else f"layer={row['layer_idx']}"
+        status = "BAD" if row["active_allclose"] < 99.0 else "ok "
+        print(
+            f"{status} {prefix:<8} {row['stage']:<16} "
+            f"{row['active_allclose']:6.2f}% mse={row['mse']:.6g} "
+            f"mae={row['mae']:.6g} max={row['max_error']:.6g}"
+        )
+    if report["first_bad"] is not None:
+        bad = report["first_bad"]
+        print(f"FIRST_BAD layer={bad['layer_idx']} stage={bad['stage']} allclose={bad['active_allclose']:.2f}%")
+    else:
+        print("FIRST_BAD none")
+
+    if args.json_out is not None:
+        with args.json_out.open("w") as f:
+            json.dump(report, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/aten/ops/cpu/attention_ops.py
+++ b/aten/ops/cpu/attention_ops.py
@@ -9,6 +9,7 @@ def flash_attention_cpu(
     K: torch.Tensor,
     V: torch.Tensor,
     scale: float | None = None,
+    **_kwargs,
 ) -> torch.Tensor:
     """CPU reference: Flash Attention = softmax(Q @ K.T * scale) @ V."""
     if scale is None:

--- a/aten/ops/plena/attention_ops.py
+++ b/aten/ops/plena/attention_ops.py
@@ -1,5 +1,30 @@
 """PLENA backend wrapper for Flash Attention."""
 
 
-def flash_attention_plena(prog, Q, K, V, scale=None, hq=1, hkv=1, h_qkv=None, causal_mask=None):
-    return prog.flash_attention(Q, K, V, scale=scale, hq=hq, hkv=hkv, h_qkv=h_qkv, causal_mask=causal_mask)
+def flash_attention_plena(
+    prog,
+    Q,
+    K,
+    V,
+    scale=None,
+    hq=1,
+    hkv=1,
+    h_qkv=None,
+    causal_mask=None,
+    batch_size=1,
+    seq_len=None,
+    kv_seq_len=None,
+):
+    return prog.flash_attention(
+        Q,
+        K,
+        V,
+        scale=scale,
+        hq=hq,
+        hkv=hkv,
+        h_qkv=h_qkv,
+        causal_mask=causal_mask,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        kv_seq_len=kv_seq_len,
+    )

--- a/aten/ops/plena/conv_ops.py
+++ b/aten/ops/plena/conv_ops.py
@@ -37,6 +37,8 @@ def conv2d_plena(
     W_padded: int | None = None,
     fp_one_reg: int = 1,
     use_shift: bool = False,
+    stride: int = 1,
+    return_im2col: bool = False,
 ):
     """
     PLENA backend: hardware im2col + systolic matmul.
@@ -60,6 +62,12 @@ def conv2d_plena(
             Padded HBM row width for 64-element alignment.
             Must satisfy W_padded % 64 == 0 and W_padded >= W.
             Defaults to next multiple of 64 >= W.
+        stride:
+            Spatial convolution stride.  Native ViT/SigLIP patch embedding
+            uses stride == K; legacy conv tests use the default stride 1.
+        return_im2col:
+            Debug/testing hook.  If true, return the generated im2col VRAM
+            matrix before the systolic projection.
 
     Returns:
         VRAMMatrixVar for the output, shape (M, C_out).
@@ -98,14 +106,22 @@ def conv2d_plena(
         # Single mask vector: [1*K, 0*(VLEN-K)] — host must preload before exec
         mask_mat = prog.alloc("im2col_mask", 1, vlen, strict=False)
     else:
-        # K basis vectors  (e_kc has 1.0 at position kc, zeros elsewhere)
-        basis_mat = prog.alloc("im2col_basis", K, vlen, strict=False)
+        # Basis vector for every intra-load position used by stride-aware
+        # extraction.  Stride-1 tests only need K rows; patch embedding with
+        # stride=K can need positions across the whole 64-element HBM load.
+        basis_positions = {
+            (ow * stride) % 64 + kc
+            for ow in range(OW)
+            for kc in range(K)
+        }
+        basis_mat = prog.alloc("im2col_basis", len(basis_positions), vlen, strict=False)
     # Scratch area for H_PREFETCH_V landing (needs PREFETCH_V_AMOUNT rows)
     scratch_mat = prog.alloc("im2col_scratch", PREFETCH_V_AMOUNT, vlen, strict=False)
     # Temp row for V_MUL_VV result (used by no_shift variant)
     temp_mat = prog.alloc("im2col_temp", 1, vlen, strict=False)
     # Output im2col matrix: M rows × K_col_padded cols (padded for tile alignment)
     output_mat = prog.alloc("im2col_out", M, K_col_padded, strict=False)
+    output_physical_rows = output_mat.physical_shape[0]
 
     # ------------------------------------------------------------------
     # Look up VRAM base addresses from the symbol table
@@ -164,8 +180,10 @@ def conv2d_plena(
             mask_vec_vram_addr=mask_vec_vram_addr,
             scratch_vram_addr=scratch_vram_addr,
             output_vram_base=output_vram_base,
+            output_physical_rows=output_physical_rows,
             W_padded=W_padded,
             fp_one_reg=fp_one_reg,
+            stride=stride,
         )
     else:
         asm_code = im2col_asm_no_shift(
@@ -184,13 +202,17 @@ def conv2d_plena(
             scratch_vram_addr=scratch_vram_addr,
             temp_vram_addr=temp_vram_addr,
             output_vram_base=output_vram_base,
+            output_physical_rows=output_physical_rows,
             W_padded=W_padded,
             fp_one_reg=fp_one_reg,  # f1 = 1.0 by default (must be in fp_preload[fp_one_reg])
             fp_ex_reg=2,  # f2 = V_RED_SUM accumulator
-        )
+            stride=stride,
+    )
     prog.emit(asm_code)
 
     # ------------------------------------------------------------------
     # Systolic matmul: im2col_out @ weight_2d  -> (M, C_out)
     # ------------------------------------------------------------------
+    if return_im2col:
+        return output_mat
     return prog.linear(output_mat, weight_2d_var)

--- a/aten/ops/plena/softmax_ops.py
+++ b/aten/ops/plena/softmax_ops.py
@@ -45,63 +45,30 @@ def softmax_plena(prog, input_var, scale: float = 1.0):
     """
     mlen = prog.mlen
 
-    # Allocate output matrix in VRAM (S holds the softmax result)
+    # Allocate output matrix in VRAM (S holds the softmax result).
     S = prog.alloc("S", mlen, mlen)
 
-    # Reserve fp_preload region (addresses 0-2): 0=0.0, 1=scale, 2=-inf
-    # This ensures FPRAM variable allocation starts after these reserved slots
-    prog.fpram_allocator.next_free = 3
-
-    # Allocate FPRAM variables
-    scale_fp = prog.fp_var("scale_fp", size=1)  # scale factor
-    m_old = prog.fp_var("m_old", size=mlen)  # per-row running max
-    m_res = prog.fp_var("m_res", size=mlen)  # per-row decay factor
-    l_old = prog.fp_var("l_old", size=mlen)  # per-row accumulated sum
-    row_max_tmp = prog.fp_var("row_max_tmp", size=1)  # temp: current row max
-    m_old_saved = prog.fp_var("m_old_saved", size=1)  # temp: saved m_old
-    sum_p_tmp = prog.fp_var("sum_p_tmp", size=1)  # temp: current row sum
-    inv_l = prog.fp_var("inv_l", size=mlen)  # 1/l for normalization
-
-    # Step 0: Initialize S = input, load constants from fp_preload
+    # Step 0: Initialize S = input.  The allocated VRAM starts zeroed in the
+    # simulator, matching the previous implementation's S += input behavior.
     prog.vram_add(S, input_var)
-    prog.fpvar_fill_from_fpram(scale_fp, src_fpram_addr=1)  # load scale
-    prog.fpvar_fill_from_fpram(m_old, src_fpram_addr=2)  # load -inf
-    prog.fpvar_fill_from_fpram(l_old, src_fpram_addr=0)  # load 0.0
 
-    # Row-by-row online softmax
-    for row in range(mlen):
-        # 1. Save old max for this row
-        prog.fpvar_copy_asm(m_old.address + row, m_old_saved.address, 1)
-
-        # 2. Scale: S[row] *= scale
-        prog.tile_row_mul_fp_broadcast(S, scale_fp.address, row)
-
-        # 3. Find row maximum
-        prog.tile_row_max(row_max_tmp.address, S, row)
-
-        # 4. Update running max: m_old[row] = max(m_old[row], row_max)
-        prog.fpvar_max_asm(m_old.address + row, row_max_tmp.address, m_old.address + row, 1)
-
-        # 5. Decay factor: m_res[row] = exp(m_old_saved - m_curr)
-        prog.fpvar_sub_asm(m_old_saved.address, m_old.address + row, m_old_saved.address, 1)
-        prog.fpvar_exp_asm(m_old_saved.address, m_res.address + row, 1)
-
-        # 6. Subtract max: S[row] -= m_curr
-        prog.tile_row_sub_fp(S, m_old.address + row, row)
-
-        # 7. Exponentiate: P[row] = exp(S[row])
-        prog.tile_row_exp(S, row)
-
-        # 8. Sum probabilities
-        prog.tile_row_sum(sum_p_tmp.address, S, row)
-
-        # 9. Update accumulated sum: l_old[row] = l_old[row]*m_res[row] + sum_p
-        prog.fpvar_mul_asm(l_old.address + row, m_res.address + row, l_old.address + row, 1)
-        prog.fpvar_add_asm(l_old.address + row, sum_p_tmp.address, l_old.address + row, 1)
-
-    # Final normalization: P[row] /= l_old[row]
-    prog.fpvar_reci(l_old, inv_l)
-    for row in range(mlen):
-        prog.tile_row_mul_fp(S, inv_l.address + row, row)
+    # Reuse the flash-attention online-softmax state layout instead of
+    # allocating separate FPVars for m_old/m_res/l_old/inv_l.  At MLEN=256 the
+    # old FPVar-heavy lowering needed 1028 slots plus reserved constants and
+    # overflowed the 1024-slot FPRAM.  The shared layout uses exactly 3*MLEN
+    # slots at _ONLINE_SOFTMAX_FPSRAM_BASE and scalar FP registers for temps.
+    fp_sram_start = prog._ONLINE_SOFTMAX_FPSRAM_BASE
+    prog.emit(prog._reset_fpsram_asm(fp_sram_start, mlen, 2))  # m_old = -inf
+    prog.emit(prog._reset_fpsram_asm(fp_sram_start + 2 * mlen, mlen, 0))  # l_old = 0
+    prog.emit(
+        prog._online_softmax_asm(
+            mlen=mlen,
+            s_address=prog.get_vram_addr(S.name),
+            m_start_address=fp_sram_start,
+            scale=scale,
+            rows=mlen,
+        )
+    )
+    prog.final_scale_o(0, S, rows=mlen)
 
     return S

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from compiler.aten.plena.isa_compiler import IsaCompiler
 from compiler.aten.plena.program_attention import ProgramAttentionMixin
@@ -10,6 +11,40 @@ from compiler.aten.plena.program_fp_tile_ops import ProgramFPTileOpsMixin
 from compiler.aten.plena.program_matrix_ops import ProgramMatrixOpsMixin
 from compiler.aten.plena.program_tensors import ProgramTensorMixin
 from compiler.aten.plena.vars import FPVar, InputVar, TensorVar
+from compiler.utils.load_config import load_toml_config
+
+
+def _find_plena_settings_toml() -> Path | None:
+    env_path = os.environ.get("PLENA_SETTINGS_TOML")
+    if env_path:
+        return Path(env_path)
+
+    candidates = [Path.cwd(), *Path(__file__).resolve().parents]
+    for base in candidates:
+        path = base / "plena_settings.toml"
+        if path.exists():
+            return path
+    return None
+
+
+def _behavior_config_value(key: str, default: int) -> int:
+    settings_path = _find_plena_settings_toml()
+    if settings_path is None or not settings_path.exists():
+        return default
+
+    try:
+        config = load_toml_config(settings_path, "CONFIG", mode="BEHAVIOR")
+    except Exception:
+        return default
+
+    value = config.get(key, {})
+    if isinstance(value, dict):
+        value = value.get("value", default)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
 
 
 # ============================================================================
@@ -38,6 +73,8 @@ class PlenaCompiler(
         real_data_ratio: float = 1.125,
         unroll_loops: bool = False,
         mram_tile_capacity: int = 4,
+        hbm_v_prefetch_amount: int | None = None,
+        hbm_v_writeback_amount: int | None = None,
     ):
         """
         Args:
@@ -45,6 +82,12 @@ class PlenaCompiler(
             blen: Vector tile size (default 4)
             real_data_ratio: HBM storage ratio (MXFP8 format = 1.125)
             mram_tile_capacity: Number of mlen x mlen tiles that fit in MRAM.
+            hbm_v_prefetch_amount: H_PREFETCH_V transfer count. Defaults to
+                          BEHAVIOR.CONFIG.HBM_V_Prefetch_Amount in
+                          PLENA_SETTINGS_TOML / plena_settings.toml.
+            hbm_v_writeback_amount: H_STORE_V transfer count. Defaults to
+                          BEHAVIOR.CONFIG.HBM_V_Writeback_Amount in
+                          PLENA_SETTINGS_TOML / plena_settings.toml.
             unroll_loops: If True, unroll sub-projection and attention helper loops
                           at ASM-gen time to eliminate C_LOOP_START/END overhead.
                           Overridden by the ATEN_UNROLL env var ("1"=True, "0"=False).
@@ -61,6 +104,18 @@ class PlenaCompiler(
             unroll_loops=unroll_loops,
             mram_tile_capacity=mram_tile_capacity,
         )
+        if hbm_v_prefetch_amount is None:
+            hbm_v_prefetch_amount = _behavior_config_value("HBM_V_Prefetch_Amount", 4)
+        if hbm_v_writeback_amount is None:
+            hbm_v_writeback_amount = _behavior_config_value("HBM_V_Writeback_Amount", 4)
+        if hbm_v_prefetch_amount <= 0:
+            raise ValueError(f"hbm_v_prefetch_amount must be > 0, got {hbm_v_prefetch_amount}")
+        if hbm_v_writeback_amount <= 0:
+            raise ValueError(f"hbm_v_writeback_amount must be > 0, got {hbm_v_writeback_amount}")
+        self.hbm_v_prefetch_amount = hbm_v_prefetch_amount
+        self.hbm_v_writeback_amount = hbm_v_writeback_amount
+        self.hlen = _behavior_config_value("HLEN", mlen)
+        self.broadcast_amount = _behavior_config_value("BROADCAST_AMOUNT", max(1, mlen // max(1, self.hlen)))
 
         # HBM address auto-allocation
         self._next_hbm_addr: int = 0

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -151,15 +151,22 @@ class PlenaCompiler(
     def _allocate_hbm(self, hbm_size: int) -> int:
         """Allocate HBM range, preferring previously freed blocks.
 
-        All addresses returned are aligned to mlen*mlen, which the Rust
-        emulator's continous_write_delayed requires (src/main.rs:155).
+        Large allocations (>= mlen*mlen) are aligned to mlen*mlen because the
+        Rust emulator's continous_write_delayed requires it (src/main.rs:155).
+        Small allocations only need mlen alignment, preserving sliced-test layout.
         """
         m = self.mlen
         tile_bytes = m * m
+        # Only pad to mlen*mlen at large tile sizes where the Rust emulator's
+        # continous_write_delayed (main.rs:155) requires tile-index alignment.
+        # At MLEN=64/128 the HBM layout must match create_mem_for_sim's
+        # sequential write order, which does not insert gaps.
+        needs_tile_align = m >= 256
+
         best_idx = None
         best_waste = None
         for i, (addr, size) in enumerate(self._hbm_free_blocks):
-            aligned_addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
+            aligned_addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes if needs_tile_align else addr
             aligned_waste = aligned_addr - addr
             effective_size = size - aligned_waste
             if effective_size >= hbm_size:
@@ -170,21 +177,23 @@ class PlenaCompiler(
 
         if best_idx is not None:
             addr, block_size = self._hbm_free_blocks.pop(best_idx)
-            aligned_addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
-            # Return any pre-alignment gap as a free fragment
-            if aligned_addr > addr:
-                self._hbm_free_blocks.append((addr, aligned_addr - addr))
+            if needs_tile_align:
+                aligned_addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
+                if aligned_addr > addr:
+                    self._hbm_free_blocks.append((addr, aligned_addr - addr))
+            else:
+                aligned_addr = addr
             excess = block_size - (aligned_addr - addr) - hbm_size
             if excess > 0:
                 self._hbm_free_blocks.append((aligned_addr + hbm_size, excess))
             return aligned_addr
 
         addr = self._next_hbm_addr
-        # Ensure the start address is tile-aligned (first alloc starts at 0;
-        # recycled blocks could have left us misaligned).
-        addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
+        if needs_tile_align:
+            addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
         self._next_hbm_addr = ((addr + hbm_size + m - 1) // m) * m
-        self._next_hbm_addr = ((self._next_hbm_addr + tile_bytes - 1) // tile_bytes) * tile_bytes
+        if needs_tile_align:
+            self._next_hbm_addr = ((self._next_hbm_addr + tile_bytes - 1) // tile_bytes) * tile_bytes
         return addr
 
     def _recycle_hbm(self, hbm_addr: int, hbm_size: int):

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -149,31 +149,42 @@ class PlenaCompiler(
         return name
 
     def _allocate_hbm(self, hbm_size: int) -> int:
-        """Allocate HBM range, preferring previously freed blocks."""
+        """Allocate HBM range, preferring previously freed blocks.
+
+        All addresses returned are aligned to mlen*mlen, which the Rust
+        emulator's continous_write_delayed requires (src/main.rs:155).
+        """
+        m = self.mlen
+        tile_bytes = m * m
         best_idx = None
         best_waste = None
         for i, (addr, size) in enumerate(self._hbm_free_blocks):
-            if size >= hbm_size:
-                waste = size - hbm_size
+            aligned_addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
+            aligned_waste = aligned_addr - addr
+            effective_size = size - aligned_waste
+            if effective_size >= hbm_size:
+                waste = effective_size - hbm_size
                 if best_waste is None or waste < best_waste:
                     best_idx = i
                     best_waste = waste
 
         if best_idx is not None:
             addr, block_size = self._hbm_free_blocks.pop(best_idx)
-            # Return excess fragment to free list
-            excess = block_size - hbm_size
+            aligned_addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
+            # Return any pre-alignment gap as a free fragment
+            if aligned_addr > addr:
+                self._hbm_free_blocks.append((addr, aligned_addr - addr))
+            excess = block_size - (aligned_addr - addr) - hbm_size
             if excess > 0:
-                self._hbm_free_blocks.append((addr + hbm_size, excess))
-            return addr
+                self._hbm_free_blocks.append((aligned_addr + hbm_size, excess))
+            return aligned_addr
 
         addr = self._next_hbm_addr
-        m = self.mlen
+        # Ensure the start address is tile-aligned (first alloc starts at 0;
+        # recycled blocks could have left us misaligned).
+        addr = ((addr + tile_bytes - 1) // tile_bytes) * tile_bytes
         self._next_hbm_addr = ((addr + hbm_size + m - 1) // m) * m
-        # Rust emulator's continous_write_delayed requires HBM addresses
-        # aligned to mlen*mlen (65536 at MLEN=256). Pad the allocation end
-        # to this alignment so the next address is compatible.
-        self._next_hbm_addr = ((self._next_hbm_addr + m * m - 1) // (m * m)) * (m * m)
+        self._next_hbm_addr = ((self._next_hbm_addr + tile_bytes - 1) // tile_bytes) * tile_bytes
         return addr
 
     def _recycle_hbm(self, hbm_addr: int, hbm_size: int):

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -31,12 +31,20 @@ class PlenaCompiler(
     program-builder helpers on top. Operations eagerly emit ISA text.
     """
 
-    def __init__(self, mlen: int = 64, blen: int = 4, real_data_ratio: float = 1.125, unroll_loops: bool = False):
+    def __init__(
+        self,
+        mlen: int = 64,
+        blen: int = 4,
+        real_data_ratio: float = 1.125,
+        unroll_loops: bool = False,
+        mram_tile_capacity: int = 4,
+    ):
         """
         Args:
             mlen: Matrix tile size (default 64)
             blen: Vector tile size (default 4)
             real_data_ratio: HBM storage ratio (MXFP8 format = 1.125)
+            mram_tile_capacity: Number of mlen x mlen tiles that fit in MRAM.
             unroll_loops: If True, unroll sub-projection and attention helper loops
                           at ASM-gen time to eliminate C_LOOP_START/END overhead.
                           Overridden by the ATEN_UNROLL env var ("1"=True, "0"=False).
@@ -46,7 +54,13 @@ class PlenaCompiler(
             unroll_loops = True
         elif _env_unroll == "0":
             unroll_loops = False
-        super().__init__(mlen=mlen, blen=blen, real_data_ratio=real_data_ratio, unroll_loops=unroll_loops)
+        super().__init__(
+            mlen=mlen,
+            blen=blen,
+            real_data_ratio=real_data_ratio,
+            unroll_loops=unroll_loops,
+            mram_tile_capacity=mram_tile_capacity,
+        )
 
         # HBM address auto-allocation
         self._next_hbm_addr: int = 0

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -170,6 +170,10 @@ class PlenaCompiler(
         addr = self._next_hbm_addr
         m = self.mlen
         self._next_hbm_addr = ((addr + hbm_size + m - 1) // m) * m
+        # Rust emulator's continous_write_delayed requires HBM addresses
+        # aligned to mlen*mlen (65536 at MLEN=256). Pad the allocation end
+        # to this alignment so the next address is compatible.
+        self._next_hbm_addr = ((self._next_hbm_addr + m * m - 1) // (m * m)) * (m * m)
         return addr
 
     def _recycle_hbm(self, hbm_addr: int, hbm_size: int):

--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import math
+
+from compiler.asm_templates._imm import load_large_int
+
 
 class IsaAttentionMixin:
     # =========================================================================
@@ -15,6 +19,7 @@ class IsaAttentionMixin:
         m_start_address: int,
         scale: float = 1.0,
         rows: int | None = None,
+        valid_cols: int | None = None,
     ) -> str:
         """
         Online Softmax Computation.
@@ -37,6 +42,7 @@ class IsaAttentionMixin:
                 s_address=s_address,
                 m_start_address=m_start_address,
                 scale=scale,
+                valid_cols=valid_cols,
             )
 
         gp_regs = self.register_allocator.allocate_gp(5)
@@ -61,10 +67,19 @@ class IsaAttentionMixin:
         lines.append("; === Online Softmax ===")
 
         # Set address registers
-        lines.append(f"S_ADDI_INT gp{gp_s}, gp0, {s_address}")
-        lines.append(f"S_ADDI_INT gp{gp_m_addr}, gp0, {m_start_address}")
+        lines.extend(load_large_int(gp_s, s_address))
+        lines.extend(load_large_int(gp_m_addr, m_start_address))
         lines.append(f"S_ADDI_INT gp{gp_m_res_addr}, gp{gp_m_addr}, {mlen}")
         lines.append(f"S_ADDI_INT gp{gp_l_addr}, gp{gp_m_res_addr}, {mlen}")
+
+        mask_en = 0
+        if valid_cols is not None and valid_cols < mlen:
+            mask_unit = getattr(self, "hlen", mlen)
+            valid_lanes = max(1, math.ceil(valid_cols / mask_unit))
+            mask_bits = (1 << valid_lanes) - 1
+            lines.append(f"S_ADDI_INT gp{gp_loop}, gp0, {mask_bits}")
+            lines.append(f"C_SET_V_MASK_REG gp{gp_loop}")
+            mask_en = 1
 
         # scale factor is pre-loaded at FP SRAM addr 1 by the flash-attention driver.
         if scale != 1.0:
@@ -76,9 +91,9 @@ class IsaAttentionMixin:
         lines.append(f"S_ADD_FP f{fp_m_res}, f{fp_m_old}, f0")
 
         if scale != 1.0:
-            lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_scale}, 0")
+            lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_scale}, {mask_en}")
 
-        lines.append(f"V_RED_MAX f{fp_row_max}, gp{gp_s}, 0")
+        lines.append(f"V_RED_MAX f{fp_row_max}, gp{gp_s}, {mask_en}")
 
         # m_curr = max(row_max, m_old) — online softmax must retain the running max.
         lines.append(f"S_MAX_FP f{fp_m_old}, f{fp_row_max}, f{fp_m_old}")
@@ -89,13 +104,13 @@ class IsaAttentionMixin:
         lines.append(f"S_ST_FP f{fp_m_res}, gp{gp_m_res_addr}, 0")
         lines.append(f"S_ST_FP f{fp_m_old}, gp{gp_m_addr}, 0")
 
-        lines.append(f"V_SUB_VF gp{gp_s}, gp{gp_s}, f{fp_m_old}, 0, 0")
-        lines.append(f"V_EXP_V gp{gp_s}, gp{gp_s}, 0, 0")
+        lines.append(f"V_SUB_VF gp{gp_s}, gp{gp_s}, f{fp_m_old}, {mask_en}, 0")
+        lines.append(f"V_EXP_V gp{gp_s}, gp{gp_s}, {mask_en}, 0")
 
         lines.append(f"S_LD_FP f{fp_l_old}, gp{gp_l_addr}, 0")
 
         lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
-        lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, 0, 0")
+        lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
 
         lines.append(f"S_MUL_FP f{fp_l_old}, f{fp_l_old}, f{fp_m_res}")
         lines.append(f"S_ADD_FP f{fp_l_old}, f{fp_l_old}, f{fp_sum_p}")
@@ -117,13 +132,15 @@ class IsaAttentionMixin:
         s_address: int,
         m_start_address: int,
         scale: float = 1.0,
+        valid_cols: int | None = None,
     ) -> str:
         """Legacy Python-unrolled online softmax emission, kept for A/B comparisons."""
-        gp_regs = self.register_allocator.allocate_gp(4)
+        gp_regs = self.register_allocator.allocate_gp(5)
         gp_s = gp_regs[0]
         gp_m_addr = gp_regs[1]
         gp_m_res_addr = gp_regs[2]
         gp_l_addr = gp_regs[3]
+        gp_mask = gp_regs[4]
 
         fp_m_old = 1
         fp_m_res = 2
@@ -134,13 +151,22 @@ class IsaAttentionMixin:
 
         lines = []
         lines.append("; === Online Softmax ===")
-        lines.append(f"S_ADDI_INT gp{gp_s}, gp0, {s_address}")
-        lines.append(f"S_ADDI_INT gp{gp_m_addr}, gp0, {m_start_address}")
+        lines.extend(load_large_int(gp_s, s_address))
+        lines.extend(load_large_int(gp_m_addr, m_start_address))
         lines.append(f"S_ADDI_INT gp{gp_m_res_addr}, gp{gp_m_addr}, {mlen}")
         lines.append(f"S_ADDI_INT gp{gp_l_addr}, gp{gp_m_res_addr}, {mlen}")
 
         if scale != 1.0:
             lines.append(f"S_LD_FP f{fp_scale}, gp0, 1")
+
+        mask_en = 0
+        if valid_cols is not None and valid_cols < mlen:
+            mask_unit = getattr(self, "hlen", mlen)
+            valid_lanes = max(1, math.ceil(valid_cols / mask_unit))
+            mask_bits = (1 << valid_lanes) - 1
+            lines.append(f"S_ADDI_INT gp{gp_mask}, gp0, {mask_bits}")
+            lines.append(f"C_SET_V_MASK_REG gp{gp_mask}")
+            mask_en = 1
 
         for row in range(mlen):
             lines.append(f"; Row {row}")
@@ -148,9 +174,9 @@ class IsaAttentionMixin:
             lines.append(f"S_ADD_FP f{fp_m_res}, f{fp_m_old}, f0")
 
             if scale != 1.0:
-                lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_scale}, 0")
+                lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_scale}, {mask_en}")
 
-            lines.append(f"V_RED_MAX f{fp_row_max}, gp{gp_s}, 0")
+            lines.append(f"V_RED_MAX f{fp_row_max}, gp{gp_s}, {mask_en}")
 
             # m_curr = max(row_max, m_old) — online softmax must retain the running max.
             lines.append(f"S_MAX_FP f{fp_m_old}, f{fp_row_max}, f{fp_m_old}")
@@ -161,13 +187,13 @@ class IsaAttentionMixin:
             lines.append(f"S_ST_FP f{fp_m_res}, gp{gp_m_res_addr}, {row}")
             lines.append(f"S_ST_FP f{fp_m_old}, gp{gp_m_addr}, {row}")
 
-            lines.append(f"V_SUB_VF gp{gp_s}, gp{gp_s}, f{fp_m_old}, 0, 0")
-            lines.append(f"V_EXP_V gp{gp_s}, gp{gp_s}, 0, 0")
+            lines.append(f"V_SUB_VF gp{gp_s}, gp{gp_s}, f{fp_m_old}, {mask_en}, 0")
+            lines.append(f"V_EXP_V gp{gp_s}, gp{gp_s}, {mask_en}, 0")
 
             lines.append(f"S_LD_FP f{fp_l_old}, gp{gp_l_addr}, {row}")
 
             lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
-            lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, 0, 0")
+            lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
 
             lines.append(f"S_MUL_FP f{fp_l_old}, f{fp_l_old}, f{fp_m_res}")
             lines.append(f"S_ADD_FP f{fp_l_old}, f{fp_l_old}, f{fp_sum_p}")
@@ -202,8 +228,6 @@ class IsaAttentionMixin:
         column blocks; the outer loop iterates blocks, middle loop iterates blen-wide
         V columns within a block, inner loop iterates blen-wide P rows.
         """
-        assert head_dim % mlen == 0, f"head_dim ({head_dim}) must be multiple of mlen ({mlen})"
-
         if getattr(self, "unroll_attention", False):
             return self._pv_multiply_asm_unrolled(
                 mlen=mlen,
@@ -225,7 +249,7 @@ class IsaAttentionMixin:
         gp_v_loop = gp_regs[6]
         gp_p_loop = gp_regs[7]
 
-        num_v_col_blocks = head_dim // mlen
+        num_v_col_blocks = max(1, math.ceil(head_dim / mlen))
         tiles_per_mlen = mlen // blen
         p_row_groups = tiles_per_mlen if rows is None else max(1, min(tiles_per_mlen, (rows + blen - 1) // blen))
 
@@ -252,13 +276,13 @@ class IsaAttentionMixin:
             # column-block base offset = v_hbm_offset + v_col_block * mlen (elements).
             v_block_hbm_offset = v_hbm_offset + v_col_block * mlen
             lines.append(f"S_ADDI_INT gp{gp_v}, gp0, 0")
-            lines.append(f"S_ADDI_INT gp{gp_hbm}, gp0, {v_block_hbm_offset}")
+            lines.extend(load_large_int(gp_hbm, v_block_hbm_offset))
             lines.append(f"H_PREFETCH_M gp{gp_v}, gp{gp_hbm}, a{v_hbm_offset_reg}, 1, 1")
 
             pv_col_block_base = pv_address + v_col_block * mlen * mlen
-            lines.append(f"S_ADDI_INT gp{gp_pv_col_base}, gp0, {pv_col_block_base}")
+            lines.extend(load_large_int(gp_pv_col_base, pv_col_block_base))
             lines.append(f"C_LOOP_START gp{gp_v_loop}, {tiles_per_mlen}")
-            lines.append(f"S_ADDI_INT gp{gp_p}, gp0, {p_address}")
+            lines.extend(load_large_int(gp_p, p_address))
             lines.append(f"S_ADDI_INT gp{gp_pv}, gp{gp_pv_col_base}, 0")
             lines.append(f"C_LOOP_START gp{gp_p_loop}, {p_row_groups}")
             lines.append(f"M_MM 0, gp{gp_v}, gp{gp_p}")
@@ -291,7 +315,7 @@ class IsaAttentionMixin:
         gp_hbm = gp_regs[3]
         gp_stride = gp_regs[4]
 
-        num_v_col_blocks = head_dim // mlen
+        num_v_col_blocks = max(1, math.ceil(head_dim / mlen))
 
         lines = []
         lines.append("; === PV Multiply (P @ V) using M_MM ===")
@@ -307,7 +331,7 @@ class IsaAttentionMixin:
             )
             v_block_hbm_offset = v_hbm_offset + v_col_block * mlen
             lines.append(f"S_ADDI_INT gp{gp_v}, gp0, 0")
-            lines.append(f"S_ADDI_INT gp{gp_hbm}, gp0, {v_block_hbm_offset}")
+            lines.extend(load_large_int(gp_hbm, v_block_hbm_offset))
             lines.append(f"H_PREFETCH_M gp{gp_v}, gp{gp_hbm}, a{v_hbm_offset_reg}, 1, 1")
 
             for v_col in range(mlen // blen):
@@ -317,11 +341,11 @@ class IsaAttentionMixin:
 
                 for p_row in range(mlen // blen):
                     p_row_addr = p_address + p_row * blen * mlen
-                    lines.append(f"S_ADDI_INT gp{gp_p}, gp0, {p_row_addr}")
+                    lines.extend(load_large_int(gp_p, p_row_addr))
                     lines.append(f"M_MM 0, gp{gp_v}, gp{gp_p}")
 
                     pv_offset = v_col_block * mlen * mlen + p_row * blen * mlen + v_col * blen
-                    lines.append(f"S_ADDI_INT gp{gp_pv}, gp0, {pv_address + pv_offset}")
+                    lines.extend(load_large_int(gp_pv, pv_address + pv_offset))
                     lines.append(f"M_MM_WO gp{gp_pv}, gp{gp_stride}, 0")
 
         self.register_allocator.free_gp(gp_regs)
@@ -338,8 +362,6 @@ class IsaAttentionMixin:
         rows: int | None = None,
     ) -> str:
         """Scale each row of O by m_res: O[row] *= m_res[row]."""
-        assert head_dim % mlen == 0, f"head_dim ({head_dim}) must be multiple of mlen ({mlen})"
-
         if getattr(self, "unroll_attention", False):
             return self._scale_o_asm_unrolled(
                 mlen=mlen,
@@ -357,7 +379,7 @@ class IsaAttentionMixin:
         gp_row_loop = gp_regs[3]
         fp_m_res = 1
 
-        num_col_blocks = head_dim // mlen
+        num_col_blocks = max(1, math.ceil(head_dim / mlen))
         loop_rows = mlen if rows is None else rows
 
         lines = []
@@ -367,8 +389,8 @@ class IsaAttentionMixin:
 
         if num_col_blocks == 1:
             o_addr = o_address + row_offset * mlen
-            lines.append(f"S_ADDI_INT gp{gp_m_res}, gp0, {m_res_address}")
-            lines.append(f"S_ADDI_INT gp{gp_o}, gp0, {o_addr}")
+            lines.extend(load_large_int(gp_m_res, m_res_address))
+            lines.extend(load_large_int(gp_o, o_addr))
             lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_m_res}, gp{gp_m_res}, 0")
             lines.append(f"V_MUL_VF gp{gp_o}, gp{gp_o}, f{fp_m_res}, 0")
@@ -378,8 +400,8 @@ class IsaAttentionMixin:
         else:
             gp_col_loop = self.register_allocator.allocate_gp(1)[0]
             o_addr = o_address + row_offset * mlen
-            lines.append(f"S_ADDI_INT gp{gp_m_res}, gp0, {m_res_address}")
-            lines.append(f"S_ADDI_INT gp{gp_o_row_base}, gp0, {o_addr}")
+            lines.extend(load_large_int(gp_m_res, m_res_address))
+            lines.extend(load_large_int(gp_o_row_base, o_addr))
             lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_m_res}, gp{gp_m_res}, 0")
             lines.append(f"S_ADDI_INT gp{gp_o}, gp{gp_o_row_base}, 0")
@@ -410,13 +432,13 @@ class IsaAttentionMixin:
         gp_o = gp_regs[1]
         fp_m_res = 1
 
-        num_col_blocks = head_dim // mlen
+        num_col_blocks = max(1, math.ceil(head_dim / mlen))
 
         lines = []
         lines.append("; === Scale O by m_res ===")
         lines.append(f"; head_dim = {head_dim}, {num_col_blocks} mlen-blocks per row")
         lines.append(f"; seq_len = {seq_len}, row_offset = {row_offset}")
-        lines.append(f"S_ADDI_INT gp{gp_m_res}, gp0, {m_res_address}")
+        lines.extend(load_large_int(gp_m_res, m_res_address))
 
         for row in range(mlen):
             lines.append(f"S_LD_FP f{fp_m_res}, gp{gp_m_res}, {row}")
@@ -424,7 +446,7 @@ class IsaAttentionMixin:
 
             for col_block in range(num_col_blocks):
                 o_addr = o_address + col_block * seq_len * mlen + actual_row * mlen
-                lines.append(f"S_ADDI_INT gp{gp_o}, gp0, {o_addr}")
+                lines.extend(load_large_int(gp_o, o_addr))
                 lines.append(f"V_MUL_VF gp{gp_o}, gp{gp_o}, f{fp_m_res}, 0")
 
         self.register_allocator.free_gp(gp_regs)
@@ -440,13 +462,11 @@ class IsaAttentionMixin:
         row_offset: int = 0,
     ) -> str:
         """Accumulate PV into O: O[row] += PV[row]."""
-        assert head_dim % mlen == 0, f"head_dim ({head_dim}) must be multiple of mlen ({mlen})"
-
         gp_regs = self.register_allocator.allocate_gp(2)
         gp_o = gp_regs[0]
         gp_pv = gp_regs[1]
 
-        num_col_blocks = head_dim // mlen
+        num_col_blocks = max(1, math.ceil(head_dim / mlen))
 
         lines = []
         lines.append("; === Add PV to O ===")
@@ -460,8 +480,8 @@ class IsaAttentionMixin:
                 o_addr = o_address + col_block * seq_len * mlen + actual_row * mlen
                 pv_addr = pv_address + col_block * mlen * mlen + row * mlen
 
-                lines.append(f"S_ADDI_INT gp{gp_o}, gp0, {o_addr}")
-                lines.append(f"S_ADDI_INT gp{gp_pv}, gp0, {pv_addr}")
+                lines.extend(load_large_int(gp_o, o_addr))
+                lines.extend(load_large_int(gp_pv, pv_addr))
                 lines.append(f"V_ADD_VV gp{gp_o}, gp{gp_o}, gp{gp_pv}, 0")
 
         self.register_allocator.free_gp(gp_regs)
@@ -483,8 +503,6 @@ class IsaAttentionMixin:
         V_MUL_VF processes mlen elements at a time; when head_dim > mlen,
         each row is split into head_dim // mlen mlen-wide blocks.
         """
-        assert head_dim % mlen == 0, f"head_dim ({head_dim}) must be multiple of mlen ({mlen})"
-
         if getattr(self, "unroll_attention", False):
             return self._final_scaling_asm_unrolled(
                 mlen=mlen,
@@ -502,7 +520,7 @@ class IsaAttentionMixin:
         gp_row_loop = gp_regs[3]
         fp_l = 1
 
-        num_col_blocks = head_dim // mlen
+        num_col_blocks = max(1, math.ceil(head_dim / mlen))
         loop_rows = mlen if rows is None else rows
 
         lines = []
@@ -513,8 +531,8 @@ class IsaAttentionMixin:
 
         if num_col_blocks == 1:
             o_addr = o_address + row_offset * mlen
-            lines.append(f"S_ADDI_INT gp{gp_l}, gp0, {l_address}")
-            lines.append(f"S_ADDI_INT gp{gp_o}, gp0, {o_addr}")
+            lines.extend(load_large_int(gp_l, l_address))
+            lines.extend(load_large_int(gp_o, o_addr))
             lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_l}, gp{gp_l}, 0")
             lines.append(f"S_RECI_FP f{fp_l}, f{fp_l}, 0")
@@ -525,8 +543,8 @@ class IsaAttentionMixin:
         else:
             gp_col_loop = self.register_allocator.allocate_gp(1)[0]
             o_addr = o_address + row_offset * mlen
-            lines.append(f"S_ADDI_INT gp{gp_l}, gp0, {l_address}")
-            lines.append(f"S_ADDI_INT gp{gp_o_row_base}, gp0, {o_addr}")
+            lines.extend(load_large_int(gp_l, l_address))
+            lines.extend(load_large_int(gp_o_row_base, o_addr))
             lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_l}, gp{gp_l}, 0")
             lines.append(f"S_RECI_FP f{fp_l}, f{fp_l}, 0")
@@ -558,14 +576,14 @@ class IsaAttentionMixin:
         gp_o = gp_regs[1]
         fp_l = 1
 
-        num_col_blocks = head_dim // mlen
+        num_col_blocks = max(1, math.ceil(head_dim / mlen))
 
         lines = []
         lines.append("; === Final Scaling O = O / l ===")
         lines.append(f"; head_dim = {head_dim}, {num_col_blocks} mlen-blocks per row")
         lines.append("; Storage layout: (seq_len, mlen, head_dim/mlen), column-block major")
         lines.append(f"; seq_len = {seq_len}, row_offset = {row_offset}")
-        lines.append(f"S_ADDI_INT gp{gp_l}, gp0, {l_address}")
+        lines.extend(load_large_int(gp_l, l_address))
 
         for row in range(mlen):
             lines.append(f"S_LD_FP f{fp_l}, gp{gp_l}, {row}")
@@ -574,7 +592,7 @@ class IsaAttentionMixin:
 
             for col_block in range(num_col_blocks):
                 o_addr = o_address + col_block * seq_len * mlen + actual_row * mlen
-                lines.append(f"S_ADDI_INT gp{gp_o}, gp0, {o_addr}")
+                lines.extend(load_large_int(gp_o, o_addr))
                 lines.append(f"V_MUL_VF gp{gp_o}, gp{gp_o}, f{fp_l}, 0")
 
         self.register_allocator.free_gp(gp_regs)
@@ -642,13 +660,13 @@ class IsaAttentionMixin:
                 actual_row = row_offset + row
                 for col_block in range(num_col_blocks):
                     addr = start_address + col_block * total_rows * mlen + actual_row * mlen
-                    lines.append(f"S_ADDI_INT gp{gp_addr}, gp0, {addr}")
+                    lines.extend(load_large_int(gp_addr, addr))
                     lines.append(f"V_MUL_VF gp{gp_addr}, gp{gp_addr}, f0, 0")
         else:
             for col_block in range(num_col_blocks):
                 addr = start_address + col_block * total_rows * mlen + row_offset * mlen
                 lines.append(f"; Column block {col_block}")
-                lines.append(f"S_ADDI_INT gp{gp_addr}, gp0, {addr}")
+                lines.extend(load_large_int(gp_addr, addr))
                 lines.append(f"C_LOOP_START gp{gp_loop}, {rows}")
                 lines.append(f"V_MUL_VF gp{gp_addr}, gp{gp_addr}, f0, 0")
                 lines.append(f"S_ADDI_INT gp{gp_addr}, gp{gp_addr}, {mlen}")
@@ -702,6 +720,7 @@ class IsaAttentionMixin:
         s_block_matrix: str,
         scale: float,
         rows: int | None = None,
+        valid_cols: int | None = None,
     ) -> str:
         """
         Run Online Softmax on one S block.
@@ -723,6 +742,7 @@ class IsaAttentionMixin:
             m_start_address=m_start_address,
             scale=scale,
             rows=rows,
+            valid_cols=valid_cols,
         )
 
         return self._emit(isa_code)

--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -93,6 +93,9 @@ class IsaAttentionMixin:
         if scale != 1.0:
             lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_scale}, {mask_en}")
 
+        # V_RED_MAX accumulates into its destination FP register in the
+        # emulator, so clear the per-row max accumulator before each row.
+        lines.append(f"S_LD_FP f{fp_row_max}, gp0, 2")
         lines.append(f"V_RED_MAX f{fp_row_max}, gp{gp_s}, {mask_en}")
 
         # m_curr = max(row_max, m_old) — online softmax must retain the running max.
@@ -176,6 +179,7 @@ class IsaAttentionMixin:
             if scale != 1.0:
                 lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_scale}, {mask_en}")
 
+            lines.append(f"S_LD_FP f{fp_row_max}, gp0, 2")
             lines.append(f"V_RED_MAX f{fp_row_max}, gp{gp_s}, {mask_en}")
 
             # m_curr = max(row_max, m_old) — online softmax must retain the running max.

--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -14,6 +14,7 @@ class IsaAttentionMixin:
         s_address: int,
         m_start_address: int,
         scale: float = 1.0,
+        rows: int | None = None,
     ) -> str:
         """
         Online Softmax Computation.
@@ -69,7 +70,8 @@ class IsaAttentionMixin:
         if scale != 1.0:
             lines.append(f"S_LD_FP f{fp_scale}, gp0, 1")
 
-        lines.append(f"C_LOOP_START gp{gp_loop}, {mlen}")
+        loop_rows = mlen if rows is None else rows
+        lines.append(f"C_LOOP_START gp{gp_loop}, {loop_rows}")
         lines.append(f"S_LD_FP f{fp_m_old}, gp{gp_m_addr}, 0")
         lines.append(f"S_ADD_FP f{fp_m_res}, f{fp_m_old}, f0")
 
@@ -186,6 +188,7 @@ class IsaAttentionMixin:
         v_hbm_offset_reg: int,
         v_hbm_offset: int,
         pv_address: int,
+        rows: int | None = None,
     ) -> str:
         """
         Compute PV = P @ V via M_MM.
@@ -224,6 +227,7 @@ class IsaAttentionMixin:
 
         num_v_col_blocks = head_dim // mlen
         tiles_per_mlen = mlen // blen
+        p_row_groups = tiles_per_mlen if rows is None else max(1, min(tiles_per_mlen, (rows + blen - 1) // blen))
 
         lines = []
         lines.append("; === PV Multiply (P @ V) using M_MM ===")
@@ -256,7 +260,7 @@ class IsaAttentionMixin:
             lines.append(f"C_LOOP_START gp{gp_v_loop}, {tiles_per_mlen}")
             lines.append(f"S_ADDI_INT gp{gp_p}, gp0, {p_address}")
             lines.append(f"S_ADDI_INT gp{gp_pv}, gp{gp_pv_col_base}, 0")
-            lines.append(f"C_LOOP_START gp{gp_p_loop}, {tiles_per_mlen}")
+            lines.append(f"C_LOOP_START gp{gp_p_loop}, {p_row_groups}")
             lines.append(f"M_MM 0, gp{gp_v}, gp{gp_p}")
             lines.append(f"M_MM_WO gp{gp_pv}, gp{gp_stride}, 0")
             lines.append(f"S_ADDI_INT gp{gp_p}, gp{gp_p}, {blen * mlen}")
@@ -331,6 +335,7 @@ class IsaAttentionMixin:
         m_res_address: int,
         o_address: int,
         row_offset: int = 0,
+        rows: int | None = None,
     ) -> str:
         """Scale each row of O by m_res: O[row] *= m_res[row]."""
         assert head_dim % mlen == 0, f"head_dim ({head_dim}) must be multiple of mlen ({mlen})"
@@ -353,6 +358,7 @@ class IsaAttentionMixin:
         fp_m_res = 1
 
         num_col_blocks = head_dim // mlen
+        loop_rows = mlen if rows is None else rows
 
         lines = []
         lines.append("; === Scale O by m_res ===")
@@ -363,7 +369,7 @@ class IsaAttentionMixin:
             o_addr = o_address + row_offset * mlen
             lines.append(f"S_ADDI_INT gp{gp_m_res}, gp0, {m_res_address}")
             lines.append(f"S_ADDI_INT gp{gp_o}, gp0, {o_addr}")
-            lines.append(f"C_LOOP_START gp{gp_row_loop}, {mlen}")
+            lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_m_res}, gp{gp_m_res}, 0")
             lines.append(f"V_MUL_VF gp{gp_o}, gp{gp_o}, f{fp_m_res}, 0")
             lines.append(f"S_ADDI_INT gp{gp_m_res}, gp{gp_m_res}, 1")
@@ -374,7 +380,7 @@ class IsaAttentionMixin:
             o_addr = o_address + row_offset * mlen
             lines.append(f"S_ADDI_INT gp{gp_m_res}, gp0, {m_res_address}")
             lines.append(f"S_ADDI_INT gp{gp_o_row_base}, gp0, {o_addr}")
-            lines.append(f"C_LOOP_START gp{gp_row_loop}, {mlen}")
+            lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_m_res}, gp{gp_m_res}, 0")
             lines.append(f"S_ADDI_INT gp{gp_o}, gp{gp_o_row_base}, 0")
             lines.append(f"C_LOOP_START gp{gp_col_loop}, {num_col_blocks}")
@@ -469,6 +475,7 @@ class IsaAttentionMixin:
         l_address: int,
         o_address: int,
         row_offset: int = 0,
+        rows: int | None = None,
     ) -> str:
         """
         Final scaling: O[row] /= l[row].
@@ -496,6 +503,7 @@ class IsaAttentionMixin:
         fp_l = 1
 
         num_col_blocks = head_dim // mlen
+        loop_rows = mlen if rows is None else rows
 
         lines = []
         lines.append("; === Final Scaling O = O / l ===")
@@ -507,7 +515,7 @@ class IsaAttentionMixin:
             o_addr = o_address + row_offset * mlen
             lines.append(f"S_ADDI_INT gp{gp_l}, gp0, {l_address}")
             lines.append(f"S_ADDI_INT gp{gp_o}, gp0, {o_addr}")
-            lines.append(f"C_LOOP_START gp{gp_row_loop}, {mlen}")
+            lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_l}, gp{gp_l}, 0")
             lines.append(f"S_RECI_FP f{fp_l}, f{fp_l}, 0")
             lines.append(f"V_MUL_VF gp{gp_o}, gp{gp_o}, f{fp_l}, 0")
@@ -519,7 +527,7 @@ class IsaAttentionMixin:
             o_addr = o_address + row_offset * mlen
             lines.append(f"S_ADDI_INT gp{gp_l}, gp0, {l_address}")
             lines.append(f"S_ADDI_INT gp{gp_o_row_base}, gp0, {o_addr}")
-            lines.append(f"C_LOOP_START gp{gp_row_loop}, {mlen}")
+            lines.append(f"C_LOOP_START gp{gp_row_loop}, {loop_rows}")
             lines.append(f"S_LD_FP f{fp_l}, gp{gp_l}, 0")
             lines.append(f"S_RECI_FP f{fp_l}, f{fp_l}, 0")
             lines.append(f"S_ADDI_INT gp{gp_o}, gp{gp_o_row_base}, 0")
@@ -659,6 +667,7 @@ class IsaAttentionMixin:
         o_matrix: str,
         seq_len: int,
         head_dim: int,
+        rows: int | None = None,
     ) -> str:
         """
         Initialize Online Softmax state for Q block q_idx:
@@ -670,6 +679,7 @@ class IsaAttentionMixin:
 
         o_info = self[o_matrix]
         o_vram_addr = o_info.vram_addr
+        physical_seq_len = o_info.physical_shape[0]
         row_offset = q_idx * self.mlen
 
         isa_code = f"; === Init Online Softmax for Q block {q_idx} ===\n"
@@ -678,9 +688,9 @@ class IsaAttentionMixin:
         isa_code += self._reset_fpsram_asm(l_addr, self.mlen, 0)  # slot 0 = 0.0
         isa_code += self._reset_vram_asm(
             start_address=o_vram_addr,
-            rows=self.mlen,
+            rows=self.mlen if rows is None else rows,
             cols=head_dim,
-            total_rows=seq_len,
+            total_rows=physical_seq_len,
             mlen=self.mlen,
             row_offset=row_offset,
         )
@@ -691,6 +701,7 @@ class IsaAttentionMixin:
         self,
         s_block_matrix: str,
         scale: float,
+        rows: int | None = None,
     ) -> str:
         """
         Run Online Softmax on one S block.
@@ -707,7 +718,11 @@ class IsaAttentionMixin:
 
         isa_code = f"; === Online Softmax Block {s_block_matrix} ===\n"
         isa_code += self._online_softmax_asm(
-            mlen=self.mlen, s_address=s_address, m_start_address=m_start_address, scale=scale
+            mlen=self.mlen,
+            s_address=s_address,
+            m_start_address=m_start_address,
+            scale=scale,
+            rows=rows,
         )
 
         return self._emit(isa_code)
@@ -719,6 +734,7 @@ class IsaAttentionMixin:
         k_idx: int,
         pv_matrix: str,
         head_dim: int,
+        rows: int | None = None,
     ) -> str:
         """
         Compute PV = P @ V[k_idx].
@@ -733,7 +749,8 @@ class IsaAttentionMixin:
         pv_address = pv_info.vram_addr
 
         v_layout = self.get_hbm_layout(v_sub_matrix)
-        v_hbm_offset = k_idx * self.mlen * head_dim
+        physical_head_dim = (v_layout.physical_shape or v_layout.full_shape)[1]
+        v_hbm_offset = k_idx * self.mlen * physical_head_dim
 
         isa_code = f"; === Compute PV = P @ V[k_idx={k_idx}] ===\n"
 
@@ -755,6 +772,7 @@ class IsaAttentionMixin:
             v_hbm_offset_reg=v_hbm_reg,
             v_hbm_offset=v_hbm_offset,
             pv_address=pv_address,
+            rows=rows,
         )
 
         self.register_allocator.free_gp(gp_regs)
@@ -768,10 +786,12 @@ class IsaAttentionMixin:
         q_idx: int,
         seq_len: int,
         head_dim: int,
+        rows: int | None = None,
     ) -> str:
         """Scale the current row block of O by m_res: O[q_idx] *= m_res."""
         o_info = self[o_matrix]
         o_address = o_info.vram_addr
+        physical_seq_len = o_info.physical_shape[0]
 
         fp_sram_start = self._ONLINE_SOFTMAX_FPSRAM_BASE
         m_res_addr = fp_sram_start + self.mlen
@@ -782,10 +802,11 @@ class IsaAttentionMixin:
         isa_code += self._scale_o_asm(
             mlen=self.mlen,
             head_dim=head_dim,
-            seq_len=seq_len,
+            seq_len=physical_seq_len,
             m_res_address=m_res_addr,
             o_address=o_address,
             row_offset=row_offset,
+            rows=rows,
         )
 
         return self._emit(isa_code)
@@ -796,10 +817,12 @@ class IsaAttentionMixin:
         o_matrix: str,
         seq_len: int,
         head_dim: int,
+        rows: int | None = None,
     ) -> str:
         """Final scaling: O[q_idx] /= l."""
         o_info = self[o_matrix]
         o_address = o_info.vram_addr
+        physical_seq_len = o_info.physical_shape[0]
 
         fp_sram_start = self._ONLINE_SOFTMAX_FPSRAM_BASE
         l_addr = fp_sram_start + 2 * self.mlen
@@ -810,10 +833,11 @@ class IsaAttentionMixin:
         isa_code += self._final_scaling_asm(
             mlen=self.mlen,
             head_dim=head_dim,
-            seq_len=seq_len,
+            seq_len=physical_seq_len,
             l_address=l_addr,
             o_address=o_address,
             row_offset=row_offset,
+            rows=rows,
         )
 
         return self._emit(isa_code)

--- a/aten/plena/isa_compiler.py
+++ b/aten/plena/isa_compiler.py
@@ -36,9 +36,21 @@ class IsaCompiler(
 
     _ONLINE_SOFTMAX_FPSRAM_BASE = 10
 
-    def __init__(self, mlen: int = 64, blen: int = 4, real_data_ratio: float = 1.125, unroll_loops: bool = False):
+    def __init__(
+        self,
+        mlen: int = 64,
+        blen: int = 4,
+        real_data_ratio: float = 1.125,
+        unroll_loops: bool = False,
+        mram_tile_capacity: int = 4,
+    ):
         # MemoryStateMixin.__init__ sets dimensions, layout tables, and memory allocators.
-        super().__init__(mlen=mlen, blen=blen, unroll_loops=unroll_loops)
+        super().__init__(
+            mlen=mlen,
+            blen=blen,
+            unroll_loops=unroll_loops,
+            mram_tile_capacity=mram_tile_capacity,
+        )
         self.real_data_ratio = real_data_ratio
         self.register_allocator = RegisterAllocator()
         self.generated_code = ""

--- a/aten/plena/isa_compiler.py
+++ b/aten/plena/isa_compiler.py
@@ -61,7 +61,7 @@ class IsaCompiler(
         hbm_object_name: str,
         vram_object_name: str,
         vlen: int = 64,
-        preload_len: int = 4,
+        preload_len: int | None = None,
     ) -> str:
         """
         Load a Batch tensor from HBM to VRAM.
@@ -72,6 +72,9 @@ class IsaCompiler(
 
         Order (matters): allocate VRAM → register in symbol table → emit ISA.
         """
+        if preload_len is None:
+            preload_len = getattr(self, "hbm_v_prefetch_amount", 4)
+
         hbm_layout = self.get_hbm_layout(hbm_object_name)
         logical_h, logical_w = hbm_layout.full_shape
         h, w = hbm_layout.physical_shape or hbm_layout.full_shape
@@ -128,7 +131,7 @@ class IsaCompiler(
         hbm_addr_reg: int | None = None,
         vlen: int = 64,
         precision: int = 0,  # 0 = Activation, 1 = KeyValue
-        store_amount: int = 4,  # HBM_V_Writeback_Amount
+        store_amount: int | None = None,  # HBM_V_Writeback_Amount
     ) -> str:
         """
         Write tensor from VRAM back to HBM.
@@ -137,6 +140,9 @@ class IsaCompiler(
         downstream ops (e.g., QK^T) can read them from HBM. Emits
         ``store_act_asm`` for tensors of any supported size.
         """
+        if store_amount is None:
+            store_amount = getattr(self, "hbm_v_writeback_amount", 4)
+
         if tensor_name not in self:
             raise KeyError(f"Tensor '{tensor_name}' not found in symbol table")
 
@@ -242,7 +248,10 @@ class IsaCompiler(
         if tensor_info.vram_addr is None:
             raise ValueError(f"Tensor '{tensor_name}' has no VRAM address")
 
-        batch_size, hidden_dim = tensor_info.shape
+        logical_batch_size, logical_hidden_dim = tensor_info.shape
+        physical_batch_size, physical_hidden_dim = tensor_info.physical_shape
+        batch_size = physical_batch_size or logical_batch_size
+        hidden_dim = physical_hidden_dim or logical_hidden_dim
         if vlen is None:
             vlen = self.mlen
         if hidden_dim % vlen != 0:
@@ -260,7 +269,11 @@ class IsaCompiler(
             scratchpad_vram_addr = self.vram_allocator.allocate(vlen, name=temp_scratchpad_name)
 
         try:
-            isa_code = f"; Normalize ({mode}) {tensor_name}, shape=({batch_size}, {hidden_dim})\n"
+            isa_code = (
+                f"; Normalize ({mode}) {tensor_name}, "
+                f"logical=({logical_batch_size}, {logical_hidden_dim}) "
+                f"physical=({batch_size}, {hidden_dim})\n"
+            )
             if mode == "rms":
                 isa_code += rms_norm_asm(
                     _eps_offset=eps_offset,
@@ -311,8 +324,10 @@ class IsaCompiler(
         if x_info.vram_addr is None:
             raise ValueError(f"Tensor '{x_name}' has no VRAM address")
 
-        seq_len, head_dim = x_info.shape
+        seq_len, logical_head_dim = x_info.shape
         vlen = self.mlen
+        physical_head_dim = x_info.physical_shape[1] if x_info.physical_shape != (0, 0) else logical_head_dim
+        head_dim = physical_head_dim if physical_head_dim >= logical_head_dim else logical_head_dim
 
         if head_dim % vlen != 0:
             raise ValueError(f"head_dim ({head_dim}) must be divisible by vlen ({vlen}) for rope")
@@ -411,6 +426,7 @@ class IsaCompiler(
         name: str,
         hbm_addr: int,
         shape: tuple[int, int],
+        physical_shape: tuple[int, int] | None = None,
         real_data_ratio: float = 1.125,
     ):
         """Ensure HBM matrix layout exists."""
@@ -420,10 +436,16 @@ class IsaCompiler(
             name=name,
             hbm_addr=hbm_addr,
             shape=shape,
+            physical_shape=physical_shape,
             real_data_ratio=real_data_ratio,
         )
 
-    def ensure_vram_matrix_layout(self, name: str, shape: tuple[int, int]):
+    def ensure_vram_matrix_layout(
+        self,
+        name: str,
+        shape: tuple[int, int],
+        physical_shape: tuple[int, int] | None = None,
+    ):
         """Ensure VRAM matrix layout exists for an already allocated VRAM object."""
         if name in self.vram_matrices:
             return
@@ -431,6 +453,7 @@ class IsaCompiler(
         self.add_vram_object(
             name=name,
             shape=shape,
+            physical_shape=physical_shape,
             vram_addr=vram_addr,
             allocate_if_none=False,
         )

--- a/aten/plena/isa_compiler.py
+++ b/aten/plena/isa_compiler.py
@@ -73,13 +73,15 @@ class IsaCompiler(
         Order (matters): allocate VRAM → register in symbol table → emit ISA.
         """
         hbm_layout = self.get_hbm_layout(hbm_object_name)
-        h, w = hbm_layout.full_shape
+        logical_h, logical_w = hbm_layout.full_shape
+        h, w = hbm_layout.physical_shape or hbm_layout.full_shape
         hbm_addr = hbm_layout.hbm_base_addr
         size = h * w
         vram_base = self.vram_allocator.allocate(size, name=vram_object_name)
         self.add_vram_object(
             name=vram_object_name,
-            shape=(h, w),
+            shape=(logical_h, logical_w),
+            physical_shape=(h, w),
             vram_addr=vram_base,
             dtype="fp16",
             kind="Batch",
@@ -155,8 +157,8 @@ class IsaCompiler(
             else:
                 raise ValueError(f"Tensor '{tensor_name}' has no HBM address. Please specify hbm_addr.")
 
-        batch_size = tensor_info.shape[0]
-        hidden_size = tensor_info.shape[1]
+        batch_size = tensor_info.physical_shape[0] if tensor_info.physical_shape != (0, 0) else tensor_info.shape[0]
+        hidden_size = tensor_info.physical_shape[1] if tensor_info.physical_shape != (0, 0) else tensor_info.shape[1]
 
         isa_code = f"; Store {tensor_name} from VRAM to HBM\n"
         isa_code += f"; VRAM[{tensor_info.vram_addr}] -> HBM[{hbm_addr}], shape=({batch_size}, {hidden_size})\n"
@@ -203,7 +205,8 @@ class IsaCompiler(
             self.add_hbm_object(
                 name=hbm_object_name,
                 hbm_addr=hbm_addr,
-                shape=(batch_size, hidden_size),
+                shape=tensor_info.shape,
+                physical_shape=(batch_size, hidden_size),
             )
 
         return self._emit(isa_code)
@@ -356,6 +359,7 @@ class IsaCompiler(
         name: str,
         hbm_addr: int,
         shape: tuple[int, int],
+        physical_shape: tuple[int, int] | None = None,
         real_data_ratio: float = 1.125,
     ):
         """Register an HBM object and build its HBM layout.
@@ -368,6 +372,7 @@ class IsaCompiler(
             self,
             name=name,
             shape=shape,
+            physical_shape=physical_shape,
             hbm_addr=hbm_addr,
             real_data_ratio=real_data_ratio,
         )

--- a/aten/plena/isa_matrix.py
+++ b/aten/plena/isa_matrix.py
@@ -396,14 +396,14 @@ class IsaMatrixMixin:
 
         if self.unroll_loops:
             for i in range(self.mlen):
-                lines.append(f"S_ADDI_INT gp{gp_dst}, gp0, {target_block.vram_addr + i * self.mlen}")
-                lines.append(f"S_ADDI_INT gp{gp_src1}, gp0, {src1_block.vram_addr + i * self.mlen}")
-                lines.append(f"S_ADDI_INT gp{gp_src2}, gp0, {src2_block.vram_addr + i * self.mlen}")
+                lines.extend(load_large_int(gp_dst, target_block.vram_addr + i * self.mlen))
+                lines.extend(load_large_int(gp_src1, src1_block.vram_addr + i * self.mlen))
+                lines.extend(load_large_int(gp_src2, src2_block.vram_addr + i * self.mlen))
                 lines.append(f"V_ADD_VV gp{gp_dst}, gp{gp_src1}, gp{gp_src2}, 0")
         else:
-            lines.append(f"S_ADDI_INT gp{gp_dst}, gp0, {target_block.vram_addr}")
-            lines.append(f"S_ADDI_INT gp{gp_src1}, gp0, {src1_block.vram_addr}")
-            lines.append(f"S_ADDI_INT gp{gp_src2}, gp0, {src2_block.vram_addr}")
+            lines.extend(load_large_int(gp_dst, target_block.vram_addr))
+            lines.extend(load_large_int(gp_src1, src1_block.vram_addr))
+            lines.extend(load_large_int(gp_src2, src2_block.vram_addr))
             lines.append(f"C_LOOP_START gp{gp_loop}, {self.mlen}")
             lines.append(f"V_ADD_VV gp{gp_dst}, gp{gp_src1}, gp{gp_src2}, 0")
             lines.append(f"S_ADDI_INT gp{gp_dst}, gp{gp_dst}, {self.mlen}")

--- a/aten/plena/isa_matrix.py
+++ b/aten/plena/isa_matrix.py
@@ -672,6 +672,69 @@ class IsaMatrixMixin:
         isa_code = "\n".join(lines) + "\n"
         return self._emit(isa_code)
 
+    def vram_matrix_mul(
+        self,
+        dst_matrix: str,
+        src_matrix: str,
+        dst_row_offset: int = 0,
+        src_row_offset: int = 0,
+        num_rows: int | None = None,
+    ) -> str:
+        """General VRAM Matrix Multiplication: dst[row_offset:] *= src."""
+        dst_info = self[dst_matrix]
+        src_info = self[src_matrix]
+
+        self._ensure_vram_matrix_layout(dst_matrix)
+        self._ensure_vram_matrix_layout(src_matrix)
+
+        dst_addr = dst_info.vram_addr
+        src_addr = src_info.vram_addr
+
+        dst_rows, dst_cols = dst_info.shape
+        src_rows, src_cols = src_info.shape
+        dst_physical_rows, dst_physical_cols = dst_info.physical_shape
+        src_physical_rows, src_physical_cols = src_info.physical_shape
+
+        if num_rows is None:
+            num_rows = src_rows
+
+        assert dst_cols == src_cols, f"Column mismatch: dst={dst_cols}, src={src_cols}"
+        assert dst_row_offset + num_rows <= dst_rows, (
+            f"dst row range out of bounds: offset={dst_row_offset}, num_rows={num_rows}, dst_rows={dst_rows}"
+        )
+        assert src_row_offset + num_rows <= src_rows, (
+            f"src row range out of bounds: offset={src_row_offset}, num_rows={num_rows}, src_rows={src_rows}"
+        )
+
+        lines = [
+            f"; === VRAM Matrix Mul: "
+            f"{dst_matrix}[{dst_row_offset}:{dst_row_offset + num_rows}] *= "
+            f"{src_matrix}[{src_row_offset}:{src_row_offset + num_rows}] ===",
+            f"; dst shape: {dst_info.shape}, src shape: {src_info.shape}",
+        ]
+
+        gp_regs = self.register_allocator.allocate_gp(2)
+        gp_dst = gp_regs[0]
+        gp_src = gp_regs[1]
+        num_col_blocks = dst_physical_cols // self.mlen
+        lines.append(f"; row-wise path: num_rows={num_rows}, num_col_blocks={num_col_blocks}")
+
+        for row in range(num_rows):
+            dst_actual_row = dst_row_offset + row
+            src_actual_row = src_row_offset + row
+
+            for col_block in range(num_col_blocks):
+                dst_block_addr = dst_addr + col_block * dst_physical_rows * self.mlen + dst_actual_row * self.mlen
+                src_block_addr = src_addr + col_block * src_physical_rows * self.mlen + src_actual_row * self.mlen
+
+                lines.extend(load_large_int(gp_dst, dst_block_addr))
+                lines.extend(load_large_int(gp_src, src_block_addr))
+                lines.append(f"V_MUL_VV gp{gp_dst}, gp{gp_dst}, gp{gp_src}, 0")
+        self.register_allocator.free_gp(gp_regs)
+
+        isa_code = "\n".join(lines) + "\n"
+        return self._emit(isa_code)
+
     def _target_tile_addr(self, target_matrix: str, target_row_idx: int, target_col_idx: int) -> tuple[int, int, int]:
         if target_matrix not in self:
             raise KeyError(f"Target matrix '{target_matrix}' not found. Use allocate_vram_matrix first.")

--- a/aten/plena/isa_matrix.py
+++ b/aten/plena/isa_matrix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 
+from compiler.asm_templates._imm import load_large_int
 from compiler.asm_templates import preload_addr_reg_asm
 from compiler.asm_templates.vram_sub_projection_asm import vram_sub_projection_asm_impl
 from compiler.aten.isa_builder import IsaBuilder, addr as areg, gp
@@ -41,7 +42,7 @@ class IsaMatrixMixin:
         return [1, 2, 3] if gp_regs is None else gp_regs
 
     def _emit_hbm_prefetch_setup(self, asm: IsaBuilder, layout, gp_scale: int, gp_stride: int) -> None:
-        rows, cols = layout.full_shape
+        rows, cols = layout.physical_shape or layout.full_shape
         asm.instr("S_ADDI_INT", gp(gp_scale), gp(0), rows * cols)
         asm.instr("C_SET_SCALE_REG", gp(gp_scale))
         asm.instr("S_ADDI_INT", gp(gp_stride), gp(0), cols)
@@ -663,8 +664,8 @@ class IsaMatrixMixin:
                     dst_block_addr = dst_addr + col_block * dst_physical_rows * self.mlen + dst_actual_row * self.mlen
                     src_block_addr = src_addr + col_block * src_physical_rows * self.mlen + src_actual_row * self.mlen
 
-                    lines.append(f"S_ADDI_INT gp{gp_dst}, gp0, {dst_block_addr}")
-                    lines.append(f"S_ADDI_INT gp{gp_src}, gp0, {src_block_addr}")
+                    lines.extend(load_large_int(gp_dst, dst_block_addr))
+                    lines.extend(load_large_int(gp_src, src_block_addr))
                     lines.append(f"V_ADD_VV gp{gp_dst}, gp{gp_dst}, gp{gp_src}, 0")
             self.register_allocator.free_gp(gp_regs)
 

--- a/aten/plena/isa_matrix.py
+++ b/aten/plena/isa_matrix.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 from compiler.asm_templates import preload_addr_reg_asm
 from compiler.asm_templates.vram_sub_projection_asm import vram_sub_projection_asm_impl
 from compiler.aten.isa_builder import IsaBuilder, addr as areg, gp
@@ -221,6 +223,7 @@ class IsaMatrixMixin:
         gp_regs: list[int],
         caller_name: str,
         unroll: bool | None = None,
+        row_loop_count: int | None = None,
     ) -> str:
         """Emit the shared projection loop after callers resolve operands."""
         do_unroll = self.unroll_loops if unroll is None else unroll
@@ -238,6 +241,7 @@ class IsaMatrixMixin:
             transposed=transposed,
             gp_regs=gp_regs,
             caller_name=caller_name,
+            row_loop_count=row_loop_count,
         )
 
     def vram_sub_projection_asm(
@@ -266,7 +270,9 @@ class IsaMatrixMixin:
                 f"got {num_hidden_blocks}"
             )
 
-        full_batch = vram_layout.full_shape[0]
+        full_batch = (vram_layout.physical_shape or vram_layout.full_shape)[0]
+        valid_rows = vram_row_blocks[k_block_start].valid_shape[0] if vram_row_blocks[k_block_start].valid_shape else self.mlen
+        row_loop_count = max(1, math.ceil(valid_rows / self.blen))
         vram_row_start_addr = vram_row_blocks[k_block_start].vram_addr
         mram_col_start_addr = self._loaded_mram_start(
             mram_col_blocks,
@@ -292,6 +298,7 @@ class IsaMatrixMixin:
             gp_regs=gp_regs,
             caller_name="vram_sub_projection_asm",
             unroll=unroll,
+            row_loop_count=row_loop_count,
         )
 
     def vram_sub_projection_T_asm(
@@ -315,7 +322,9 @@ class IsaMatrixMixin:
             )
 
         num_hidden_blocks = len(vram_row_blocks)
-        full_batch = vram_layout.full_shape[0]
+        full_batch = (vram_layout.physical_shape or vram_layout.full_shape)[0]
+        valid_rows = vram_row_blocks[0].valid_shape[0] if vram_row_blocks[0].valid_shape else self.mlen
+        row_loop_count = max(1, math.ceil(valid_rows / self.blen))
         vram_row_start_addr = vram_row_blocks[0].vram_addr
         mram_row_start_addr = self._loaded_mram_start(
             mram_row_blocks,
@@ -344,6 +353,7 @@ class IsaMatrixMixin:
             gp_regs=gp_regs,
             caller_name="vram_sub_projection_T_asm",
             unroll=unroll,
+            row_loop_count=row_loop_count,
         )
 
     def vram_block_add_asm(
@@ -470,14 +480,17 @@ class IsaMatrixMixin:
         rows: int,
         cols: int,
         strict: bool = True,
+        physical_shape: tuple[int, int] | None = None,
     ) -> int:
         """Allocate a VRAM matrix large enough to hold combined results of multiple sub-blocks. Returns the VRAM base address."""
-        size = rows * cols
+        physical_rows, physical_cols = physical_shape or (rows, cols)
+        size = physical_rows * physical_cols
         vram_addr = self.vram_allocator.allocate(size, name=name)
 
         self.add_vram_object(
             name=name,
             shape=(rows, cols),
+            physical_shape=(physical_rows, physical_cols),
             vram_addr=vram_addr,
             dtype="fp32",
             kind="VRAMMatrix",
@@ -485,7 +498,10 @@ class IsaMatrixMixin:
             strict=strict,
         )
 
-        isa_code = f"; Allocate VRAM Matrix {name}: ({rows}, {cols}) at VRAM[{vram_addr}]\n"
+        isa_code = (
+            f"; Allocate VRAM Matrix {name}: logical=({rows}, {cols}) "
+            f"physical=({physical_rows}, {physical_cols}) at VRAM[{vram_addr}]\n"
+        )
         self._emit(isa_code)
 
         return vram_addr
@@ -505,7 +521,9 @@ class IsaMatrixMixin:
             self.register_vram_matrix(
                 name=matrix_name,
                 shape=info.shape,
+                physical_shape=info.physical_shape,
                 vram_base_addr=info.vram_addr,
+                strict=False,
             )
 
     def vram_block_add_to(
@@ -573,6 +591,8 @@ class IsaMatrixMixin:
 
         dst_rows, dst_cols = dst_info.shape
         src_rows, src_cols = src_info.shape
+        dst_physical_rows, dst_physical_cols = dst_info.physical_shape
+        src_physical_rows, src_physical_cols = src_info.physical_shape
 
         if num_rows is None:
             num_rows = src_rows
@@ -595,8 +615,8 @@ class IsaMatrixMixin:
 
         # Prefer block add path so we can reuse the compact C_LOOP-based add kernel.
         block_aligned = (
-            dst_cols % self.mlen == 0
-            and src_cols % self.mlen == 0
+            dst_physical_cols % self.mlen == 0
+            and src_physical_cols % self.mlen == 0
             and dst_row_offset % self.mlen == 0
             and src_row_offset % self.mlen == 0
             and num_rows % self.mlen == 0
@@ -604,7 +624,7 @@ class IsaMatrixMixin:
 
         if block_aligned:
             num_row_blocks = num_rows // self.mlen
-            num_col_blocks = dst_cols // self.mlen
+            num_col_blocks = dst_physical_cols // self.mlen
             dst_row_block_base = dst_row_offset // self.mlen
             src_row_block_base = src_row_offset // self.mlen
             lines.append(f"; block add path: row_blocks={num_row_blocks}, col_blocks={num_col_blocks}")
@@ -632,7 +652,7 @@ class IsaMatrixMixin:
             gp_regs = self.register_allocator.allocate_gp(2)
             gp_dst = gp_regs[0]
             gp_src = gp_regs[1]
-            num_col_blocks = dst_cols // self.mlen
+            num_col_blocks = dst_physical_cols // self.mlen
             lines.append(f"; fallback row-wise path: num_rows={num_rows}, num_col_blocks={num_col_blocks}")
 
             for row in range(num_rows):
@@ -640,8 +660,8 @@ class IsaMatrixMixin:
                 src_actual_row = src_row_offset + row
 
                 for col_block in range(num_col_blocks):
-                    dst_block_addr = dst_addr + col_block * dst_rows * self.mlen + dst_actual_row * self.mlen
-                    src_block_addr = src_addr + col_block * src_rows * self.mlen + src_actual_row * self.mlen
+                    dst_block_addr = dst_addr + col_block * dst_physical_rows * self.mlen + dst_actual_row * self.mlen
+                    src_block_addr = src_addr + col_block * src_physical_rows * self.mlen + src_actual_row * self.mlen
 
                     lines.append(f"S_ADDI_INT gp{gp_dst}, gp0, {dst_block_addr}")
                     lines.append(f"S_ADDI_INT gp{gp_src}, gp0, {src_block_addr}")
@@ -656,7 +676,7 @@ class IsaMatrixMixin:
             raise KeyError(f"Target matrix '{target_matrix}' not found. Use allocate_vram_matrix first.")
 
         target_info = self[target_matrix]
-        target_rows, _target_cols = target_info.shape
+        target_rows, _target_cols = target_info.physical_shape
         target_base_addr = target_info.vram_addr
         result_vram_addr = (
             target_base_addr + target_col_idx * target_rows * self.mlen + target_row_idx * self.mlen * self.mlen

--- a/aten/plena/memory.py
+++ b/aten/plena/memory.py
@@ -141,7 +141,8 @@ class SubMatrixInfo:
     parent_name: str  # Parent matrix name
     row_idx: int  # Sub-block row index
     col_idx: int  # Sub-block column index
-    shape: tuple[int, int]  # Sub-block shape (typically 64x64)
+    shape: tuple[int, int]  # Physical sub-block shape (typically mlen x mlen)
+    valid_shape: tuple[int, int] | None = None  # Logical rows/cols carried by this physical tile
 
     # Pre-calculated addresses (computed during compiler phase, used directly at runtime)
     hbm_offset: int = 0  # Offset in HBM (in elements)
@@ -158,8 +159,9 @@ class MatrixBlockLayout:
     """
 
     name: str
-    full_shape: tuple[int, int]  # Full matrix shape (rows, cols)
+    full_shape: tuple[int, int]  # Logical matrix shape (rows, cols)
     block_size: int = MLEN  # Sub-block size (default 64)
+    physical_shape: tuple[int, int] | None = None  # Backing storage shape, if padded
 
     num_row_blocks: int = 0
     num_col_blocks: int = 0
@@ -174,20 +176,29 @@ class MatrixBlockLayout:
     def __post_init__(self):
         """Initialize block information"""
         rows, cols = self.full_shape
-        self.num_row_blocks = math.ceil(rows / self.block_size)
-        self.num_col_blocks = math.ceil(cols / self.block_size)
+        physical_rows, physical_cols = self.physical_shape or self.full_shape
+        if physical_rows < rows or physical_cols < cols:
+            raise ValueError(
+                f"Physical shape {self.physical_shape} cannot be smaller than logical shape {self.full_shape}"
+            )
+        self.physical_shape = (physical_rows, physical_cols)
+        self.num_row_blocks = math.ceil(physical_rows / self.block_size)
+        self.num_col_blocks = math.ceil(physical_cols / self.block_size)
 
         # Create information for all sub-blocks (pre-calculate addresses)
         for r in range(self.num_row_blocks):
             for c in range(self.num_col_blocks):
                 # HBM offset (row-major): sub-block (r,c) starts at r*block_size*cols + c*block_size
-                hbm_offset = r * self.block_size * cols + c * self.block_size
+                hbm_offset = r * self.block_size * physical_cols + c * self.block_size
+                valid_rows = max(0, min(self.block_size, rows - r * self.block_size))
+                valid_cols = max(0, min(self.block_size, cols - c * self.block_size))
 
                 sub_info = SubMatrixInfo(
                     parent_name=self.name,
                     row_idx=r,
                     col_idx=c,
                     shape=(self.block_size, self.block_size),
+                    valid_shape=(valid_rows, valid_cols),
                     hbm_offset=hbm_offset,
                     mram_addr=None,
                 )
@@ -220,7 +231,8 @@ class VRAMSubMatrixInfo:
     parent_name: str  # Parent matrix name
     row_idx: int  # Sub-block row index (batch dimension)
     col_idx: int  # Sub-block column index (hidden dimension)
-    shape: tuple[int, int]  # Sub-block shape (typically mlen x mlen)
+    shape: tuple[int, int]  # Physical sub-block shape (typically mlen x mlen)
+    valid_shape: tuple[int, int] | None = None  # Logical rows/cols carried by this physical tile
 
     # Pre-calculated VRAM address
     vram_addr: int = 0
@@ -240,9 +252,10 @@ class VRAMMatrixBlockLayout:
     """
 
     name: str
-    full_shape: tuple[int, int]  # Full matrix shape (batch, hidden_size)
+    full_shape: tuple[int, int]  # Logical matrix shape (batch, hidden_size)
     vram_base_addr: int  # VRAM base address
     block_size: int = MLEN  # Sub-block size (default 64)
+    physical_shape: tuple[int, int] | None = None  # Backing storage shape, if padded
 
     num_row_blocks: int = 0  # Number of blocks in batch dimension
     num_col_blocks: int = 0  # Number of blocks in hidden dimension
@@ -253,23 +266,32 @@ class VRAMMatrixBlockLayout:
     def __post_init__(self):
         """Initialize block information"""
         batch, hidden = self.full_shape
-        self.num_row_blocks = math.ceil(batch / self.block_size)
-        self.num_col_blocks = math.ceil(hidden / self.block_size)
+        physical_batch, physical_hidden = self.physical_shape or self.full_shape
+        if physical_batch < batch or physical_hidden < hidden:
+            raise ValueError(
+                f"Physical shape {self.physical_shape} cannot be smaller than logical shape {self.full_shape}"
+            )
+        self.physical_shape = (physical_batch, physical_hidden)
+        self.num_row_blocks = math.ceil(physical_batch / self.block_size)
+        self.num_col_blocks = math.ceil(physical_hidden / self.block_size)
 
         # VRAM column-block major address calculation:
-        # col block c base = vram_base + c * batch * mlen
+        # col block c base = vram_base + c * physical_batch * mlen
         # row sub-block r offset within column block = r * mlen * mlen
         for r in range(self.num_row_blocks):
             for c in range(self.num_col_blocks):
-                col_block_base = self.vram_base_addr + c * batch * self.block_size
+                col_block_base = self.vram_base_addr + c * physical_batch * self.block_size
                 row_offset = r * self.block_size * self.block_size
                 vram_addr = col_block_base + row_offset
+                valid_rows = max(0, min(self.block_size, batch - r * self.block_size))
+                valid_cols = max(0, min(self.block_size, hidden - c * self.block_size))
 
                 sub_info = VRAMSubMatrixInfo(
                     parent_name=self.name,
                     row_idx=r,
                     col_idx=c,
                     shape=(self.block_size, self.block_size),
+                    valid_shape=(valid_rows, valid_cols),
                     vram_addr=vram_addr,
                 )
                 self.sub_blocks[(r, c)] = sub_info
@@ -302,6 +324,7 @@ class MemoryObjectInfo:
     kind: str
     dtype: str = "fp16"
     shape: tuple[int, int] = (0, 0)
+    physical_shape: tuple[int, int] = (0, 0)
     size: int = 0
     hbm_addr: int = -1
     hbm_size: int = 0

--- a/aten/plena/memory.py
+++ b/aten/plena/memory.py
@@ -357,12 +357,22 @@ class MRAMAllocator(MemoryAllocatorBase):
     """
     Matrix RAM address allocator.
 
-    Each sub-block is mlen x mlen = 4096 elements; aligned to mlen*mlen.
-    Default total_size=16384 holds 4 sub-blocks (MAX_K_TILES=4).
+    Each sub-block is mlen x mlen elements; aligned to mlen*mlen.
+    By default the allocator holds four matrix tiles.
     """
 
-    def __init__(self, total_size: int = MLEN * MLEN * 4):
-        super().__init__(total_size=total_size, alignment=MLEN * MLEN, mem_name="MRAM")
+    def __init__(self, total_size: int | None = None, *, mlen: int = MLEN, tile_capacity: int = 4):
+        if mlen <= 0:
+            raise ValueError(f"mlen must be > 0, got {mlen}")
+        if tile_capacity <= 0:
+            raise ValueError(f"tile_capacity must be > 0, got {tile_capacity}")
+
+        self.mlen = mlen
+        self.tile_capacity = tile_capacity
+        self.tile_elems = mlen * mlen
+        if total_size is None:
+            total_size = self.tile_elems * tile_capacity
+        super().__init__(total_size=total_size, alignment=self.tile_elems, mem_name="MRAM")
 
     def allocate(self, name: str, size: int) -> int:
         return self._vmm.allocate(name, size)

--- a/aten/plena/memory_state.py
+++ b/aten/plena/memory_state.py
@@ -18,18 +18,32 @@ from compiler.aten.plena.memory import (
 class MemoryStateMixin:
     """Sub-matrix layout manager for PLENA HBM, VRAM, MRAM, and FPRAM state."""
 
-    def __init__(self, mlen: int = MLEN, blen: int = BLEN, unroll_loops: bool = False):
+    def __init__(
+        self,
+        mlen: int = MLEN,
+        blen: int = BLEN,
+        unroll_loops: bool = False,
+        mram_tile_capacity: int = 4,
+    ):
+        if mlen <= 0:
+            raise ValueError(f"mlen must be > 0, got {mlen}")
+        if mram_tile_capacity <= 0:
+            raise ValueError(f"mram_tile_capacity must be > 0, got {mram_tile_capacity}")
+
         self.mlen = mlen
         self.blen = blen
         self.unroll_loops = unroll_loops
+        self.mram_tile_capacity = mram_tile_capacity
+        self.mram_tile_elems = mlen * mlen
+        self.mram_capacity_elems = self.mram_tile_capacity * self.mram_tile_elems
 
         # Layout tables
         self.hbm_matrices: dict[str, MatrixBlockLayout] = {}
         self.vram_matrices: dict[str, VRAMMatrixBlockLayout] = {}
         self.fpram_matrices: dict[str, FPRAMObjectLayout] = {}
         # Memory Allocators
-        self.vram_allocator = VRAMAllocator()
-        self.mram_allocator = MRAMAllocator()
+        self.vram_allocator = VRAMAllocator(alignment=mlen)
+        self.mram_allocator = MRAMAllocator(mlen=mlen, tile_capacity=mram_tile_capacity)
         self.fpram_allocator = FPRAMAllocator()
 
     def __contains__(self, name: str) -> bool:

--- a/aten/plena/memory_state.py
+++ b/aten/plena/memory_state.py
@@ -42,7 +42,10 @@ class MemoryStateMixin:
         self.vram_matrices: dict[str, VRAMMatrixBlockLayout] = {}
         self.fpram_matrices: dict[str, FPRAMObjectLayout] = {}
         # Memory Allocators
-        self.vram_allocator = VRAMAllocator(alignment=mlen)
+        # Matrix ops consume VRAM in MLEN x MLEN tiles. Row-only alignment is
+        # enough for vector reads/writes, but a matrix result can become the
+        # next layer's M_MM input, so keep VRAM allocations tile-aligned.
+        self.vram_allocator = VRAMAllocator(alignment=mlen * mlen)
         self.mram_allocator = MRAMAllocator(mlen=mlen, tile_capacity=mram_tile_capacity)
         self.fpram_allocator = FPRAMAllocator()
 

--- a/aten/plena/memory_state.py
+++ b/aten/plena/memory_state.py
@@ -60,6 +60,7 @@ class MemoryStateMixin:
         if hbm_layout is not None:
             rows, cols = hbm_layout.full_shape
             info.shape = hbm_layout.full_shape
+            info.physical_shape = hbm_layout.physical_shape or hbm_layout.full_shape
             info.size = rows * cols
             info.hbm_addr = hbm_layout.hbm_base_addr
             info.hbm_size = hbm_layout.hbm_size
@@ -68,6 +69,7 @@ class MemoryStateMixin:
         if vram_layout is not None:
             rows, cols = vram_layout.full_shape
             info.shape = vram_layout.full_shape
+            info.physical_shape = vram_layout.physical_shape or vram_layout.full_shape
             info.size = rows * cols
             info.vram_addr = vram_layout.vram_base_addr
             info.kind = "VRAMMatrix" if hbm_layout is None else "Batch"
@@ -108,6 +110,7 @@ class MemoryStateMixin:
         name: str,
         shape: tuple[int, int],
         hbm_addr: int,
+        physical_shape: tuple[int, int] | None = None,
         dtype: str = "fp16",
         kind: str = "HBMObject",
         real_data_ratio: float = 1.125,
@@ -117,6 +120,7 @@ class MemoryStateMixin:
         self.register_matrix(
             name=name,
             shape=shape,
+            physical_shape=physical_shape,
             hbm_base_addr=hbm_addr,
             real_data_ratio=real_data_ratio,
             strict=strict,
@@ -137,12 +141,13 @@ class MemoryStateMixin:
         name: str,
         shape: tuple[int, int],
         vram_addr: int | None = None,
+        physical_shape: tuple[int, int] | None = None,
         dtype: str = "fp16",
         kind: str = "VRAMObject",
         allocate_if_none: bool = True,
         strict: bool = True,
     ) -> MemoryObjectInfo:
-        rows, cols = shape
+        rows, cols = physical_shape or shape
         size = rows * cols
         if vram_addr is None:
             if not allocate_if_none:
@@ -152,6 +157,7 @@ class MemoryStateMixin:
         self.register_vram_matrix(
             name=name,
             shape=shape,
+            physical_shape=physical_shape,
             vram_base_addr=vram_addr,
             strict=strict,
         )
@@ -199,23 +205,30 @@ class MemoryStateMixin:
         name: str,
         shape: tuple[int, int],
         hbm_base_addr: int,
+        physical_shape: tuple[int, int] | None = None,
         real_data_ratio: float = 1.125,
         strict: bool = True,
     ) -> MatrixBlockLayout:
         """Register an HBM matrix and derive its mlen block layout."""
         rows, cols = shape
+        physical_rows, physical_cols = physical_shape or shape
 
         if strict:
-            if rows % self.mlen != 0:
-                raise ValueError(f"Matrix rows ({rows}) must be multiple of mlen ({self.mlen})")
-            if cols % self.mlen != 0:
-                raise ValueError(f"Matrix cols ({cols}) must be multiple of mlen ({self.mlen})")
+            if physical_rows % self.mlen != 0:
+                raise ValueError(f"Matrix physical rows ({physical_rows}) must be multiple of mlen ({self.mlen})")
+            if physical_cols % self.mlen != 0:
+                raise ValueError(f"Matrix physical cols ({physical_cols}) must be multiple of mlen ({self.mlen})")
 
-        size = rows * cols
+        size = physical_rows * physical_cols
         hbm_size = int(size * real_data_ratio)
 
         layout = MatrixBlockLayout(
-            name=name, full_shape=shape, block_size=self.mlen, hbm_base_addr=hbm_base_addr, hbm_size=hbm_size
+            name=name,
+            full_shape=shape,
+            physical_shape=(physical_rows, physical_cols),
+            block_size=self.mlen,
+            hbm_base_addr=hbm_base_addr,
+            hbm_size=hbm_size,
         )
 
         self.hbm_matrices[name] = layout
@@ -230,6 +243,7 @@ class MemoryStateMixin:
         name: str,
         shape: tuple[int, int],
         vram_base_addr: int,
+        physical_shape: tuple[int, int] | None = None,
         strict: bool = True,
     ) -> VRAMMatrixBlockLayout:
         """
@@ -244,14 +258,25 @@ class MemoryStateMixin:
             VRAMMatrixBlockLayout object
         """
         batch, hidden = shape
+        physical_batch, physical_hidden = physical_shape or shape
 
         if strict:
-            if batch % self.mlen != 0:
-                raise ValueError(f"VRAM matrix batch ({batch}) must be multiple of mlen ({self.mlen})")
-            if hidden % self.mlen != 0:
-                raise ValueError(f"VRAM matrix hidden ({hidden}) must be multiple of mlen ({self.mlen})")
+            if physical_batch % self.mlen != 0:
+                raise ValueError(
+                    f"VRAM matrix physical batch ({physical_batch}) must be multiple of mlen ({self.mlen})"
+                )
+            if physical_hidden % self.mlen != 0:
+                raise ValueError(
+                    f"VRAM matrix physical hidden ({physical_hidden}) must be multiple of mlen ({self.mlen})"
+                )
 
-        layout = VRAMMatrixBlockLayout(name=name, full_shape=shape, vram_base_addr=vram_base_addr, block_size=self.mlen)
+        layout = VRAMMatrixBlockLayout(
+            name=name,
+            full_shape=shape,
+            physical_shape=(physical_batch, physical_hidden),
+            vram_base_addr=vram_base_addr,
+            block_size=self.mlen,
+        )
 
         self.vram_matrices[name] = layout
         return layout

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -33,15 +33,17 @@ class ProgramAttentionMixin:
         if scale is None:
             scale = 1.0 / math.sqrt(head_dim)
 
-        num_q_blocks = seq_len // mlen
-        num_k_blocks = seq_len // mlen
+        num_q_blocks = math.ceil(seq_len / mlen)
+        num_k_blocks = math.ceil(seq_len / mlen)
 
         S_block = self.alloc("S", mlen, mlen)
-        PV = self.alloc("PV", mlen, head_dim)
-        O = self.alloc("O", seq_len, head_dim)
+        pv_rows = min(mlen, seq_len)
+        PV = self.alloc("PV", pv_rows, head_dim, strict=False)
+        O = self.alloc("O", seq_len, head_dim, strict=False)
 
         for q_idx in range(num_q_blocks):
-            self.init_online_softmax(q_idx, O)
+            block_rows = min(mlen, seq_len - q_idx * mlen)
+            self.init_online_softmax(q_idx, O, rows=block_rows)
 
             for k_idx in range(num_k_blocks):
                 self.vram_sub_projection_T_to(
@@ -55,12 +57,12 @@ class ProgramAttentionMixin:
                 )
                 if causal_mask is not None:
                     self.vram_add(S_block, causal_mask)
-                self.online_softmax_block(S_block, scale)
-                self.compute_pv(S_block, V, k_idx, PV, head_dim)
-                self.scale_o_row(O, q_idx)
-                self.vram_add(O, PV, dst_row_offset=q_idx * mlen)
+                self.online_softmax_block(S_block, scale, rows=block_rows)
+                self.compute_pv(S_block, V, k_idx, PV, head_dim, rows=block_rows)
+                self.scale_o_row(O, q_idx, rows=block_rows)
+                self.vram_add(O, PV, dst_row_offset=q_idx * mlen, num_rows=block_rows)
 
-            self.final_scale_o(q_idx, O)
+            self.final_scale_o(q_idx, O, rows=block_rows)
 
         return O
 
@@ -139,7 +141,85 @@ class ProgramAttentionMixin:
         self._tensors[o_name] = O
         return O
 
-    def init_online_softmax(self, q_idx: int, o_matrix: VRAMMatrixVar):
+    def flash_attention_packed_group(
+        self,
+        Q_group: VRAMMatrixVar,
+        K: InputVar,
+        V: InputVar,
+        *,
+        group_heads: int,
+        head_slot_dim: int,
+        output_base_address: int,
+        scratch_base_address: int,
+        broadcast_amount: int,
+        scale=None,
+        causal_mask: bool = True,
+    ) -> None:
+        """Emit one KV group's packed-head flash-attention body.
+
+        Q_group and the output use an MLEN-wide row where active Q heads occupy
+        HLEN-sized lanes. K/V are one KV head stored as MLEN-padded HBM rows.
+        """
+        seq_len, q_width = Q_group.shape
+        mlen = self.mlen
+        vlen = mlen
+        if q_width != mlen:
+            raise ValueError(f"packed Q group must be one MLEN row wide, got {q_width}")
+        if group_heads > broadcast_amount:
+            raise ValueError(
+                f"group_heads={group_heads} exceeds broadcast_amount={broadcast_amount}"
+            )
+        if broadcast_amount * head_slot_dim != mlen:
+            raise ValueError(
+                f"broadcast_amount*head_slot_dim must equal MLEN "
+                f"({broadcast_amount}*{head_slot_dim} != {mlen})"
+            )
+        if scale is None:
+            scale = 1.0 / math.sqrt(head_slot_dim)
+
+        self._ensure_hbm_sub_matrix_registered(K)
+        self._ensure_hbm_sub_matrix_registered(V)
+        alloc = self.register_allocator
+        k_addr, v_addr = alloc.allocate_addr(2)
+        gp_for_preload = alloc.allocate_gp(2)
+        setup = preload_addr_reg_asm(
+            addr_reg_to_set=[k_addr, v_addr],
+            available_registers=gp_for_preload,
+            addr_reg_val=[K.hbm_addr, V.hbm_addr],
+        )
+        alloc.free_gp(gp_for_preload)
+        self.emit(setup)
+
+        self.emit(
+            flash_attn_asm(
+                mlen=mlen,
+                vlen=vlen,
+                blen=self.blen,
+                batch=1,
+                hq=group_heads,
+                hkv=1,
+                d=head_slot_dim,
+                q_len=seq_len,
+                kv_len=seq_len,
+                alive_registers_int=list(range(1, 16)),
+                alive_registers_fp=list(range(1, 8)),
+                vector_sram_base_address=self.get_vram_addr(Q_group.name),
+                fp_sram_start_address=self._ONLINE_SOFTMAX_FPSRAM_BASE,
+                k_base_hbm_offset_reg=k_addr,
+                v_base_hbm_offset_reg=v_addr,
+                scratch_base_address=scratch_base_address,
+                output_base_address=output_base_address,
+                broadcast_amount=broadcast_amount,
+                packed_group_layout=True,
+                attn_scale_fp_address=1,
+                inf_fp_address=2,
+                causal_mask=causal_mask,
+            )
+        )
+
+        alloc.free_addr([k_addr, v_addr])
+
+    def init_online_softmax(self, q_idx: int, o_matrix: VRAMMatrixVar, rows: int | None = None):
         """Initialize Online Softmax state: m=-inf, l=0, O_row=0"""
         o_info = super().get_tensor_info(o_matrix.name)
         seq_len, head_dim = o_info.shape
@@ -149,13 +229,15 @@ class ProgramAttentionMixin:
             o_matrix=o_matrix.name,
             seq_len=seq_len,
             head_dim=head_dim,
+            rows=rows,
         )
 
-    def online_softmax_block(self, s_block: VRAMMatrixVar, scale: float):
+    def online_softmax_block(self, s_block: VRAMMatrixVar, scale: float, rows: int | None = None):
         """Perform Online Softmax on S block"""
         super().online_softmax_block(
             s_block_matrix=s_block.name,
             scale=scale,
+            rows=rows,
         )
 
     def compute_pv(
@@ -165,6 +247,7 @@ class ProgramAttentionMixin:
         k_idx: int,
         pv_matrix: VRAMMatrixVar,
         head_dim: int,
+        rows: int | None = None,
     ):
         """Compute PV = P @ V[k_idx] where P is stored in s_block."""
         if not isinstance(s_block, VRAMMatrixVar):
@@ -181,9 +264,10 @@ class ProgramAttentionMixin:
             k_idx=k_idx,
             pv_matrix=pv_matrix.name,
             head_dim=head_dim,
+            rows=rows,
         )
 
-    def scale_o_row(self, o_matrix: VRAMMatrixVar, q_idx: int):
+    def scale_o_row(self, o_matrix: VRAMMatrixVar, q_idx: int, rows: int | None = None):
         """Scale current row block of O by m_res"""
         o_info = super().get_tensor_info(o_matrix.name)
         seq_len, head_dim = o_info.shape
@@ -193,9 +277,10 @@ class ProgramAttentionMixin:
             q_idx=q_idx,
             seq_len=seq_len,
             head_dim=head_dim,
+            rows=rows,
         )
 
-    def final_scale_o(self, q_idx: int, o_matrix: VRAMMatrixVar):
+    def final_scale_o(self, q_idx: int, o_matrix: VRAMMatrixVar, rows: int | None = None):
         """Final scaling: O[q_idx] = O[q_idx] / l"""
         o_info = super().get_tensor_info(o_matrix.name)
         seq_len, head_dim = o_info.shape
@@ -205,6 +290,7 @@ class ProgramAttentionMixin:
             o_matrix=o_matrix.name,
             seq_len=seq_len,
             head_dim=head_dim,
+            rows=rows,
         )
 
 

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-
 from compiler.asm_templates._imm import add_large_int
 from compiler.asm_templates._imm import load_large_int
 from compiler.aten.plena.vars import InputVar, VRAMMatrixVar
@@ -589,7 +588,12 @@ class ProgramAttentionMixin:
                 self.vram_add(s_head, causal_mask, num_rows=rows)
             elif causal_mask is True:
                 self.emit("; NOTE: packed attention received causal_mask=True without a VRAM mask; no mask applied.\n")
-            self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=valid_cols or seq_len)
+            # A materialized causal mask already makes inactive/future columns
+            # negligible for the active rows. Passing valid_cols here selects
+            # the vector-mask reduce path, whose semantics differ from a pure
+            # active-lane reduction in the emulator.
+            softmax_valid_cols = None if isinstance(causal_mask, VRAMMatrixVar) else (valid_cols or seq_len)
+            self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=softmax_valid_cols)
             self.compute_pv(s_head, V, k_idx, pv, head_slot_dim, rows=rows)
             self.scale_o_row(o_head, 0, rows=rows)
             self.vram_add(o_head, pv, num_rows=rows)
@@ -732,7 +736,8 @@ class ProgramAttentionMixin:
                     self.vram_add(s_head, causal_mask, num_rows=rows)
                 elif causal_mask is True:
                     self.emit("; NOTE: packed attention received causal_mask=True without a VRAM mask; no mask applied.\n")
-                self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=seq_len)
+                softmax_valid_cols = None if isinstance(causal_mask, VRAMMatrixVar) else seq_len
+                self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=softmax_valid_cols)
                 self.emit(
                     self._pv_multiply_asm(
                         mlen=mlen,

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -13,6 +13,51 @@ class ProgramAttentionMixin:
     # Flash Attention Operations
     # ========================================================================
 
+    def _needs_explicit_valid_col_mask(self, valid_cols: int | None) -> bool:
+        """Return true when softmax must ignore padded K columns.
+
+        The vector mask path is not sufficient for reductions on current
+        behavioral hardware: padded score lanes can still affect the softmax
+        denominator.  Materialize a VRAM score mask for every partial K block
+        so padded columns are explicitly set to -inf before online softmax.
+        """
+        if valid_cols is None or valid_cols >= self.mlen:
+            return False
+        return True
+
+    def _build_valid_col_mask(self, name: str, valid_cols: int) -> VRAMMatrixVar:
+        """Materialize an MLEN x MLEN score mask with -inf in padded columns."""
+        if valid_cols < 0 or valid_cols > self.mlen:
+            raise ValueError(f"valid_cols must be in [0, {self.mlen}], got {valid_cols}")
+
+        mask = self.alloc(name, self.mlen, self.mlen)
+        mask_addr = self.get_vram_addr(mask.name)
+        fp_scratch_base = self._ONLINE_SOFTMAX_FPSRAM_BASE
+        gp_mask, gp_fp, gp_loop = self.register_allocator.allocate_gp(3)
+
+        lines = [
+            f"; === Build valid-column score mask: valid_cols={valid_cols}, MLEN={self.mlen} ===",
+            f"S_ADDI_INT gp{gp_fp}, gp0, {fp_scratch_base}",
+            "S_LD_FP f7, gp0, 2",
+        ]
+        for col in range(valid_cols):
+            lines.append(f"S_ST_FP f0, gp{gp_fp}, {col}")
+        for col in range(valid_cols, self.mlen):
+            lines.append(f"S_ST_FP f7, gp{gp_fp}, {col}")
+        lines.extend(load_large_int(gp_mask, mask_addr))
+        lines.extend(
+            [
+                f"C_LOOP_START gp{gp_loop}, {self.mlen}",
+                f"S_MAP_V_FP gp{gp_mask}, gp{gp_fp}, 0",
+                f"S_ADDI_INT gp{gp_mask}, gp{gp_mask}, {self.mlen}",
+                f"C_LOOP_END gp{gp_loop}",
+            ]
+        )
+
+        self.register_allocator.free_gp([gp_mask, gp_fp, gp_loop])
+        self.emit("\n".join(lines) + "\n")
+        return mask
+
     def flash_attention(
         self,
         Q,
@@ -123,6 +168,13 @@ class ProgramAttentionMixin:
         num_q_blocks = math.ceil(seq_len / mlen)
         num_k_blocks = math.ceil(kv_seq_len / mlen)
         k_row_blocks_per_batch = max(1, math.ceil(k_rows_per_batch / mlen))
+        valid_col_masks: dict[int, VRAMMatrixVar] = {}
+        for k_idx in range(num_k_blocks):
+            block_cols = min(mlen, kv_seq_len - k_idx * mlen)
+            if self._needs_explicit_valid_col_mask(block_cols):
+                valid_col_masks[block_cols] = self._build_valid_col_mask(
+                    f"_mha_valid_col_mask_{block_cols}", block_cols
+                )
 
         S_block = self.alloc("S", mlen, mlen)
         pv_rows = min(mlen, seq_len)
@@ -177,14 +229,21 @@ class ProgramAttentionMixin:
                         target_row_idx=0,
                         target_col_idx=0,
                     )
+                    valid_col_mask = valid_col_masks.get(block_cols)
+                    if valid_col_mask is not None:
+                        self.vram_add(S_block, valid_col_mask, num_rows=block_rows)
                     if causal_mask is not None:
                         self.vram_add(S_block, causal_mask)
-                    self.online_softmax_block(S_block, scale, rows=block_rows, valid_cols=block_cols)
+                    softmax_valid_cols = None if valid_col_mask is not None else block_cols
+                    self.online_softmax_block(S_block, scale, rows=block_rows, valid_cols=softmax_valid_cols)
                     self.compute_pv(S_block, V, physical_k_idx, PV, head_dim, rows=block_rows)
                     self.scale_o_row(O_batch, q_idx, rows=block_rows)
                     self.vram_add(O_batch, PV, dst_row_offset=q_idx * mlen, num_rows=block_rows)
 
                 self.final_scale_o(q_idx, O_batch, rows=block_rows)
+
+        for mask in valid_col_masks.values():
+            self.free_tensor(mask)
 
         return O
 
@@ -575,6 +634,12 @@ class ProgramAttentionMixin:
             s_base_address=scratch_base_address,
         )
 
+        active_cols = valid_cols or seq_len
+        valid_col_mask = (
+            self._build_valid_col_mask(f"_packed_valid_col_mask_{active_cols}", active_cols)
+            if self._needs_explicit_valid_col_mask(active_cols)
+            else None
+        )
         for head, s_head in enumerate(s_views):
             o_head = self.alloc(
                 f"_packed_O_head{head}",
@@ -584,15 +649,17 @@ class ProgramAttentionMixin:
                 physical_shape=(mlen, mlen),
             )
             self.init_online_softmax(0, o_head, rows=rows)
+            if valid_col_mask is not None:
+                self.vram_add(s_head, valid_col_mask, num_rows=rows)
             if isinstance(causal_mask, VRAMMatrixVar):
                 self.vram_add(s_head, causal_mask, num_rows=rows)
             elif causal_mask is True:
                 self.emit("; NOTE: packed attention received causal_mask=True without a VRAM mask; no mask applied.\n")
-            # A materialized causal mask already makes inactive/future columns
-            # negligible for the active rows. Passing valid_cols here selects
-            # the vector-mask reduce path, whose semantics differ from a pure
-            # active-lane reduction in the emulator.
-            softmax_valid_cols = None if isinstance(causal_mask, VRAMMatrixVar) else (valid_cols or seq_len)
+            softmax_valid_cols = (
+                None
+                if valid_col_mask is not None or isinstance(causal_mask, VRAMMatrixVar)
+                else active_cols
+            )
             self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=softmax_valid_cols)
             self.compute_pv(s_head, V, k_idx, pv, head_slot_dim, rows=rows)
             self.scale_o_row(o_head, 0, rows=rows)
@@ -613,6 +680,8 @@ class ProgramAttentionMixin:
             )
             self.free_tensor(o_head)
 
+        if valid_col_mask is not None:
+            self.free_tensor(valid_col_mask)
         self.free_tensor(pv)
         self.free_tensor(pack_scratch)
 
@@ -699,6 +768,11 @@ class ProgramAttentionMixin:
         pv = self.alloc("_packed_loop_PV", rows, head_slot_dim, strict=False, physical_shape=(mlen, mlen))
         pack_scratch = self.alloc("_packed_loop_pack_scratch", 1, mlen, strict=False, physical_shape=(1, mlen))
         pack_scratch_addr = self.get_vram_addr(pack_scratch.name)
+        valid_col_mask = (
+            self._build_valid_col_mask(f"_packed_loop_valid_col_mask_{seq_len}", seq_len)
+            if self._needs_explicit_valid_col_mask(seq_len)
+            else None
+        )
 
         gp_q, gp_o, gp_k, gp_v, gp_tmp, gp_kv_loop = self.register_allocator.allocate_gp(6)
         k_addr_reg, v_addr_reg = self.register_allocator.allocate_addr(2)
@@ -732,11 +806,17 @@ class ProgramAttentionMixin:
                     physical_shape=(mlen, mlen),
                 )
                 self.init_online_softmax(0, o_head, rows=rows)
+                if valid_col_mask is not None:
+                    self.vram_add(s_head, valid_col_mask, num_rows=rows)
                 if isinstance(causal_mask, VRAMMatrixVar):
                     self.vram_add(s_head, causal_mask, num_rows=rows)
                 elif causal_mask is True:
                     self.emit("; NOTE: packed attention received causal_mask=True without a VRAM mask; no mask applied.\n")
-                softmax_valid_cols = None if isinstance(causal_mask, VRAMMatrixVar) else seq_len
+                softmax_valid_cols = (
+                    None
+                    if valid_col_mask is not None or isinstance(causal_mask, VRAMMatrixVar)
+                    else seq_len
+                )
                 self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=softmax_valid_cols)
                 self.emit(
                     self._pv_multiply_asm(
@@ -774,6 +854,8 @@ class ProgramAttentionMixin:
             self.register_allocator.free_addr([k_addr_reg, v_addr_reg])
             self.register_allocator.free_gp([gp_q, gp_o, gp_k, gp_v, gp_tmp, gp_kv_loop])
             self.free_tensor(pv)
+            if valid_col_mask is not None:
+                self.free_tensor(valid_col_mask)
             self.free_tensor(pack_scratch)
 
     def flash_attention_packed_group(

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import math
 
-from compiler.asm_templates import preload_addr_reg_asm
-from compiler.asm_templates.flashattn import flash_attn_asm
+from compiler.asm_templates._imm import add_large_int
+from compiler.asm_templates._imm import load_large_int
 from compiler.aten.plena.vars import InputVar, VRAMMatrixVar
 
 
@@ -14,132 +14,762 @@ class ProgramAttentionMixin:
     # Flash Attention Operations
     # ========================================================================
 
-    def flash_attention(self, Q, K, V, scale=None, hq=1, hkv=1, h_qkv=None, causal_mask=None):
+    def flash_attention(
+        self,
+        Q,
+        K,
+        V,
+        scale=None,
+        hq=1,
+        hkv=1,
+        h_qkv=None,
+        causal_mask=None,
+        batch_size: int = 1,
+        seq_len: int | None = None,
+        kv_seq_len: int | None = None,
+    ):
         """Emit flash attention, dispatching to MHA or fused GQA codegen by shape."""
         if hq == 1 and hkv == 1:
-            return self._flash_attention_mha(Q, K, V, scale, causal_mask=causal_mask)
+            return self._flash_attention_mha(
+                Q,
+                K,
+                V,
+                scale,
+                causal_mask=causal_mask,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                kv_seq_len=kv_seq_len,
+            )
 
         if h_qkv is None:
             raise ValueError("GQA mode requires h_qkv to be specified")
         if causal_mask is not None:
             raise NotImplementedError("causal_mask is not yet supported for GQA flash attention")
-        return self._flash_attention_gqa_fused(Q, K, V, scale, hq, hkv, h_qkv)
+        return self._flash_attention_gqa_fused(
+            Q,
+            K,
+            V,
+            scale,
+            hq,
+            hkv,
+            h_qkv,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            kv_seq_len=kv_seq_len,
+        )
 
-    def _flash_attention_mha(self, Q, K, V, scale, causal_mask=None):
+    def _flash_attention_mha(
+        self,
+        Q,
+        K,
+        V,
+        scale,
+        causal_mask=None,
+        *,
+        batch_size: int = 1,
+        seq_len: int | None = None,
+        kv_seq_len: int | None = None,
+    ):
         """Single-head online-softmax flash attention using compiler primitives."""
-        seq_len, head_dim = Q.shape
+        total_q_rows, head_dim = Q.shape
         mlen = self.mlen
+
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if seq_len is None:
+            if total_q_rows % batch_size != 0:
+                raise ValueError(f"Q rows {total_q_rows} are not divisible by batch_size={batch_size}")
+            seq_len = total_q_rows // batch_size
+        elif total_q_rows < batch_size * seq_len:
+            raise ValueError(f"Q rows {total_q_rows} cannot cover batch_size*seq_len={batch_size * seq_len}")
+
+        total_k_rows, _ = K.shape
+        if kv_seq_len is None:
+            if total_k_rows % batch_size != 0:
+                raise ValueError(f"K rows {total_k_rows} are not divisible by batch_size={batch_size}")
+            kv_seq_len = total_k_rows // batch_size
+        elif total_k_rows < batch_size * kv_seq_len:
+            raise ValueError(f"K rows {total_k_rows} cannot cover batch_size*kv_seq_len={batch_size * kv_seq_len}")
+        if V.shape[0] < batch_size * kv_seq_len:
+            raise ValueError(f"V rows {V.shape[0]} cannot cover batch_size*kv_seq_len={batch_size * kv_seq_len}")
+
+        if Q.physical_shape[0] % batch_size != 0:
+            raise ValueError(f"Q physical rows {Q.physical_shape[0]} are not divisible by batch_size={batch_size}")
+        if K.physical_shape[0] % batch_size != 0:
+            raise ValueError(f"K physical rows {K.physical_shape[0]} are not divisible by batch_size={batch_size}")
+        if V.physical_shape[0] % batch_size != 0:
+            raise ValueError(f"V physical rows {V.physical_shape[0]} are not divisible by batch_size={batch_size}")
+
+        q_rows_per_batch = Q.physical_shape[0] // batch_size
+        k_rows_per_batch = K.physical_shape[0] // batch_size
+        v_rows_per_batch = V.physical_shape[0] // batch_size
+        if q_rows_per_batch < max(mlen, seq_len):
+            raise ValueError(f"Q physical rows per batch {q_rows_per_batch} are too small for seq_len={seq_len}")
+        if k_rows_per_batch < max(mlen, kv_seq_len):
+            raise ValueError(f"K physical rows per batch {k_rows_per_batch} are too small for kv_seq_len={kv_seq_len}")
+        if v_rows_per_batch < max(mlen, kv_seq_len):
+            raise ValueError(f"V physical rows per batch {v_rows_per_batch} are too small for kv_seq_len={kv_seq_len}")
+        if batch_size > 1 and q_rows_per_batch % mlen != 0:
+            raise ValueError(f"Q physical rows per batch {q_rows_per_batch} must be multiple of MLEN={mlen}")
+        if batch_size > 1 and k_rows_per_batch % mlen != 0:
+            raise ValueError(f"K physical rows per batch {k_rows_per_batch} must be multiple of MLEN={mlen}")
+        if batch_size > 1 and v_rows_per_batch % mlen != 0:
+            raise ValueError(f"V physical rows per batch {v_rows_per_batch} must be multiple of MLEN={mlen}")
+        if head_dim > mlen and batch_size > 1:
+            raise NotImplementedError("Batched MHA currently supports head_dim <= MLEN.")
 
         if scale is None:
             scale = 1.0 / math.sqrt(head_dim)
 
         num_q_blocks = math.ceil(seq_len / mlen)
-        num_k_blocks = math.ceil(seq_len / mlen)
+        num_k_blocks = math.ceil(kv_seq_len / mlen)
+        k_row_blocks_per_batch = max(1, math.ceil(k_rows_per_batch / mlen))
 
         S_block = self.alloc("S", mlen, mlen)
         pv_rows = min(mlen, seq_len)
         PV = self.alloc("PV", pv_rows, head_dim, strict=False)
-        O = self.alloc("O", seq_len, head_dim, strict=False)
+        O = self.alloc(
+            "O",
+            batch_size * seq_len,
+            head_dim,
+            strict=False,
+            physical_shape=(max(mlen, batch_size * seq_len), max(mlen, Q.physical_shape[1])),
+        )
 
-        for q_idx in range(num_q_blocks):
-            block_rows = min(mlen, seq_len - q_idx * mlen)
-            self.init_online_softmax(q_idx, O, rows=block_rows)
+        q_base = self.get_vram_addr(Q.name)
+        o_base = self.get_vram_addr(O.name)
+        q_batch_stride = q_rows_per_batch * Q.physical_shape[1]
+        o_batch_stride = seq_len * mlen
 
-            for k_idx in range(num_k_blocks):
-                self.vram_sub_projection_T_to(
-                    Q,
-                    q_idx,
-                    K,
-                    k_idx,
-                    S_block,
-                    target_row_idx=0,
-                    target_col_idx=0,
+        for batch_idx in range(batch_size):
+            if batch_size == 1 and total_q_rows == seq_len:
+                Q_batch = Q
+                O_batch = O
+            else:
+                Q_batch = self.alloc_at(
+                    f"_mha_Q_b{batch_idx}",
+                    seq_len,
+                    head_dim,
+                    q_base + batch_idx * q_batch_stride,
+                    physical_shape=(q_rows_per_batch, Q.physical_shape[1]),
                 )
-                if causal_mask is not None:
-                    self.vram_add(S_block, causal_mask)
-                self.online_softmax_block(S_block, scale, rows=block_rows)
-                self.compute_pv(S_block, V, k_idx, PV, head_dim, rows=block_rows)
-                self.scale_o_row(O, q_idx, rows=block_rows)
-                self.vram_add(O, PV, dst_row_offset=q_idx * mlen, num_rows=block_rows)
+                O_batch = self.alloc_at(
+                    f"_mha_O_b{batch_idx}",
+                    seq_len,
+                    head_dim,
+                    o_base + batch_idx * o_batch_stride,
+                    physical_shape=(max(mlen, seq_len), O.physical_shape[1]),
+                )
 
-            self.final_scale_o(q_idx, O, rows=block_rows)
+            batch_k_block_base = batch_idx * k_row_blocks_per_batch
+            for q_idx in range(num_q_blocks):
+                block_rows = min(mlen, seq_len - q_idx * mlen)
+                self.init_online_softmax(q_idx, O_batch, rows=block_rows)
+
+                for k_idx in range(num_k_blocks):
+                    block_cols = min(mlen, kv_seq_len - k_idx * mlen)
+                    physical_k_idx = batch_k_block_base + k_idx
+                    self.vram_sub_projection_T_to(
+                        Q_batch,
+                        q_idx,
+                        K,
+                        physical_k_idx,
+                        S_block,
+                        target_row_idx=0,
+                        target_col_idx=0,
+                    )
+                    if causal_mask is not None:
+                        self.vram_add(S_block, causal_mask)
+                    self.online_softmax_block(S_block, scale, rows=block_rows, valid_cols=block_cols)
+                    self.compute_pv(S_block, V, physical_k_idx, PV, head_dim, rows=block_rows)
+                    self.scale_o_row(O_batch, q_idx, rows=block_rows)
+                    self.vram_add(O_batch, PV, dst_row_offset=q_idx * mlen, num_rows=block_rows)
+
+                self.final_scale_o(q_idx, O_batch, rows=block_rows)
 
         return O
 
-    def _flash_attention_gqa_fused(self, Q, K, V, scale, hq, hkv, h_qkv):
-        """GQA flash attention using the fused M_BTMM template."""
+    def _flash_attention_gqa_fused(
+        self,
+        Q,
+        K,
+        V,
+        scale,
+        hq,
+        hkv,
+        h_qkv,
+        *,
+        batch_size: int = 1,
+        seq_len: int | None = None,
+        kv_seq_len: int | None = None,
+    ):
+        """GQA flash attention using compiler-owned packed-head primitives."""
+        if hq % hkv != 0:
+            raise ValueError(f"hq={hq} must be divisible by hkv={hkv}")
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
         ratio = hq // hkv
         mlen = self.mlen
-        blen = self.blen
-        vlen = mlen
+        broadcast_amount = mlen // h_qkv
 
-        if ratio != blen:
-            raise ValueError(f"GQA ratio hq/hkv={ratio} must equal blen={blen} (hardware packs heads into blen).")
-        if ratio * h_qkv != mlen:
-            raise ValueError(f"GQA constraint: (hq/hkv)*h_qkv = {ratio * h_qkv} must equal mlen={mlen}.")
+        if broadcast_amount * h_qkv != mlen:
+            raise ValueError(
+                f"GQA constraint: BROADCAST_AMOUNT*h_qkv must equal mlen "
+                f"({broadcast_amount}*{h_qkv} != {mlen})."
+            )
+        if ratio > broadcast_amount:
+            raise ValueError(
+                f"GQA ratio hq/hkv={ratio} exceeds packed broadcast lanes "
+                f"{broadcast_amount}."
+            )
+        if hkv != 1:
+            raise NotImplementedError(
+                "ATen fused GQA currently supports one packed KV group in this "
+                "entry point. Multi-KV packed decoder lowering should use "
+                "flash_attention_packed_group per KV group."
+            )
 
-        s_q, _q_total_dim = Q.shape
-        s_kv, _k_total_dim = K.shape
+        total_q_rows, q_total_dim = Q.shape
+        total_k_rows, _k_total_dim = K.shape
+
+        if seq_len is None:
+            if total_q_rows % batch_size != 0:
+                raise ValueError(f"Q rows {total_q_rows} are not divisible by batch_size={batch_size}")
+            s_q = total_q_rows // batch_size
+        else:
+            s_q = seq_len
+            if total_q_rows < batch_size * s_q:
+                raise ValueError(
+                    f"Q rows {total_q_rows} cannot cover batch_size*seq_len={batch_size * s_q}"
+                )
+
+        if kv_seq_len is None:
+            if total_k_rows % batch_size != 0:
+                raise ValueError(f"K rows {total_k_rows} are not divisible by batch_size={batch_size}")
+            s_kv = total_k_rows // batch_size
+        else:
+            s_kv = kv_seq_len
+            if total_k_rows < batch_size * s_kv:
+                raise ValueError(
+                    f"K rows {total_k_rows} cannot cover batch_size*kv_seq_len={batch_size * s_kv}"
+                )
 
         if scale is None:
             scale = 1.0 / math.sqrt(h_qkv)
 
-        self._ensure_hbm_sub_matrix_registered(K)
-        self._ensure_hbm_sub_matrix_registered(V)
-        alloc = self.register_allocator
-        k_addr, v_addr = alloc.allocate_addr(2)
-        gp_for_preload = alloc.allocate_gp(2)
-        setup = preload_addr_reg_asm(
-            addr_reg_to_set=[k_addr, v_addr],
-            available_registers=gp_for_preload,
-            addr_reg_val=[K.hbm_addr, V.hbm_addr],
-        )
-        alloc.free_gp(gp_for_preload)
-        self.emit(setup)
+        if s_q > mlen or s_kv > mlen:
+            raise NotImplementedError("Packed GQA lowering currently supports one sequence tile.")
+        if V.shape[0] < batch_size * s_kv:
+            raise ValueError(f"V rows {V.shape[0]} cannot cover batch_size*kv_seq_len={batch_size * s_kv}")
 
-        q_vram_base = self.get_vram_addr(Q.name)
-        s_name = self._scoped_name("_gqa_S")
-        pv_name = self._scoped_name("_gqa_PV")
+        q_physical_rows_total, q_physical_cols = Q.physical_shape
+        k_physical_rows_total, _k_physical_cols = K.physical_shape
+        v_physical_rows_total, _v_physical_cols = V.physical_shape
+        if q_physical_rows_total % batch_size != 0:
+            raise ValueError(f"Q physical rows {q_physical_rows_total} are not divisible by batch_size={batch_size}")
+        if k_physical_rows_total % batch_size != 0:
+            raise ValueError(f"K physical rows {k_physical_rows_total} are not divisible by batch_size={batch_size}")
+        if v_physical_rows_total % batch_size != 0:
+            raise ValueError(f"V physical rows {v_physical_rows_total} are not divisible by batch_size={batch_size}")
+
+        q_rows_per_batch = q_physical_rows_total // batch_size
+        k_rows_per_batch = k_physical_rows_total // batch_size
+        v_rows_per_batch = v_physical_rows_total // batch_size
+        if q_rows_per_batch < max(mlen, s_q):
+            raise ValueError(f"Q physical rows per batch {q_rows_per_batch} are too small for seq_len={s_q}")
+        if k_rows_per_batch < max(mlen, s_kv):
+            raise ValueError(f"K physical rows per batch {k_rows_per_batch} are too small for kv_seq_len={s_kv}")
+        if v_rows_per_batch < max(mlen, s_kv):
+            raise ValueError(f"V physical rows per batch {v_rows_per_batch} are too small for kv_seq_len={s_kv}")
+        if k_rows_per_batch % mlen != 0:
+            raise ValueError(f"K physical rows per batch {k_rows_per_batch} must be multiple of MLEN={mlen}")
+        if v_rows_per_batch % mlen != 0:
+            raise ValueError(f"V physical rows per batch {v_rows_per_batch} must be multiple of MLEN={mlen}")
+
         o_name = self._scoped_name("O")
-
-        self.allocate_vram_matrix(name=s_name, rows=mlen * ratio, cols=mlen, strict=False)
-        self.allocate_vram_matrix(name=pv_name, rows=mlen * ratio, cols=mlen, strict=False)
-        self.allocate_vram_matrix(name=o_name, rows=s_q, cols=hq * h_qkv, strict=False)
-
-        br = min(mlen, s_q)
-        fp_allocs = self.fpram_allocator
-        if "_gqa_fp_const_zero" not in fp_allocs.allocations:
-            fp_allocs.allocate(name="_gqa_fp_const_zero", size=1)
-            fp_allocs.allocate(name="_gqa_fp_const_scale", size=1)
-            fp_allocs.allocate(name="_gqa_fp_const_neg_inf", size=1)
-        fp_info = self.add_fpram_object(name="_gqa_softmax_state", size=3 * br * ratio)
-        if fp_info.fpram_addr is None:
-            raise RuntimeError("Failed to allocate FPRAM for GQA softmax state")
-
-        self.emit(
-            flash_attn_asm(
-                mlen=mlen,
-                vlen=vlen,
-                blen=blen,
-                batch=1,
-                hq=hq,
-                hkv=hkv,
-                d=h_qkv,
-                q_len=s_q,
-                kv_len=s_kv,
-                alive_registers_int=list(range(1, 16)),
-                alive_registers_fp=list(range(1, 8)),
-                vector_sram_base_address=q_vram_base,
-                fp_sram_start_address=fp_info.fpram_addr,
-                k_base_hbm_offset_reg=k_addr,
-                v_base_hbm_offset_reg=v_addr,
-            )
+        logical_rows = batch_size * s_q
+        physical_rows = max(mlen, logical_rows)
+        physical_cols = math.ceil((hq * h_qkv) / mlen) * mlen
+        self.allocate_vram_matrix(
+            name=o_name,
+            rows=logical_rows,
+            cols=hq * h_qkv,
+            strict=False,
+            physical_shape=(physical_rows, physical_cols),
+        )
+        o_addr = self.get_vram_addr(o_name)
+        scratch = self.alloc(
+            "_gqa_internal_scratch",
+            mlen * broadcast_amount,
+            mlen,
+            strict=True,
         )
 
-        alloc.free_addr([k_addr, v_addr])
-        O = VRAMMatrixVar(self, o_name, (s_q, hq * h_qkv), display_name="O")
+        q_base = self.get_vram_addr(Q.name)
+        scratch_addr = self.get_vram_addr(scratch.name)
+        q_batch_stride = q_rows_per_batch * q_physical_cols
+        o_batch_stride = s_q * mlen
+        k_row_blocks_per_batch = k_rows_per_batch // mlen
+
+        for batch_idx in range(batch_size):
+            if batch_size == 1 and total_q_rows == s_q:
+                Q_batch = Q
+            else:
+                Q_batch = self.alloc_at(
+                    f"_gqa_Q_b{batch_idx}",
+                    s_q,
+                    q_total_dim,
+                    q_base + batch_idx * q_batch_stride,
+                    physical_shape=(q_rows_per_batch, q_physical_cols),
+                )
+            self._emit_packed_attention_group_internal(
+                Q_group=Q_batch,
+                K=K,
+                V=V,
+                group_heads=ratio,
+                head_slot_dim=h_qkv,
+                output_base_address=o_addr + batch_idx * o_batch_stride,
+                output_physical_rows=physical_rows,
+                scratch_base_address=scratch_addr,
+                broadcast_amount=broadcast_amount,
+                scale=scale,
+                causal_mask=None,
+                output_head_base=0,
+                k_idx=batch_idx * k_row_blocks_per_batch,
+                valid_cols=s_kv,
+            )
+
+        self.free_tensor(scratch)
+        O = VRAMMatrixVar(
+            self,
+            o_name,
+            (logical_rows, hq * h_qkv),
+            display_name="O",
+            physical_shape=(physical_rows, physical_cols),
+        )
         self._tensors[o_name] = O
         return O
+
+    def _emit_packed_qkt_to_s(
+        self,
+        *,
+        Q_group: VRAMMatrixVar,
+        K: InputVar,
+        q_idx: int,
+        k_idx: int,
+        s_base_address: int,
+        k_head_offset: int = 0,
+    ) -> None:
+        """Emit packed QK^T with M_BTMM/M_BMM_WO into head-major S tiles."""
+        self._ensure_hbm_sub_matrix_registered(K)
+        k_layout = self.get_hbm_layout(K.name)
+        self._emit_hbm_matrix_load(
+            k_layout,
+            3,
+            lambda addr_reg, gp_regs: self.load_sub_matrix_asm(
+                name=K.name,
+                row_idx=k_idx,
+                col_idx=0,
+                mram_dest_addr=0,
+                hbm_addr_reg=addr_reg,
+                gp_regs=gp_regs,
+            ),
+        )
+
+        q_base = self.get_vram_addr(Q_group.name) + q_idx * self.mlen * self.mlen
+        gp_q, gp_s = self.register_allocator.allocate_gp(2)
+        lines = [
+            "; === Packed GQA QK^T using compiler M_BTMM ===",
+            *load_large_int(gp_q, q_base),
+            f"M_BTMM {k_head_offset}, gp0, gp{gp_q}",
+            *load_large_int(gp_s, s_base_address),
+            f"M_BMM_WO gp{gp_s}, 0",
+        ]
+        self.register_allocator.free_gp([gp_q, gp_s])
+        self.emit("\n".join(lines) + "\n")
+
+    def _emit_packed_qkt_to_s_dynamic(
+        self,
+        *,
+        q_base_gp: int,
+        k_hbm_addr_reg: int,
+        s_base_address: int,
+        k_layout,
+        k_head_offset: int = 0,
+    ) -> None:
+        """Emit packed QK^T using loop-carried Q and K base registers."""
+        gp_mram, gp_hbm, gp_s = self.register_allocator.allocate_gp(3)
+        rows, cols = k_layout.physical_shape or k_layout.full_shape
+        lines = [
+            "; === Packed GQA QK^T using compiler M_BTMM (KV-looped) ===",
+            *load_large_int(gp_hbm, rows * cols),
+            f"C_SET_SCALE_REG gp{gp_hbm}",
+            *load_large_int(gp_hbm, cols),
+            f"C_SET_STRIDE_REG gp{gp_hbm}",
+            f"S_ADDI_INT gp{gp_mram}, gp0, 0",
+            f"S_ADDI_INT gp{gp_hbm}, gp0, 0",
+            f"H_PREFETCH_M gp{gp_mram}, gp{gp_hbm}, a{k_hbm_addr_reg}, 1, 0",
+            f"M_BTMM {k_head_offset}, gp0, gp{q_base_gp}",
+            *load_large_int(gp_s, s_base_address),
+            f"M_BMM_WO gp{gp_s}, 0",
+        ]
+        self.register_allocator.free_gp([gp_mram, gp_hbm, gp_s])
+        self.emit("\n".join(lines) + "\n")
+
+    def _reset_vram_from_gp(
+        self,
+        *,
+        base_gp: int,
+        rows: int,
+    ) -> None:
+        """Reset an MLEN-wide VRAM row range whose base is held in a GP register."""
+        gp_addr, gp_loop = self.register_allocator.allocate_gp(2)
+        lines = [
+            "; Reset loop-carried packed attention output group",
+            f"S_ADDI_INT gp{gp_addr}, gp{base_gp}, 0",
+            f"C_LOOP_START gp{gp_loop}, {rows}",
+            f"V_MUL_VF gp{gp_addr}, gp{gp_addr}, f0, 0",
+            f"S_ADDI_INT gp{gp_addr}, gp{gp_addr}, {self.mlen}",
+            f"C_LOOP_END gp{gp_loop}",
+        ]
+        self.register_allocator.free_gp([gp_addr, gp_loop])
+        self.emit("\n".join(lines) + "\n")
+
+    def _pack_o_head_to_output(
+        self,
+        *,
+        o_head: VRAMMatrixVar,
+        output_base_address: int,
+        output_physical_rows: int,
+        head_slot: int,
+        head_slot_dim: int,
+        rows: int,
+        scratch_address: int,
+    ) -> None:
+        """Pack the first head_slot_dim columns of o_head into one packed output lane."""
+        del output_physical_rows
+        shift = head_slot * head_slot_dim
+        gp_src, gp_dst, gp_scratch, gp_shift, gp_loop = self.register_allocator.allocate_gp(5)
+        src_addr = self.get_vram_addr(o_head.name)
+        lines = [
+            f"; === Pack O head lane {head_slot} into packed output ===",
+            *load_large_int(gp_src, src_addr),
+            *load_large_int(gp_dst, output_base_address),
+            *load_large_int(gp_scratch, scratch_address),
+            *load_large_int(gp_shift, shift),
+            f"C_LOOP_START gp{gp_loop}, {rows}",
+            f"V_SHIFT_V gp{gp_scratch}, gp{gp_src}, gp{gp_shift}",
+            f"V_ADD_VV gp{gp_dst}, gp{gp_dst}, gp{gp_scratch}, 0",
+            f"S_ADDI_INT gp{gp_src}, gp{gp_src}, {self.mlen}",
+            f"S_ADDI_INT gp{gp_dst}, gp{gp_dst}, {self.mlen}",
+            f"C_LOOP_END gp{gp_loop}",
+        ]
+        self.register_allocator.free_gp([gp_src, gp_dst, gp_scratch, gp_shift, gp_loop])
+        self.emit("\n".join(lines) + "\n")
+
+    def _pack_o_head_to_output_dynamic(
+        self,
+        *,
+        o_head: VRAMMatrixVar,
+        output_base_gp: int,
+        head_slot: int,
+        head_slot_dim: int,
+        rows: int,
+        scratch_address: int,
+    ) -> None:
+        """Pack one O scratch head into a loop-carried packed-output group."""
+        shift = head_slot * head_slot_dim
+        gp_src, gp_dst, gp_scratch, gp_shift, gp_loop = self.register_allocator.allocate_gp(5)
+        src_addr = self.get_vram_addr(o_head.name)
+        lines = [
+            f"; === Pack O head lane {head_slot} into KV-looped packed output ===",
+            *load_large_int(gp_src, src_addr),
+            f"S_ADDI_INT gp{gp_dst}, gp{output_base_gp}, 0",
+            *load_large_int(gp_scratch, scratch_address),
+            *load_large_int(gp_shift, shift),
+            f"C_LOOP_START gp{gp_loop}, {rows}",
+            f"V_SHIFT_V gp{gp_scratch}, gp{gp_src}, gp{gp_shift}",
+            f"V_ADD_VV gp{gp_dst}, gp{gp_dst}, gp{gp_scratch}, 0",
+            f"S_ADDI_INT gp{gp_src}, gp{gp_src}, {self.mlen}",
+            f"S_ADDI_INT gp{gp_dst}, gp{gp_dst}, {self.mlen}",
+            f"C_LOOP_END gp{gp_loop}",
+        ]
+        self.register_allocator.free_gp([gp_src, gp_dst, gp_scratch, gp_shift, gp_loop])
+        self.emit("\n".join(lines) + "\n")
+
+    def _emit_packed_attention_group_internal(
+        self,
+        *,
+        Q_group: VRAMMatrixVar,
+        K: InputVar,
+        V: InputVar,
+        group_heads: int,
+        head_slot_dim: int,
+        output_base_address: int,
+        output_physical_rows: int,
+        scratch_base_address: int,
+        broadcast_amount: int,
+        scale: float,
+        causal_mask: bool | VRAMMatrixVar | None,
+        output_head_base: int = 0,
+        k_idx: int = 0,
+        valid_cols: int | None = None,
+    ) -> None:
+        """Compiler-owned packed-head flash attention for one KV group."""
+        seq_len, q_width = Q_group.shape
+        mlen = self.mlen
+        q_physical_width = Q_group.physical_shape[1]
+        if q_width > mlen or q_physical_width != mlen:
+            raise ValueError(
+                f"packed Q group must fit in one physical MLEN row, "
+                f"got logical_width={q_width}, physical_width={q_physical_width}, MLEN={mlen}"
+            )
+        if seq_len > mlen:
+            raise NotImplementedError("Packed attention currently supports one sequence tile.")
+        if group_heads > broadcast_amount:
+            raise ValueError(f"group_heads={group_heads} exceeds broadcast_amount={broadcast_amount}")
+        if broadcast_amount * head_slot_dim != mlen:
+            raise ValueError(
+                f"broadcast_amount*head_slot_dim must equal MLEN "
+                f"({broadcast_amount}*{head_slot_dim} != {mlen})"
+            )
+        if getattr(self, "hlen", head_slot_dim) != head_slot_dim:
+            raise ValueError(f"Packed attention requires HLEN={head_slot_dim}, got {self.hlen}")
+
+        self._ensure_hbm_sub_matrix_registered(K)
+        self._ensure_hbm_sub_matrix_registered(V)
+        self._ensure_vram_matrix_layout(Q_group.name)
+
+        rows = min(mlen, seq_len)
+        # M_BTMM applies the emulator's fixed bmm_scale (0.25). Compensate in
+        # online softmax so the effective QK scale remains caller-provided.
+        softmax_scale = scale / 0.25
+
+        s_views = [
+            self.alloc_at(
+                f"_packed_S_h{head}",
+                mlen,
+                mlen,
+                scratch_base_address + head * mlen * mlen,
+                physical_shape=(mlen, mlen),
+            )
+            for head in range(group_heads)
+        ]
+        pv = self.alloc("_packed_PV", rows, head_slot_dim, strict=False, physical_shape=(mlen, mlen))
+        pack_scratch = self.alloc("_packed_pack_scratch", 1, mlen, strict=False, physical_shape=(1, mlen))
+        pack_scratch_addr = self.get_vram_addr(pack_scratch.name)
+
+        self.emit(
+            self._reset_vram_asm(
+                start_address=output_base_address,
+                rows=rows,
+                cols=mlen,
+                total_rows=output_physical_rows,
+                mlen=mlen,
+            )
+        )
+        self._emit_packed_qkt_to_s(
+            Q_group=Q_group,
+            K=K,
+            q_idx=0,
+            k_idx=k_idx,
+            s_base_address=scratch_base_address,
+        )
+
+        for head, s_head in enumerate(s_views):
+            o_head = self.alloc(
+                f"_packed_O_head{head}",
+                rows,
+                head_slot_dim,
+                strict=False,
+                physical_shape=(mlen, mlen),
+            )
+            self.init_online_softmax(0, o_head, rows=rows)
+            if isinstance(causal_mask, VRAMMatrixVar):
+                self.vram_add(s_head, causal_mask, num_rows=rows)
+            elif causal_mask is True:
+                self.emit("; NOTE: packed attention received causal_mask=True without a VRAM mask; no mask applied.\n")
+            self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=valid_cols or seq_len)
+            self.compute_pv(s_head, V, k_idx, pv, head_slot_dim, rows=rows)
+            self.scale_o_row(o_head, 0, rows=rows)
+            self.vram_add(o_head, pv, num_rows=rows)
+            self.final_scale_o(0, o_head, rows=rows)
+            output_head = output_head_base + head
+            output_col_block = (output_head * head_slot_dim) // mlen
+            output_lane = (output_head * head_slot_dim) % mlen // head_slot_dim
+            output_block_base = output_base_address + output_col_block * output_physical_rows * mlen
+            self._pack_o_head_to_output(
+                o_head=o_head,
+                output_base_address=output_block_base,
+                output_physical_rows=output_physical_rows,
+                head_slot=output_lane,
+                head_slot_dim=head_slot_dim,
+                rows=rows,
+                scratch_address=pack_scratch_addr,
+            )
+            self.free_tensor(o_head)
+
+        self.free_tensor(pv)
+        self.free_tensor(pack_scratch)
+
+    def flash_attention_packed_groups_looped(
+        self,
+        Q_full: VRAMMatrixVar,
+        kv_pairs: list[tuple[InputVar, InputVar]],
+        *,
+        group_heads: int,
+        head_slot_dim: int,
+        output_base_address: int,
+        scratch_base_address: int,
+        broadcast_amount: int,
+        scale=None,
+        causal_mask: bool | VRAMMatrixVar | None = True,
+    ) -> None:
+        """Emit packed GQA attention with one hardware loop over KV groups.
+
+        This rolls only the attention core. Q/K/V projection and RoPE lowering
+        still happen before this call, but the repeated QK/softmax/PV/O body is
+        emitted once and parameterized by loop-carried Q/O VRAM and K/V HBM
+        pointers.
+        """
+        if not kv_pairs:
+            raise ValueError("kv_pairs must not be empty")
+        seq_len, _q_width = Q_full.shape
+        mlen = self.mlen
+        num_kv_heads = len(kv_pairs)
+        q_physical_rows, q_physical_cols = Q_full.physical_shape
+        if seq_len > mlen:
+            raise NotImplementedError("KV-group looped packed attention currently supports one sequence tile.")
+        if q_physical_cols < num_kv_heads * mlen:
+            raise ValueError(
+                f"Q_full physical cols {q_physical_cols} cannot hold {num_kv_heads} MLEN-wide groups"
+            )
+        if group_heads > broadcast_amount:
+            raise ValueError(f"group_heads={group_heads} exceeds broadcast_amount={broadcast_amount}")
+        if broadcast_amount * head_slot_dim != mlen:
+            raise ValueError(
+                f"broadcast_amount*head_slot_dim must equal MLEN "
+                f"({broadcast_amount}*{head_slot_dim} != {mlen})"
+            )
+        if getattr(self, "hlen", head_slot_dim) != head_slot_dim:
+            raise ValueError(f"Packed attention requires HLEN={head_slot_dim}, got {self.hlen}")
+        if scale is None:
+            scale = 1.0 / math.sqrt(head_slot_dim)
+
+        for K, V in kv_pairs:
+            self._ensure_hbm_sub_matrix_registered(K)
+            self._ensure_hbm_sub_matrix_registered(V)
+            if K.physical_shape != kv_pairs[0][0].physical_shape:
+                raise ValueError("all looped K heads must share physical_shape")
+            if V.physical_shape != kv_pairs[0][1].physical_shape:
+                raise ValueError("all looped V heads must share physical_shape")
+
+        if num_kv_heads > 1:
+            k_stride = kv_pairs[1][0].hbm_addr - kv_pairs[0][0].hbm_addr
+            v_stride = kv_pairs[1][1].hbm_addr - kv_pairs[0][1].hbm_addr
+            for idx in range(1, num_kv_heads):
+                if kv_pairs[idx][0].hbm_addr != kv_pairs[0][0].hbm_addr + idx * k_stride:
+                    raise ValueError("K head HBM bases are not affine; cannot roll KV groups")
+                if kv_pairs[idx][1].hbm_addr != kv_pairs[0][1].hbm_addr + idx * v_stride:
+                    raise ValueError("V head HBM bases are not affine; cannot roll KV groups")
+        else:
+            k_stride = 0
+            v_stride = 0
+
+        q_group_stride = q_physical_rows * mlen
+        o_group_stride = q_physical_rows * mlen
+        rows = min(mlen, seq_len)
+        softmax_scale = scale / 0.25
+        k_layout = self.get_hbm_layout(kv_pairs[0][0].name)
+
+        s_views = [
+            self.alloc_at(
+                f"_packed_loop_S_h{head}",
+                mlen,
+                mlen,
+                scratch_base_address + head * mlen * mlen,
+                physical_shape=(mlen, mlen),
+            )
+            for head in range(group_heads)
+        ]
+        pv = self.alloc("_packed_loop_PV", rows, head_slot_dim, strict=False, physical_shape=(mlen, mlen))
+        pack_scratch = self.alloc("_packed_loop_pack_scratch", 1, mlen, strict=False, physical_shape=(1, mlen))
+        pack_scratch_addr = self.get_vram_addr(pack_scratch.name)
+
+        gp_q, gp_o, gp_k, gp_v, gp_tmp, gp_kv_loop = self.register_allocator.allocate_gp(6)
+        k_addr_reg, v_addr_reg = self.register_allocator.allocate_addr(2)
+        try:
+            setup_lines = [
+                "; === Packed GQA attention core loop over KV groups ===",
+                *load_large_int(gp_q, self.get_vram_addr(Q_full.name)),
+                *load_large_int(gp_o, output_base_address),
+                *load_large_int(gp_k, kv_pairs[0][0].hbm_addr),
+                *load_large_int(gp_v, kv_pairs[0][1].hbm_addr),
+                f"C_LOOP_START gp{gp_kv_loop}, {num_kv_heads}",
+                f"C_SET_ADDR_REG a{k_addr_reg}, gp0, gp{gp_k}",
+                f"C_SET_ADDR_REG a{v_addr_reg}, gp0, gp{gp_v}",
+            ]
+            self.emit("\n".join(setup_lines) + "\n")
+
+            self._reset_vram_from_gp(base_gp=gp_o, rows=rows)
+            self._emit_packed_qkt_to_s_dynamic(
+                q_base_gp=gp_q,
+                k_hbm_addr_reg=k_addr_reg,
+                s_base_address=scratch_base_address,
+                k_layout=k_layout,
+            )
+
+            for head, s_head in enumerate(s_views):
+                o_head = self.alloc(
+                    f"_packed_loop_O_head{head}",
+                    rows,
+                    head_slot_dim,
+                    strict=False,
+                    physical_shape=(mlen, mlen),
+                )
+                self.init_online_softmax(0, o_head, rows=rows)
+                if isinstance(causal_mask, VRAMMatrixVar):
+                    self.vram_add(s_head, causal_mask, num_rows=rows)
+                elif causal_mask is True:
+                    self.emit("; NOTE: packed attention received causal_mask=True without a VRAM mask; no mask applied.\n")
+                self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=seq_len)
+                self.emit(
+                    self._pv_multiply_asm(
+                        mlen=mlen,
+                        blen=self.blen,
+                        head_dim=head_slot_dim,
+                        p_address=self.get_vram_addr(s_head.name),
+                        v_hbm_offset_reg=v_addr_reg,
+                        v_hbm_offset=0,
+                        pv_address=self.get_vram_addr(pv.name),
+                        rows=rows,
+                    )
+                )
+                self.scale_o_row(o_head, 0, rows=rows)
+                self.vram_add(o_head, pv, num_rows=rows)
+                self.final_scale_o(0, o_head, rows=rows)
+                self._pack_o_head_to_output_dynamic(
+                    o_head=o_head,
+                    output_base_gp=gp_o,
+                    head_slot=head,
+                    head_slot_dim=head_slot_dim,
+                    rows=rows,
+                    scratch_address=pack_scratch_addr,
+                )
+                self.free_tensor(o_head)
+
+            update_lines = []
+            update_lines.extend(add_large_int(gp_q, gp_q, q_group_stride, temp_reg=gp_tmp))
+            update_lines.extend(add_large_int(gp_o, gp_o, o_group_stride, temp_reg=gp_tmp))
+            update_lines.extend(add_large_int(gp_k, gp_k, k_stride, temp_reg=gp_tmp))
+            update_lines.extend(add_large_int(gp_v, gp_v, v_stride, temp_reg=gp_tmp))
+            update_lines.append(f"C_LOOP_END gp{gp_kv_loop}")
+            self.emit("\n".join(update_lines) + "\n")
+        finally:
+            self.register_allocator.free_addr([k_addr_reg, v_addr_reg])
+            self.register_allocator.free_gp([gp_q, gp_o, gp_k, gp_v, gp_tmp, gp_kv_loop])
+            self.free_tensor(pv)
+            self.free_tensor(pack_scratch)
 
     def flash_attention_packed_group(
         self,
@@ -153,7 +783,9 @@ class ProgramAttentionMixin:
         scratch_base_address: int,
         broadcast_amount: int,
         scale=None,
-        causal_mask: bool = True,
+        causal_mask: bool | VRAMMatrixVar | None = True,
+        k_idx: int = 0,
+        valid_cols: int | None = None,
     ) -> None:
         """Emit one KV group's packed-head flash-attention body.
 
@@ -162,7 +794,6 @@ class ProgramAttentionMixin:
         """
         seq_len, q_width = Q_group.shape
         mlen = self.mlen
-        vlen = mlen
         if q_width != mlen:
             raise ValueError(f"packed Q group must be one MLEN row wide, got {q_width}")
         if group_heads > broadcast_amount:
@@ -177,47 +808,21 @@ class ProgramAttentionMixin:
         if scale is None:
             scale = 1.0 / math.sqrt(head_slot_dim)
 
-        self._ensure_hbm_sub_matrix_registered(K)
-        self._ensure_hbm_sub_matrix_registered(V)
-        alloc = self.register_allocator
-        k_addr, v_addr = alloc.allocate_addr(2)
-        gp_for_preload = alloc.allocate_gp(2)
-        setup = preload_addr_reg_asm(
-            addr_reg_to_set=[k_addr, v_addr],
-            available_registers=gp_for_preload,
-            addr_reg_val=[K.hbm_addr, V.hbm_addr],
+        self._emit_packed_attention_group_internal(
+            Q_group=Q_group,
+            K=K,
+            V=V,
+            group_heads=group_heads,
+            head_slot_dim=head_slot_dim,
+            output_base_address=output_base_address,
+            output_physical_rows=Q_group.physical_shape[0],
+            scratch_base_address=scratch_base_address,
+            broadcast_amount=broadcast_amount,
+            scale=scale,
+            causal_mask=causal_mask,
+            k_idx=k_idx,
+            valid_cols=valid_cols,
         )
-        alloc.free_gp(gp_for_preload)
-        self.emit(setup)
-
-        self.emit(
-            flash_attn_asm(
-                mlen=mlen,
-                vlen=vlen,
-                blen=self.blen,
-                batch=1,
-                hq=group_heads,
-                hkv=1,
-                d=head_slot_dim,
-                q_len=seq_len,
-                kv_len=seq_len,
-                alive_registers_int=list(range(1, 16)),
-                alive_registers_fp=list(range(1, 8)),
-                vector_sram_base_address=self.get_vram_addr(Q_group.name),
-                fp_sram_start_address=self._ONLINE_SOFTMAX_FPSRAM_BASE,
-                k_base_hbm_offset_reg=k_addr,
-                v_base_hbm_offset_reg=v_addr,
-                scratch_base_address=scratch_base_address,
-                output_base_address=output_base_address,
-                broadcast_amount=broadcast_amount,
-                packed_group_layout=True,
-                attn_scale_fp_address=1,
-                inf_fp_address=2,
-                causal_mask=causal_mask,
-            )
-        )
-
-        alloc.free_addr([k_addr, v_addr])
 
     def init_online_softmax(self, q_idx: int, o_matrix: VRAMMatrixVar, rows: int | None = None):
         """Initialize Online Softmax state: m=-inf, l=0, O_row=0"""
@@ -232,12 +837,19 @@ class ProgramAttentionMixin:
             rows=rows,
         )
 
-    def online_softmax_block(self, s_block: VRAMMatrixVar, scale: float, rows: int | None = None):
+    def online_softmax_block(
+        self,
+        s_block: VRAMMatrixVar,
+        scale: float,
+        rows: int | None = None,
+        valid_cols: int | None = None,
+    ):
         """Perform Online Softmax on S block"""
         super().online_softmax_block(
             s_block_matrix=s_block.name,
             scale=scale,
             rows=rows,
+            valid_cols=valid_cols,
         )
 
     def compute_pv(

--- a/aten/plena/program_matrix_ops.py
+++ b/aten/plena/program_matrix_ops.py
@@ -6,13 +6,13 @@ import math
 
 from compiler.aten.plena.vars import InputVar, TensorVar, VRAMMatrixVar
 
-MAX_K_TILES = 4  # MRAM capacity: 4 x mlen^2 elements
 
-
-def _iter_k_chunks(num_k_tiles: int):
+def _iter_k_chunks(num_k_tiles: int, max_k_tiles: int):
+    if max_k_tiles <= 0:
+        raise ValueError(f"max_k_tiles must be > 0, got {max_k_tiles}")
     k_start = 0
     while k_start < num_k_tiles:
-        k_end = min(k_start + MAX_K_TILES, num_k_tiles)
+        k_end = min(k_start + max_k_tiles, num_k_tiles)
         yield k_start, k_end - k_start
         k_start = k_end
 
@@ -133,6 +133,7 @@ class ProgramMatrixOpsMixin:
             raise ValueError(f"out_features ({out_features}) must be a multiple of mlen ({mlen})")
         num_col_blocks = out_features // mlen
         num_k_tiles = math.ceil(k_total / mlen)
+        max_k_tiles = self.mram_tile_capacity
 
         # When rows is not a multiple of mlen the hardware still operates on
         # full tiles; only the first `rows` rows contain valid output.
@@ -150,7 +151,7 @@ class ProgramMatrixOpsMixin:
                 **k_split,
             )
 
-        if num_k_tiles <= MAX_K_TILES:
+        if num_k_tiles <= max_k_tiles:
             for col_idx in range(num_col_blocks):
                 for row_idx in range(num_row_blocks):
                     emit_projection(row_idx, col_idx, output, row_idx, col_idx)
@@ -159,7 +160,7 @@ class ProgramMatrixOpsMixin:
         # Temp buffer for one partial-sum tile. Allocating the full output shape
         # here can overlap with the real output for wide projections.
         temp = self.alloc(f"{name}_temp", mlen, mlen)
-        for k_chunk_idx, (k_block_start, k_block_count) in enumerate(_iter_k_chunks(num_k_tiles)):
+        for k_chunk_idx, (k_block_start, k_block_count) in enumerate(_iter_k_chunks(num_k_tiles, max_k_tiles)):
             k_split = {
                 "k_block_start": k_block_start,
                 "k_block_count": k_block_count,

--- a/aten/plena/program_matrix_ops.py
+++ b/aten/plena/program_matrix_ops.py
@@ -36,6 +36,7 @@ class ProgramMatrixOpsMixin:
             name=input_var.name,
             hbm_addr=input_var.hbm_addr,
             shape=(h, w),
+            physical_shape=input_var.physical_shape,
             real_data_ratio=self.real_data_ratio,
         )
         self._registered_hbm_sub_matrices[input_var.name] = True
@@ -47,6 +48,7 @@ class ProgramMatrixOpsMixin:
         super().ensure_vram_matrix_layout(
             name=matrix_var.name,
             shape=matrix_var.shape,
+            physical_shape=matrix_var.physical_shape,
         )
         self._registered_vram_sub_matrices[matrix_var.name] = True
 

--- a/aten/plena/program_matrix_ops.py
+++ b/aten/plena/program_matrix_ops.py
@@ -267,6 +267,24 @@ class ProgramMatrixOpsMixin:
         self.vram_add(input_var, pos_weight_var)
         return input_var
 
+    def vram_mul(
+        self,
+        dst: VRAMMatrixVar,
+        src: VRAMMatrixVar,
+        dst_row_offset: int = 0,
+        src_row_offset: int = 0,
+        num_rows: int | None = None,
+    ):
+        """VRAM matrix multiply: dst[row_offset:] *= src."""
+        super().vram_matrix_mul(
+            dst_matrix=dst.name,
+            src_matrix=src.name,
+            dst_row_offset=dst_row_offset,
+            src_row_offset=src_row_offset,
+            num_rows=num_rows,
+        )
+        return dst
+
     def vram_block_add_to(
         self,
         src1: TensorVar,

--- a/aten/plena/program_matrix_ops.py
+++ b/aten/plena/program_matrix_ops.py
@@ -122,22 +122,43 @@ class ProgramMatrixOpsMixin:
             target_col_idx=target_col_idx,
         )
 
-    def linear_projection(self, input_var: VRAMMatrixVar, weight_var: InputVar, name: str = "linear_out"):
+    def linear_projection(
+        self,
+        input_var: VRAMMatrixVar,
+        weight_var: InputVar,
+        name: str = "linear_out",
+        physical_shape: tuple[int, int] | None = None,
+    ):
         """Emit tiled PLENA linear projection, including K-split accumulation."""
         mlen = self.mlen
 
         rows, k_total = input_var.shape
         _, out_features = weight_var.shape
-        num_row_blocks = math.ceil(rows / mlen)
-        if out_features % mlen != 0:
-            raise ValueError(f"out_features ({out_features}) must be a multiple of mlen ({mlen})")
-        num_col_blocks = out_features // mlen
-        num_k_tiles = math.ceil(k_total / mlen)
+        if physical_shape is None:
+            physical_rows = max(input_var.physical_shape[0], math.ceil(rows / self.blen) * self.blen)
+            physical_out_features = weight_var.physical_shape[1]
+        else:
+            physical_rows, physical_out_features = physical_shape
+            if physical_rows < rows or physical_out_features < out_features:
+                raise ValueError(
+                    f"physical_shape {physical_shape} cannot be smaller than "
+                    f"logical output {(rows, out_features)}"
+                )
+        physical_k = max(input_var.physical_shape[1], weight_var.physical_shape[0])
+        num_row_blocks = math.ceil(physical_rows / mlen)
+        num_col_blocks = math.ceil(physical_out_features / mlen)
+        num_k_tiles = math.ceil(physical_k / mlen)
         max_k_tiles = self.mram_tile_capacity
 
         # When rows is not a multiple of mlen the hardware still operates on
         # full tiles; only the first `rows` rows contain valid output.
-        output = self.alloc(name, rows, out_features, strict=rows % mlen == 0)
+        output = self.alloc(
+            name,
+            rows,
+            out_features,
+            strict=False,
+            physical_shape=(physical_rows, physical_out_features),
+        )
 
         def emit_projection(row_idx, col_idx, target, target_row_idx, target_col_idx, **k_split):
             self.vram_sub_projection_to(
@@ -185,9 +206,14 @@ class ProgramMatrixOpsMixin:
         self.free_tensor(temp)
         return output
 
-    def linear(self, input_var: VRAMMatrixVar, weight_var: InputVar):
+    def linear(
+        self,
+        input_var: VRAMMatrixVar,
+        weight_var: InputVar,
+        physical_shape: tuple[int, int] | None = None,
+    ):
         """Default linear op compatibility surface."""
-        return self.linear_projection(input_var, weight_var)
+        return self.linear_projection(input_var, weight_var, physical_shape=physical_shape)
 
     # ========================================================================
     # RoPE (1D Positional Encoding)

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -396,6 +396,16 @@ class ProgramTensorMixin:
         activation_base_address = self.get_vram_addr(input_var.name)
         max_k_tiles = max(hidden_size // mlen, inter_dim // mlen)
         use_loop_instructions = max_k_tiles <= self.mram_tile_capacity
+        workspace_elems = batch_size * (2 * inter_dim + max(hidden_size, inter_dim))
+        workspace_rows = (workspace_elems + mlen - 1) // mlen
+        workspace = self.alloc(
+            "_ffn_workspace",
+            workspace_rows,
+            mlen,
+            strict=False,
+            physical_shape=(workspace_rows, mlen),
+        )
+        workspace_base_address = self.get_vram_addr(workspace.name)
 
         isa_code = preload_addr_reg_asm(
             addr_reg_to_set=[1, 2, 3],
@@ -419,9 +429,11 @@ class ProgramTensorMixin:
             activation_base_address=activation_base_address,
             use_loop_instructions=use_loop_instructions,
             matrix_sram_size=self.mram_capacity_elems,
+            workspace_base_address=workspace_base_address,
         )
 
         self.emit(isa_code)
+        self.free_tensor(workspace)
         return input_var
 
 

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -111,7 +111,10 @@ class ProgramTensorMixin:
         else:
             # Normal path: emit HBM → VRAM prefetch ISA.
             super().load_batch(
-                hbm_object_name=input_var.name, vram_object_name=internal_name, vlen=self.mlen, preload_len=4
+                hbm_object_name=input_var.name,
+                vram_object_name=internal_name,
+                vlen=self.mlen,
+                preload_len=self.hbm_v_prefetch_amount,
             )
 
         var = VRAMMatrixVar(
@@ -155,6 +158,7 @@ class ProgramTensorMixin:
             hbm_addr=hbm_addr,
             hbm_object_name=internal_name,
             vlen=self.mlen,
+            store_amount=self.hbm_v_writeback_amount,
         )
 
         var = InputVar(
@@ -385,11 +389,13 @@ class ProgramTensorMixin:
 
     def ffn(self, input_var: VRAMMatrixVar, w_gate: InputVar, w_up: InputVar, w_down: InputVar):
         """Emit the fused FFN kernel and return the in-place activation var."""
-        batch_size, hidden_size = input_var.shape
-        _, inter_dim = w_up.shape
+        batch_size, hidden_size = input_var.physical_shape
+        _, inter_dim = w_up.physical_shape
         mlen = self.mlen
         blen = self.blen
         activation_base_address = self.get_vram_addr(input_var.name)
+        max_k_tiles = max(hidden_size // mlen, inter_dim // mlen)
+        use_loop_instructions = max_k_tiles <= self.mram_tile_capacity
 
         isa_code = preload_addr_reg_asm(
             addr_reg_to_set=[1, 2, 3],
@@ -411,7 +417,8 @@ class ProgramTensorMixin:
             down_weight_hbm_offset_reg=3,
             const_one_fp_address=5,
             activation_base_address=activation_base_address,
-            use_loop_instructions=True,
+            use_loop_instructions=use_loop_instructions,
+            matrix_sram_size=self.mram_capacity_elems,
         )
 
         self.emit(isa_code)

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -17,6 +17,7 @@ class ProgramTensorMixin:
         shape: tuple[int, int],
         hbm_addr: int | None = None,
         prestaged_vram_addr: int | None = None,
+        physical_shape: tuple[int, int] | None = None,
     ) -> InputVar:
         """
         Declare an input tensor (in HBM).
@@ -34,19 +35,28 @@ class ProgramTensorMixin:
         Returns:
             InputVar proxy object
         """
-        h, w = shape
+        h, w = physical_shape or shape
         size = h * w
         hbm_size = int(size * self.real_data_ratio)
 
         if hbm_addr is None:
             hbm_addr = self._allocate_hbm(hbm_size)
 
-        var = InputVar(self, name, shape, hbm_addr, hbm_size, prestaged_vram_addr=prestaged_vram_addr)
+        var = InputVar(
+            self,
+            name,
+            shape,
+            hbm_addr,
+            hbm_size,
+            prestaged_vram_addr=prestaged_vram_addr,
+            physical_shape=physical_shape,
+        )
         self._inputs[name] = var
         super().add_hbm_object(
             name=name,
             hbm_addr=hbm_addr,
             shape=shape,
+            physical_shape=physical_shape,
             real_data_ratio=self.real_data_ratio,
         )
         return var
@@ -83,14 +93,15 @@ class ProgramTensorMixin:
 
         if input_var.prestaged_vram_addr is not None:
             # Prestaged path: tensor is already in VRAM — register without ISA.
-            h, w = input_var.shape
+            h, w = input_var.physical_shape
             vram_addr = input_var.prestaged_vram_addr
             # Tell the VRAM allocator that this region is occupied so subsequent
             # allocations don't collide with it.
             self.vram_allocator._vmm.mark_used(vram_addr, h * w, name=internal_name)
             super().add_vram_object(
                 name=internal_name,
-                shape=(h, w),
+                shape=input_var.shape,
+                physical_shape=input_var.physical_shape,
                 vram_addr=vram_addr,
                 dtype="fp16",
                 kind="Batch",
@@ -103,7 +114,13 @@ class ProgramTensorMixin:
                 hbm_object_name=input_var.name, vram_object_name=internal_name, vlen=self.mlen, preload_len=4
             )
 
-        var = VRAMMatrixVar(self, internal_name, input_var.shape, display_name=display_name)
+        var = VRAMMatrixVar(
+            self,
+            internal_name,
+            input_var.shape,
+            display_name=display_name,
+            physical_shape=input_var.physical_shape,
+        )
         self._tensors[internal_name] = var
         return var
 
@@ -125,12 +142,12 @@ class ProgramTensorMixin:
         internal_name = self._scoped_name(display_name)
 
         if hbm_addr is None:
-            h, w = tensor_var.shape
+            h, w = tensor_var.physical_shape
             size = h * w
             hbm_size = int(size * self.real_data_ratio)
             hbm_addr = self._allocate_hbm(hbm_size)
         else:
-            h, w = tensor_var.shape
+            h, w = tensor_var.physical_shape
             hbm_size = int(h * w * self.real_data_ratio)
 
         super().store_to_hbm(
@@ -140,7 +157,15 @@ class ProgramTensorMixin:
             vlen=self.mlen,
         )
 
-        var = InputVar(self, internal_name, tensor_var.shape, hbm_addr, hbm_size, display_name=display_name)
+        var = InputVar(
+            self,
+            internal_name,
+            tensor_var.shape,
+            hbm_addr,
+            hbm_size,
+            display_name=display_name,
+            physical_shape=tensor_var.physical_shape,
+        )
         self._inputs[internal_name] = var
         return var
 
@@ -148,7 +173,14 @@ class ProgramTensorMixin:
     # VRAM Matrix Allocation
     # ========================================================================
 
-    def alloc(self, name: str, rows: int, cols: int, strict: bool = True) -> VRAMMatrixVar:
+    def alloc(
+        self,
+        name: str,
+        rows: int,
+        cols: int,
+        strict: bool = True,
+        physical_shape: tuple[int, int] | None = None,
+    ) -> VRAMMatrixVar:
         """
         Allocate a VRAM matrix.
 
@@ -166,13 +198,36 @@ class ProgramTensorMixin:
         """
         display_name = name
         internal_name = self._scoped_name(name)
-        super().allocate_vram_matrix(name=internal_name, rows=rows, cols=cols, strict=strict)
+        if physical_shape is None and not strict:
+            physical_rows = ((rows + self.blen - 1) // self.blen) * self.blen
+            physical_cols = ((cols + self.mlen - 1) // self.mlen) * self.mlen
+            physical_shape = (max(self.blen, physical_rows), max(self.mlen, physical_cols))
+        super().allocate_vram_matrix(
+            name=internal_name,
+            rows=rows,
+            cols=cols,
+            strict=strict,
+            physical_shape=physical_shape,
+        )
 
-        var = VRAMMatrixVar(self, internal_name, (rows, cols), display_name=display_name)
+        var = VRAMMatrixVar(
+            self,
+            internal_name,
+            (rows, cols),
+            display_name=display_name,
+            physical_shape=physical_shape,
+        )
         self._tensors[internal_name] = var
         return var
 
-    def alloc_at(self, name: str, rows: int, cols: int, vram_addr: int) -> VRAMMatrixVar:
+    def alloc_at(
+        self,
+        name: str,
+        rows: int,
+        cols: int,
+        vram_addr: int,
+        physical_shape: tuple[int, int] | None = None,
+    ) -> VRAMMatrixVar:
         """Allocate a VRAM matrix view at a specific address.
 
         Used to create views into existing VRAM matrices (e.g., per-head
@@ -194,12 +249,20 @@ class ProgramTensorMixin:
         self.add_vram_object(
             name=internal_name,
             shape=(rows, cols),
+            physical_shape=physical_shape,
             vram_addr=vram_addr,
             allocate_if_none=False,
+            strict=False,
         )
         isa_code = f"; VRAM View {name}: ({rows}, {cols}) at VRAM[{vram_addr}]\n"
         self.emit(isa_code)
-        var = VRAMMatrixVar(self, internal_name, (rows, cols), display_name=display_name)
+        var = VRAMMatrixVar(
+            self,
+            internal_name,
+            (rows, cols),
+            display_name=display_name,
+            physical_shape=physical_shape,
+        )
         self._tensors[internal_name] = var
         return var
 

--- a/aten/plena/vars.py
+++ b/aten/plena/vars.py
@@ -25,12 +25,14 @@ class TensorVar:
         kind: str,
         shape: tuple[int, int],
         display_name: str | None = None,
+        physical_shape: tuple[int, int] | None = None,
     ):
         self._program = program
         self.internal_name = internal_name  # System internal name (with scope prefix), used by symbol table
         self.display_name = display_name if display_name is not None else internal_name  # User-visible name
         self.kind = kind  # "input", "batch", "matrix", "vram_matrix"
         self.shape = shape
+        self.physical_shape = physical_shape or shape
 
     @property
     def name(self) -> str:
@@ -66,8 +68,9 @@ class InputVar(TensorVar):
         hbm_size: int,
         display_name: str | None = None,
         prestaged_vram_addr: int | None = None,
+        physical_shape: tuple[int, int] | None = None,
     ):
-        super().__init__(program, name, "input", shape, display_name=display_name)
+        super().__init__(program, name, "input", shape, display_name=display_name, physical_shape=physical_shape)
         self.hbm_addr = hbm_addr
         self.hbm_size = hbm_size
         self.prestaged_vram_addr = prestaged_vram_addr
@@ -120,5 +123,19 @@ class VRAMMatrixVar(TensorVar):
     Supports sub-block indexed writes: `O[r][c] = ...`
     """
 
-    def __init__(self, program: PlenaCompiler, name: str, shape: tuple[int, int], display_name: str | None = None):
-        super().__init__(program, name, "vram_matrix", shape, display_name=display_name)
+    def __init__(
+        self,
+        program: PlenaCompiler,
+        name: str,
+        shape: tuple[int, int],
+        display_name: str | None = None,
+        physical_shape: tuple[int, int] | None = None,
+    ):
+        super().__init__(
+            program,
+            name,
+            "vram_matrix",
+            shape,
+            display_name=display_name,
+            physical_shape=physical_shape,
+        )

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -3210,11 +3210,13 @@ def compile_native_hf_decoder(
     COS = prog.load_batch(cos_input, name="COS")
     SIN = prog.load_batch(sin_input, name="SIN")
 
-    # Causal mask: (mlen, mlen) with 0 on/below diagonal, -inf above
+    # Causal mask: (mlen, mlen) with 0 on/below diagonal, -inf above.
+    # Bidirectional models (e.g. LLaDA) use an all-zero mask.
     causal_mask_data = torch.zeros(mlen, mlen)
-    causal_mask_data.masked_fill_(
-        torch.triu(torch.ones(mlen, mlen), diagonal=1).bool(), float('-inf')
-    )
+    if model_cfg.model_type != "llada":
+        causal_mask_data.masked_fill_(
+            torch.triu(torch.ones(mlen, mlen), diagonal=1).bool(), float('-inf')
+        )
     causal_mask_input = prog.input("causal_mask", shape=(mlen, mlen))
     CAUSAL_MASK = prog.load_batch(causal_mask_input, name="CAUSAL_MASK")
 

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -3448,6 +3448,11 @@ def compile_native_hf_decoder(
 
     print(f"\nCompilation complete: {info['isa_lines']} ISA lines, "
           f"{n_layers} layers, output at VRAM row {o_vram_addr // mlen}")
+    hbm_addrs = {}
+    for name, inp in prog._inputs.items():
+        if hasattr(inp, "hbm_addr"):
+            hbm_addrs[name] = inp.hbm_addr
+
     return {
         "isa": isa_code,
         "golden_output": golden_out,
@@ -3460,6 +3465,7 @@ def compile_native_hf_decoder(
         "comparison_params": comparison_params,
         "info": info,
         "stage_checkpoints": stage_checkpoint_metadata,
+        "hbm_addrs": hbm_addrs,
         "sim_golden_result": {
             "original_output": padded_golden_output,
             "tensor_layouts": tensor_layouts,

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -464,27 +464,6 @@ def _copy_into_vram_view(prog, source, name, rows, cols, vram_addr):
     return target
 
 
-def _reserve_vram_until(prog, min_next_addr: int, name: str):
-    """Bump the VRAM allocator above an absolute-address template workspace."""
-    current = prog.vram_allocator.next_free
-    if current >= min_next_addr:
-        return None
-    pad_elems = min_next_addr - current
-    pad_rows = (pad_elems + prog.mlen - 1) // prog.mlen
-    return prog.alloc(
-        name,
-        pad_rows,
-        prog.mlen,
-        strict=False,
-        physical_shape=(pad_rows, prog.mlen),
-    )
-
-
-def _ffn_absolute_workspace_end(physical_rows: int, hidden_size: int, inter_dim: int) -> int:
-    """Upper bound for the legacy FFN template's absolute low-VRAM workspace."""
-    return physical_rows * (hidden_size + 2 * inter_dim + max(hidden_size, inter_dim))
-
-
 def _free_named_tensors(prog, names):
     for name in names:
         tensor = prog._tensors.get(name)
@@ -772,7 +751,6 @@ def _emit_packed_attention_block(
                     k_idx=batch_idx * row_block_stride,
                     valid_cols=active_seq_len_per_batch,
                 )
-
     prog.free_tensor(attn_scratch)
     if checkpoint_recorder is not None:
         checkpoint_recorder.record(
@@ -1449,13 +1427,6 @@ def compile_native_hf_decoder(
     sin_input = prog.input("SIN", shape=(compile_seq_rows, rope_width), physical_shape=rope_table_physical_shape)
     COS = prog.load_batch(cos_input, name="COS")
     SIN = prog.load_batch(sin_input, name="SIN")
-
-    # The legacy FFN template uses absolute low-VRAM regions for up/gate/scratch
-    # intermediates. Reserve that region before allocating reusable tensors
-    # (causal mask, X/POS, debug checkpoints) so FFN cannot clobber them.
-    ffn_physical_rows = max(compile_seq_rows, blen, mlen)
-    ffn_workspace_end = _ffn_absolute_workspace_end(ffn_physical_rows, padded_hidden, padded_inter)
-    _reserve_vram_until(prog, ffn_workspace_end, "_ffn_absolute_workspace_padding")
 
     # Causal mask: (mlen, mlen) with 0 on/below diagonal, -inf above
     causal_mask_data = torch.zeros(mlen, mlen)

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -270,6 +270,7 @@ def compile_native_hf_decoder(
     layer_idx_start: int = 0,
     mlen: int = 64,
     blen: int = 4,
+    mram_tile_capacity: int = 4,
     seed: int = 42,
     golden_precision: str = "hardware",
     verbose: bool = False,
@@ -301,8 +302,14 @@ def compile_native_hf_decoder(
 
     print("=" * 80)
     print(f"Model Compiler - {model_cfg.model_type} ({n_layers} layer{'s' if n_layers != 1 else ''})")
-    print(f"  decoder: hidden={hidden}, inter={inter}, heads={num_heads}/{num_kv_heads}, head_dim={head_dim}")
-    print(f"  compile: seq_len={seq_len}, mlen={mlen}, blen={blen}, total_q_dim={total_q_dim}")
+    print(
+        f"  decoder: hidden={hidden}, inter={inter}, heads={num_heads}/{num_kv_heads}, "
+        f"head_dim={head_dim}"
+    )
+    print(
+        f"  compile: seq_len={seq_len}, mlen={mlen}, blen={blen}, "
+        f"mram_tile_capacity={mram_tile_capacity}, total_q_dim={total_q_dim}"
+    )
     print("=" * 80)
 
     # ----------------------------------------------------------- weights
@@ -361,6 +368,7 @@ def compile_native_hf_decoder(
         cos_table,
         sin_table,
         mlen=mlen,
+        max_k_tiles=mram_tile_capacity,
         precision=golden_policy,
         trace=lambda i, x: _verbose(f"  After layer {i}: X_gold[0,:4] = {x[0, :4].tolist()}"),
     )
@@ -378,6 +386,7 @@ def compile_native_hf_decoder(
             cos_table,
             sin_table,
             mlen=mlen,
+            max_k_tiles=mram_tile_capacity,
             precision=ReferencePrecision.from_mode("hf_fp32"),
             trace=lambda i, x: _verbose(f"  After layer {i}: X_hf[0,:4] = {x[0, :4].tolist()}"),
         )
@@ -390,7 +399,12 @@ def compile_native_hf_decoder(
     registry = OpRegistry.load()
     registry.set_backend(Backend.PLENA)
 
-    prog = PlenaCompiler(mlen=mlen, blen=blen, real_data_ratio=REAL_DATA_RATIO)
+    prog = PlenaCompiler(
+        mlen=mlen,
+        blen=blen,
+        real_data_ratio=REAL_DATA_RATIO,
+        mram_tile_capacity=mram_tile_capacity,
+    )
 
     # Shared inputs
     x_input = prog.input("X", shape=(seq_len, hidden))

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import os
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -17,15 +18,19 @@ from compiler.aten.model_extract import (
     find_model_root,
 )
 import compiler.aten.ops as ops
+from asm_templates._imm import add_large_int as _add_large_int_lines
+from asm_templates._imm import load_large_int as _load_large_int_lines
 from compiler.aten.ops.registry import Backend, OpRegistry
 from compiler.aten.plena import PlenaCompiler
 from compiler.aten.reference import (
     ReferencePrecision,
+    ScheduledReferenceConfig,
     _ksplit_matmul,
     _make_rotate_half_matrix,
     make_rope_inputs,
     quantize_to_mxfp,
     run_decoder_reference,
+    run_native_decoder_scheduled_reference,
 )
 
 __all__ = [
@@ -41,29 +46,31 @@ _IMM2_BOUND = 1 << 18  # S_ADDI_INT max immediate
 
 
 def _fix_large_immediates(isa_code: str) -> str:
-    """Post-process ISA: replace S_ADDI_INT gp{r}, gp0, {large} with S_LUI_INT + S_ADDI_INT.
+    """Post-process ISA so every S_ADDI_INT immediate fits in the 18-bit field.
 
-    PlenaCompiler emits raw S_ADDI_INT for VRAM/HBM addresses. At large
-    model dimensions these can exceed the 18-bit immediate limit. This pass
-    splits them into S_LUI_INT (upper 22 bits, shifted <<12) + S_ADDI_INT
-    (lower 12 bits), matching asm_templates._imm.load_large_int.
+    Absolute loads from gp0 use asm_templates._imm.load_large_int. Relative
+    adds use asm_templates._imm.add_large_int without a temp register, which
+    lowers to bounded S_ADDI_INT chunks and is safe as a compiler-wide pass.
     """
-    pattern = re.compile(r"^(\s*)S_ADDI_INT gp(\d+), gp0, (\d+)(.*)")
+    pattern = re.compile(r'^(\s*)S_ADDI_INT gp(\d+), gp(\d+), (\d+)(.*)')
     out = []
-    for line in isa_code.split("\n"):
+    for line in isa_code.split('\n'):
         m = pattern.match(line)
         if m:
-            indent, rd, imm_str, rest = m.groups()
+            indent, rd_str, rs_str, imm_str, rest = m.groups()
+            rd = int(rd_str)
+            rs = int(rs_str)
             imm = int(imm_str)
             if imm >= _IMM2_BOUND:
-                upper = imm >> 12
-                lower = imm & 0xFFF
-                out.append(f"{indent}S_LUI_INT gp{rd}, {upper}{rest}")
-                if lower:
-                    out.append(f"{indent}S_ADDI_INT gp{rd}, gp{rd}, {lower}{rest}")
+                replacement = (
+                    _load_large_int_lines(rd, imm)
+                    if rs == 0
+                    else _add_large_int_lines(rd, rs, imm, temp_reg=None)
+                )
+                out.extend(f"{indent}{replacement_line}{rest}" for replacement_line in replacement)
                 continue
         out.append(line)
-    return "\n".join(out)
+    return '\n'.join(out)
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +104,72 @@ class AttentionHeadPacking:
     total_q_dim: int
 
 
+@dataclass
+class StageCheckpointRecorder:
+    """Optional debug recorder for preserving VRAM stage boundaries.
+
+    The normal compiler reuses a small set of VRAM buffers. That is good for
+    execution, but bad for post-run validation because the final VRAM dump no
+    longer contains most intermediate values. When enabled, this recorder emits
+    explicit VRAM copies after selected stages and records their addresses.
+    """
+
+    enabled: bool = False
+    checkpoints: list[dict[str, Any]] | None = None
+
+    def __post_init__(self):
+        if self.checkpoints is None:
+            self.checkpoints = []
+
+    def record(
+        self,
+        prog,
+        *,
+        layer_idx: int | None,
+        stage: str,
+        tensor,
+        active_shape: tuple[int, int],
+        semantic: str,
+    ):
+        if not self.enabled:
+            return None
+
+        layer_part = "global" if layer_idx is None else f"l{layer_idx}"
+        safe_stage = re.sub(r"[^0-9A-Za-z_]+", "_", stage).strip("_")
+        name = f"checkpoint_{layer_part}_{safe_stage}"
+        checkpoint = prog.alloc(
+            name,
+            tensor.shape[0],
+            tensor.shape[1],
+            strict=False,
+            physical_shape=tensor.physical_shape,
+        )
+        prog.vram_fill_zero(checkpoint)
+        prog.vram_add(checkpoint, tensor)
+        addr = prog.get_vram_addr(checkpoint.name)
+        self.checkpoints.append(
+            {
+                "name": checkpoint.name,
+                "source": tensor.name,
+                "layer_idx": layer_idx,
+                "stage": stage,
+                "semantic": semantic,
+                "vram_addr": addr,
+                "active_shape": [int(active_shape[0]), int(active_shape[1])],
+                "logical_shape": [int(tensor.shape[0]), int(tensor.shape[1])],
+                "physical_shape": [int(tensor.physical_shape[0]), int(tensor.physical_shape[1])],
+            }
+        )
+        return checkpoint
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "kind": "native_decoder_vram_stage_checkpoints",
+            "checkpoints": list(self.checkpoints or []),
+        }
+
+
 def _ceil_to_multiple(value: int, multiple: int) -> int:
     return ((value + multiple - 1) // multiple) * multiple
 
@@ -111,6 +184,76 @@ def _pad_2d(tensor: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
     out = torch.zeros((rows, cols), dtype=tensor.dtype, device=tensor.device)
     out[:src_rows, :src_cols] = tensor
     return out.contiguous()
+
+
+def _pad_batched_sequence_storage(
+    tensor: torch.Tensor,
+    *,
+    batch_size: int,
+    seq_len: int,
+    rows_per_batch: int,
+    cols: int,
+) -> torch.Tensor:
+    """Pad (B, S, C) data into independent per-batch row slabs."""
+    if tensor.dim() == 2:
+        if batch_size != 1:
+            raise ValueError(f"2D tensor storage is only valid for batch_size=1, got {batch_size}")
+        tensor = tensor.unsqueeze(0)
+    if tensor.dim() != 3:
+        raise ValueError(f"Expected 2D or 3D sequence tensor, got shape {tuple(tensor.shape)}")
+    if tensor.shape[0] != batch_size or tensor.shape[1] != seq_len:
+        raise ValueError(
+            f"Expected tensor shape ({batch_size}, {seq_len}, C), got {tuple(tensor.shape)}"
+        )
+    if rows_per_batch < seq_len:
+        raise ValueError(f"rows_per_batch={rows_per_batch} cannot cover seq_len={seq_len}")
+    if tensor.shape[2] > cols:
+        raise ValueError(f"Cannot pad tensor with {tensor.shape[2]} cols to {cols}")
+
+    out = torch.zeros((batch_size * rows_per_batch, cols), dtype=tensor.dtype, device=tensor.device)
+    for batch_idx in range(batch_size):
+        start = batch_idx * rows_per_batch
+        out[start:start + seq_len, : tensor.shape[2]] = tensor[batch_idx]
+    return out.contiguous()
+
+
+def _repeat_sequence_storage(
+    tensor: torch.Tensor,
+    *,
+    batch_size: int,
+    seq_len: int,
+    rows_per_batch: int,
+) -> torch.Tensor:
+    """Repeat a per-position table into per-batch row slabs."""
+    if tensor.dim() != 2:
+        raise ValueError(f"Expected 2D sequence table, got shape {tuple(tensor.shape)}")
+    if tensor.shape[0] < seq_len:
+        raise ValueError(f"Table rows {tensor.shape[0]} cannot cover seq_len={seq_len}")
+    out = torch.zeros(
+        (batch_size * rows_per_batch, tensor.shape[1]),
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    for batch_idx in range(batch_size):
+        start = batch_idx * rows_per_batch
+        out[start:start + seq_len] = tensor[:seq_len]
+    return out.contiguous()
+
+
+def _compact_active_sequence_rows(
+    tensor: torch.Tensor,
+    *,
+    batch_size: int,
+    seq_len: int,
+    rows_per_batch: int,
+    cols: int,
+) -> torch.Tensor:
+    """Gather active sequence rows from per-batch slabs into compact B*S rows."""
+    rows = []
+    for batch_idx in range(batch_size):
+        start = batch_idx * rows_per_batch
+        rows.append(tensor[start:start + seq_len, :cols])
+    return torch.cat(rows, dim=0).contiguous()
 
 
 def _pad_q_weight_grouped(weight: torch.Tensor, num_heads: int, head_dim: int, padded_hidden: int, padded_head_dim: int):
@@ -229,11 +372,12 @@ def _pad_decoder_weights_for_tiles(
         w_q = _pad_q_weight_grouped(weights.w_q, num_heads, head_dim, padded_hidden, padded_head_dim)
         w_o = _pad_o_weight_grouped(weights.w_o, num_heads, head_dim, padded_head_dim, padded_hidden)
 
+    kv_head_dim = head_packing.head_slot_dim if head_packing is not None and head_packing.enabled else padded_head_dim
     return LayerWeights(
         w_q=w_q,
         w_o=w_o,
-        w_k_heads=[_pad_2d(w, padded_hidden, padded_head_dim) for w in weights.w_k_heads],
-        w_v_heads=[_pad_2d(w, padded_hidden, padded_head_dim) for w in weights.w_v_heads],
+        w_k_heads=[_pad_2d(w, padded_hidden, kv_head_dim) for w in weights.w_k_heads],
+        w_v_heads=[_pad_2d(w, padded_hidden, kv_head_dim) for w in weights.w_v_heads],
         w_gate=_pad_2d(weights.w_gate, padded_hidden, padded_inter),
         w_up=_pad_2d(weights.w_up, padded_hidden, padded_inter),
         w_down=_pad_2d(weights.w_down, padded_inter, padded_hidden),
@@ -320,6 +464,27 @@ def _copy_into_vram_view(prog, source, name, rows, cols, vram_addr):
     return target
 
 
+def _reserve_vram_until(prog, min_next_addr: int, name: str):
+    """Bump the VRAM allocator above an absolute-address template workspace."""
+    current = prog.vram_allocator.next_free
+    if current >= min_next_addr:
+        return None
+    pad_elems = min_next_addr - current
+    pad_rows = (pad_elems + prog.mlen - 1) // prog.mlen
+    return prog.alloc(
+        name,
+        pad_rows,
+        prog.mlen,
+        strict=False,
+        physical_shape=(pad_rows, prog.mlen),
+    )
+
+
+def _ffn_absolute_workspace_end(physical_rows: int, hidden_size: int, inter_dim: int) -> int:
+    """Upper bound for the legacy FFN template's absolute low-VRAM workspace."""
+    return physical_rows * (hidden_size + 2 * inter_dim + max(hidden_size, inter_dim))
+
+
 def _free_named_tensors(prog, names):
     for name in names:
         tensor = prog._tensors.get(name)
@@ -336,9 +501,13 @@ def _emit_kv_stores(
     layer_idx,
     num_kv_heads,
     physical_rows: int | None = None,
+    checkpoint_recorder: StageCheckpointRecorder | None = None,
+    active_seq_len: int | None = None,
+    active_head_dim: int | None = None,
 ):
     rope_matrix, cos_var, sin_var = rope_inputs
     kv_stored = []
+    active_seq_len = active_seq_len or current.shape[0]
     for kv_h in range(num_kv_heads):
         kv_physical_shape = None
         if physical_rows is not None:
@@ -360,6 +529,24 @@ def _emit_kv_stores(
             f"V_{layer_idx}_h{kv_h}",
             physical_shape=v_physical_shape,
         )
+        checkpoint_cols = active_head_dim or K_h.shape[1]
+        if checkpoint_recorder is not None:
+            checkpoint_recorder.record(
+                prog,
+                layer_idx=layer_idx,
+                stage=f"k_proj_h{kv_h}",
+                tensor=K_h,
+                active_shape=(active_seq_len, checkpoint_cols),
+                semantic=f"K projection for KV head {kv_h} before RoPE",
+            )
+            checkpoint_recorder.record(
+                prog,
+                layer_idx=layer_idx,
+                stage=f"v_proj_h{kv_h}",
+                tensor=V_h,
+                active_shape=(active_seq_len, checkpoint_cols),
+                semantic=f"V projection for KV head {kv_h}",
+            )
 
         _apply_rope_projection(
             prog,
@@ -369,6 +556,15 @@ def _emit_kv_stores(
             sin_var,
             f"K_rot_{layer_idx}_h{kv_h}",
         )
+        if checkpoint_recorder is not None:
+            checkpoint_recorder.record(
+                prog,
+                layer_idx=layer_idx,
+                stage=f"k_rope_h{kv_h}",
+                tensor=K_h,
+                active_shape=(active_seq_len, checkpoint_cols),
+                semantic=f"K projection for KV head {kv_h} after RoPE",
+            )
 
         K_stored = prog.store(K_h, name=f"K_stored_{layer_idx}_h{kv_h}")
         V_stored = prog.store(V_h, name=f"V_stored_{layer_idx}_h{kv_h}")
@@ -394,10 +590,46 @@ def _emit_packed_attention_block(
     num_kv_heads,
     ratio,
     head_packing: AttentionHeadPacking,
+    checkpoint_recorder: StageCheckpointRecorder | None = None,
+    active_seq_len: int | None = None,
+    active_hidden: int | None = None,
+    batch_size: int = 1,
+    rows_per_batch: int | None = None,
+    active_seq_len_per_batch: int | None = None,
 ):
-    _save_residual_and_norm(prog, current, scratch)
+    active_seq_len = active_seq_len or seq_len
+    active_hidden = active_hidden or current.shape[1]
+    active_seq_len_per_batch = active_seq_len_per_batch or seq_len
+    rows_per_batch = rows_per_batch or max(prog.mlen, seq_len)
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if rows_per_batch < active_seq_len_per_batch:
+        raise ValueError(
+            f"rows_per_batch={rows_per_batch} cannot cover active_seq_len={active_seq_len_per_batch}"
+        )
+    total_physical_rows = batch_size * rows_per_batch if batch_size > 1 else max(prog.mlen, seq_len)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="attn_input",
+            tensor=current,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="decoder layer input before attention RMS norm",
+        )
 
-    q_physical_shape = (max(prog.mlen, seq_len), head_packing.total_q_dim)
+    _save_residual_and_norm(prog, current, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="attn_norm",
+            tensor=current,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="attention RMS-normalized input",
+        )
+
+    q_physical_shape = (total_physical_rows, head_packing.total_q_dim)
     Q = _linear_projection(
         prog,
         current,
@@ -406,14 +638,24 @@ def _emit_packed_attention_block(
         physical_shape=q_physical_shape,
     )
     q_full_addr = prog.get_vram_addr(Q.name)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="q_full",
+            tensor=Q,
+            active_shape=(active_seq_len, head_packing.total_q_dim),
+            semantic="packed Q projection before RoPE",
+        )
 
     O_full = prog.alloc(
         f"O_full_{layer_idx}",
-        seq_len,
+        current.shape[0],
         head_packing.total_q_dim,
         strict=False,
-        physical_shape=(max(prog.mlen, seq_len), head_packing.total_q_dim),
+        physical_shape=(total_physical_rows, head_packing.total_q_dim),
     )
+    prog.vram_fill_zero(O_full)
     o_full_addr = prog.get_vram_addr(O_full.name)
 
     kv_stored = _emit_kv_stores(
@@ -423,7 +665,10 @@ def _emit_packed_attention_block(
         rope_inputs,
         layer_idx,
         num_kv_heads,
-        physical_rows=max(prog.mlen, seq_len),
+        physical_rows=total_physical_rows,
+        checkpoint_recorder=checkpoint_recorder,
+        active_seq_len=active_seq_len,
+        active_head_dim=head_packing.head_slot_dim,
     )
 
     scratch_rows = prog.mlen * (head_packing.broadcast_amount + ratio)
@@ -438,41 +683,127 @@ def _emit_packed_attention_block(
     rope_matrix, cos_var, sin_var = rope_inputs
     q_group_stride = Q.physical_shape[0] * prog.mlen
     o_group_stride = O_full.physical_shape[0] * prog.mlen
-    for kv_h in range(num_kv_heads):
-        q_group_addr = q_full_addr + kv_h * q_group_stride
-        Q_group = prog.alloc_at(
-            f"Q_group{kv_h}_{layer_idx}",
-            seq_len,
-            prog.mlen,
-            q_group_addr,
-            physical_shape=(Q.physical_shape[0], prog.mlen),
-        )
-        _apply_rope_projection(
-            prog,
-            Q_group,
-            rope_matrix,
-            cos_var,
-            sin_var,
-            f"Q_rot_{layer_idx}_g{kv_h}",
-        )
+    q_groups = []
+    if batch_size == 1:
+        for kv_h in range(num_kv_heads):
+            q_group_addr = q_full_addr + kv_h * q_group_stride
+            Q_group = prog.alloc_at(
+                f"Q_group{kv_h}_{layer_idx}",
+                seq_len,
+                prog.mlen,
+                q_group_addr,
+                physical_shape=(Q.physical_shape[0], prog.mlen),
+            )
+            _apply_rope_projection(
+                prog,
+                Q_group,
+                rope_matrix,
+                cos_var,
+                sin_var,
+                f"Q_rot_{layer_idx}_g{kv_h}",
+            )
+            q_groups.append(Q_group)
 
-        K_stored, V_stored = kv_stored[kv_h]
-        prog.flash_attention_packed_group(
-            Q_group,
-            K_stored,
-            V_stored,
+    roll_kv_groups = os.environ.get("PLENA_ROLL_KV_GROUPS", "1") != "0"
+    if batch_size == 1 and roll_kv_groups and num_kv_heads > 1:
+        prog.flash_attention_packed_groups_looped(
+            Q,
+            kv_stored,
             group_heads=ratio,
             head_slot_dim=head_packing.head_slot_dim,
-            output_base_address=o_full_addr + kv_h * o_group_stride,
+            output_base_address=o_full_addr,
             scratch_base_address=attn_scratch_addr,
             broadcast_amount=head_packing.broadcast_amount,
             scale=scale,
-            causal_mask=True,
+            causal_mask=causal_mask,
         )
+    elif batch_size == 1:
+        for kv_h, Q_group in enumerate(q_groups):
+            K_stored, V_stored = kv_stored[kv_h]
+            prog.flash_attention_packed_group(
+                Q_group,
+                K_stored,
+                V_stored,
+                group_heads=ratio,
+                head_slot_dim=head_packing.head_slot_dim,
+                output_base_address=o_full_addr + kv_h * o_group_stride,
+                scratch_base_address=attn_scratch_addr,
+                broadcast_amount=head_packing.broadcast_amount,
+                scale=scale,
+                causal_mask=causal_mask,
+                valid_cols=active_seq_len_per_batch,
+            )
+    else:
+        row_block_stride = rows_per_batch // prog.mlen
+        if rows_per_batch % prog.mlen != 0:
+            raise ValueError(f"rows_per_batch={rows_per_batch} must be a multiple of MLEN={prog.mlen}")
+        batch_vram_stride = rows_per_batch * prog.mlen
+        for batch_idx in range(batch_size):
+            batch_row_offset = batch_idx * batch_vram_stride
+            for kv_h in range(num_kv_heads):
+                q_group_addr = q_full_addr + kv_h * q_group_stride + batch_row_offset
+                Q_group = prog.alloc_at(
+                    f"Q_group{kv_h}_b{batch_idx}_{layer_idx}",
+                    active_seq_len_per_batch,
+                    prog.mlen,
+                    q_group_addr,
+                    physical_shape=(rows_per_batch, prog.mlen),
+                )
+                _apply_rope_projection(
+                    prog,
+                    Q_group,
+                    rope_matrix,
+                    cos_var,
+                    sin_var,
+                    f"Q_rot_{layer_idx}_g{kv_h}_b{batch_idx}",
+                )
+                K_stored, V_stored = kv_stored[kv_h]
+                prog.flash_attention_packed_group(
+                    Q_group,
+                    K_stored,
+                    V_stored,
+                    group_heads=ratio,
+                    head_slot_dim=head_packing.head_slot_dim,
+                    output_base_address=o_full_addr + kv_h * o_group_stride + batch_row_offset,
+                    scratch_base_address=attn_scratch_addr,
+                    broadcast_amount=head_packing.broadcast_amount,
+                    scale=scale,
+                    causal_mask=causal_mask,
+                    k_idx=batch_idx * row_block_stride,
+                    valid_cols=active_seq_len_per_batch,
+                )
 
     prog.free_tensor(attn_scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="o_full",
+            tensor=O_full,
+            active_shape=(active_seq_len, head_packing.total_q_dim),
+            semantic="packed attention output before output projection",
+        )
     O_proj = _linear_projection(prog, O_full, layer_inputs.w_o, f"O_proj_{layer_idx}")
-    return _add_residual(prog, O_proj, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="o_proj",
+            tensor=O_proj,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="attention output projection before residual add",
+        )
+    out = _add_residual(prog, O_proj, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="attn_residual",
+            tensor=out,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="attention block output after residual add",
+        )
+    return out
 
 
 def _emit_attention_block(
@@ -490,11 +821,44 @@ def _emit_attention_block(
     num_heads,
     num_kv_heads,
     ratio,
+    checkpoint_recorder: StageCheckpointRecorder | None = None,
+    active_seq_len: int | None = None,
+    active_hidden: int | None = None,
 ):
+    active_seq_len = active_seq_len or seq_len
+    active_hidden = active_hidden or current.shape[1]
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="attn_input",
+            tensor=current,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="decoder layer input before attention RMS norm",
+        )
+
     _save_residual_and_norm(prog, current, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="attn_norm",
+            tensor=current,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="attention RMS-normalized input",
+        )
 
     Q = _linear_projection(prog, current, layer_inputs.w_q, f"Q_{layer_idx}")
     q_full_addr = prog.get_vram_addr(Q.name)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="q_full",
+            tensor=Q,
+            active_shape=(active_seq_len, total_q_dim),
+            semantic="Q projection before per-head RoPE",
+        )
 
     O_full = prog.alloc(f"O_full_{layer_idx}", seq_len, total_q_dim, strict=False)
     o_full_addr = prog.get_vram_addr(O_full.name)
@@ -506,6 +870,9 @@ def _emit_attention_block(
         rope_inputs,
         layer_idx,
         num_kv_heads,
+        checkpoint_recorder=checkpoint_recorder,
+        active_seq_len=active_seq_len,
+        active_head_dim=head_dim,
     )
 
     rope_matrix, cos_var, sin_var = rope_inputs
@@ -544,22 +911,104 @@ def _emit_attention_block(
         )
         _free_named_tensors(prog, ("O", "S", "PV"))
 
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="o_full",
+            tensor=O_full,
+            active_shape=(active_seq_len, total_q_dim),
+            semantic="attention output before output projection",
+        )
     O_proj = _linear_projection(prog, O_full, layer_inputs.w_o, f"O_proj_{layer_idx}")
-    return _add_residual(prog, O_proj, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="o_proj",
+            tensor=O_proj,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="attention output projection before residual add",
+        )
+    out = _add_residual(prog, O_proj, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="attn_residual",
+            tensor=out,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="attention block output after residual add",
+        )
+    return out
 
 
-def _emit_ffn_block(prog, current, layer_inputs, scratch):
+def _emit_ffn_block(
+    prog,
+    current,
+    layer_inputs,
+    scratch,
+    layer_idx: int | None = None,
+    checkpoint_recorder: StageCheckpointRecorder | None = None,
+    active_seq_len: int | None = None,
+    active_hidden: int | None = None,
+):
+    active_seq_len = active_seq_len or current.shape[0]
+    active_hidden = active_hidden or current.shape[1]
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="ffn_input",
+            tensor=current,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="FFN block input before RMS norm",
+        )
     _save_residual_and_norm(prog, current, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="ffn_norm",
+            tensor=current,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="FFN RMS-normalized input",
+        )
     ops.ffn(prog, current, layer_inputs.w_gate, layer_inputs.w_up, layer_inputs.w_down)
-    return _add_residual(prog, current, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="ffn_out",
+            tensor=current,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="FFN projection output before residual add",
+        )
+    out = _add_residual(prog, current, scratch)
+    if checkpoint_recorder is not None:
+        checkpoint_recorder.record(
+            prog,
+            layer_idx=layer_idx,
+            stage="ffn_residual",
+            tensor=out,
+            active_shape=(active_seq_len, active_hidden),
+            semantic="FFN block output after residual add",
+        )
+    return out
 
 
-def _register_layer_inputs(prog, layer_idx: int, weights: LayerWeights) -> LayerInputVars:
+def _register_layer_inputs(
+    prog,
+    layer_idx: int,
+    weights: LayerWeights,
+    physical_shapes: dict[str, tuple[int, int]] | None = None,
+) -> LayerInputVars:
     named_vars = {}
     w_k_heads = []
     w_v_heads = []
+    physical_shapes = physical_shapes or {}
     for tensor_name, tensor in weights.tensor_entries(layer_idx):
-        var = prog.input(tensor_name, shape=tuple(tensor.shape))
+        var = prog.input(tensor_name, shape=tuple(tensor.shape), physical_shape=physical_shapes.get(tensor_name))
         if tensor_name.startswith(f"W_k_{layer_idx}_h"):
             w_k_heads.append(var)
         elif tensor_name.startswith(f"W_v_{layer_idx}_h"):
@@ -578,12 +1027,50 @@ def _register_layer_inputs(prog, layer_idx: int, weights: LayerWeights) -> Layer
     )
 
 
+def _weight_physical_shapes_for_layer(
+    layer_idx: int,
+    weights: LayerWeights,
+    *,
+    head_packing: AttentionHeadPacking | None,
+    padded_head_dim: int,
+) -> dict[str, tuple[int, int]]:
+    if head_packing is None or not head_packing.enabled:
+        return {}
+
+    physical_shapes = {}
+    for kv_h, (w_k, w_v) in enumerate(zip(weights.w_k_heads, weights.w_v_heads)):
+        physical_shapes[f"W_k_{layer_idx}_h{kv_h}"] = (w_k.shape[0], padded_head_dim)
+        physical_shapes[f"W_v_{layer_idx}_h{kv_h}"] = (w_v.shape[0], padded_head_dim)
+    return physical_shapes
+
+
+def _tensor_layout_metadata(prog, input_tensors: dict[str, torch.Tensor]) -> dict[str, dict[str, list[int] | int]]:
+    layouts = {}
+    for name, tensor in input_tensors.items():
+        hbm_layout = prog.hbm_matrices.get(name)
+        if hbm_layout is None:
+            continue
+        source_shape = tuple(int(dim) for dim in tensor.shape)
+        storage_shape = tuple(int(dim) for dim in (hbm_layout.physical_shape or hbm_layout.full_shape))
+        if len(source_shape) < 2 or len(storage_shape) < 2:
+            continue
+        layouts[name] = {
+            "source_shape": list(source_shape),
+            "storage_shape": list(storage_shape),
+            "logical_shape": list(hbm_layout.full_shape),
+            "source_row_elements": source_shape[-1],
+            "storage_row_elements": storage_shape[-1],
+        }
+    return layouts
+
+
 # ---------------------------------------------------------------------------
 # Main compilation function
 # ---------------------------------------------------------------------------
 def compile_native_hf_decoder(
     model,
     seq_len: int = 64,
+    batch_size: int = 1,
     hidden_size: int | None = None,
     inter_dim: int | None = None,
     num_layers: int | None = None,
@@ -596,13 +1083,17 @@ def compile_native_hf_decoder(
     mram_tile_capacity: int = 4,
     seed: int = 42,
     golden_precision: str = "hardware",
+    reference_backend: str = "scheduled",
+    stage_checkpoints: bool = False,
     verbose: bool = False,
 ) -> dict:
     """Compile a HuggingFace decoder model at native dimensions to PLENA ISA metadata."""
-
     def _verbose(message: str = ""):
         if verbose:
             print(message)
+
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
 
     model_cfg = extract_model_config(model)
     if hidden_size is not None and hidden_size != model_cfg.hidden_size:
@@ -625,7 +1116,19 @@ def compile_native_hf_decoder(
     # Rows only need enough physical lanes for the matrix writeback group
     # (BLEN), not a full MLEN block. Columns/K dimensions still use MLEN
     # until the vector, norm, RoPE, and FFN templates learn true tail masks.
-    padded_seq_len = _ceil_to_multiple(seq_len, blen)
+    #
+    # Keep an opt-in compatibility path for reproducing older tile-scaling
+    # reports that padded sequence rows to MLEN.
+    seq_padding_multiple = mlen if os.environ.get("PLENA_PAD_SEQ_TO_MLEN") == "1" else blen
+    padded_seq_len = _ceil_to_multiple(seq_len, seq_padding_multiple)
+    rows_per_batch = (
+        padded_seq_len
+        if batch_size == 1
+        else _ceil_to_multiple(max(mlen, padded_seq_len), mlen)
+    )
+    compile_seq_rows = batch_size * rows_per_batch
+    active_rows = batch_size * seq_len
+    checkpoint_rows = compile_seq_rows if batch_size > 1 else seq_len
     padded_hidden = _ceil_to_multiple(hidden, mlen)
     padded_inter = _ceil_to_multiple(inter, mlen)
     padded_head_dim = _ceil_to_multiple(head_dim, mlen)
@@ -658,6 +1161,8 @@ def compile_native_hf_decoder(
     padded_total_q_dim = head_packing.total_q_dim if head_packing is not None else num_heads * padded_head_dim
     padding_enabled = (
         padded_seq_len != seq_len
+        or rows_per_batch != seq_len
+        or batch_size != 1
         or padded_hidden != hidden
         or padded_inter != inter
         or padded_head_dim != head_dim
@@ -668,7 +1173,8 @@ def compile_native_hf_decoder(
     layers = root.layers
     n_layers = num_layers if num_layers is not None else len(layers)
     assert layer_idx_start + n_layers <= len(layers), (
-        f"Requested layers [{layer_idx_start}, {layer_idx_start + n_layers}) but model only has {len(layers)} layers"
+        f"Requested layers [{layer_idx_start}, {layer_idx_start + n_layers}) "
+        f"but model only has {len(layers)} layers"
     )
 
     scale = 1.0 / math.sqrt(head_dim)
@@ -681,13 +1187,13 @@ def compile_native_hf_decoder(
         f"head_dim={head_dim}"
     )
     print(
-        f"  compile: seq_len={seq_len}, mlen={mlen}, blen={blen}, "
+        f"  compile: batch_size={batch_size}, seq_len={seq_len}, mlen={mlen}, blen={blen}, "
         f"mram_tile_capacity={mram_tile_capacity}, total_q_dim={total_q_dim}"
     )
     if padding_enabled:
         print(
             "  tile padding: "
-            f"seq_len={seq_len}->{padded_seq_len}, "
+            f"seq_len={seq_len}->{padded_seq_len}, rows_per_batch={rows_per_batch}, "
             f"hidden={hidden}->{padded_hidden}, "
             f"inter={inter}->{padded_inter}, "
             f"head_dim={head_dim}->{padded_head_dim}, "
@@ -732,23 +1238,41 @@ def compile_native_hf_decoder(
     torch.manual_seed(seed)
 
     if embed is not None:
-        input_ids = torch.randint(0, model_cfg.vocab_size or 32000, (seq_len,))
+        input_shape = (seq_len,) if batch_size == 1 else (batch_size, seq_len)
+        input_ids = torch.randint(0, model_cfg.vocab_size or 32000, input_shape)
         with torch.no_grad():
             token_embeds = embed(input_ids).float()
-        if token_embeds.dim() == 3:
+        if batch_size == 1 and token_embeds.dim() == 3:
             token_embeds = token_embeds.squeeze(0)
+        if batch_size > 1 and token_embeds.dim() == 2:
+            token_embeds = token_embeds.unsqueeze(0)
         # Slice to the model hidden width.
-        token_embeds = token_embeds[:, :hidden]
-        _verbose(f"\nEmbedding lookup: input_ids shape={input_ids.shape}, token_embeds={token_embeds.shape}")
+        token_embeds = token_embeds[..., :hidden]
+        _verbose(
+            f"\nEmbedding lookup: input_ids shape={input_ids.shape}, "
+            f"token_embeds={token_embeds.shape}"
+        )
     else:
-        token_embeds = torch.randn(seq_len, hidden)
+        token_embeds = torch.randn(seq_len, hidden) if batch_size == 1 else torch.randn(batch_size, seq_len, hidden)
         print(f"\nNo embed_tokens found; using random token_embeds: {token_embeds.shape}")
 
     # Llama-style models use RoPE (not learned position embeddings).
     # Set pos_weight to zeros so embedding_add is a no-op for position.
-    pos_weight = torch.zeros(seq_len, hidden)
-    compile_token_embeds = _pad_2d(token_embeds, padded_seq_len, padded_hidden)
-    compile_pos_weight = _pad_2d(pos_weight, padded_seq_len, padded_hidden)
+    pos_weight = torch.zeros_like(token_embeds)
+    compile_token_embeds = _pad_batched_sequence_storage(
+        token_embeds,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        rows_per_batch=rows_per_batch,
+        cols=padded_hidden,
+    )
+    compile_pos_weight = _pad_batched_sequence_storage(
+        pos_weight,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        rows_per_batch=rows_per_batch,
+        cols=padded_hidden,
+    )
 
     _verbose(f"pos_weight: zeros {pos_weight.shape} (RoPE model; learned position add is a no-op)")
     for i in range(n_layers):
@@ -761,7 +1285,7 @@ def compile_native_hf_decoder(
 
     R_matrix, cos_table, sin_table = make_rope_inputs(seq_len, model_cfg)
     if head_packing is not None:
-        compile_R_matrix, compile_cos_table, compile_sin_table = _pad_rope_inputs_for_head_slots(
+        compile_R_matrix, per_sequence_cos_table, per_sequence_sin_table = _pad_rope_inputs_for_head_slots(
             R_matrix,
             cos_table,
             sin_table,
@@ -772,7 +1296,7 @@ def compile_native_hf_decoder(
         )
         rope_width = head_packing.group_width
     else:
-        compile_R_matrix, compile_cos_table, compile_sin_table = _pad_rope_inputs_for_tiles(
+        compile_R_matrix, per_sequence_cos_table, per_sequence_sin_table = _pad_rope_inputs_for_tiles(
             R_matrix,
             cos_table,
             sin_table,
@@ -780,28 +1304,66 @@ def compile_native_hf_decoder(
             padded_head_dim=padded_head_dim,
         )
         rope_width = padded_head_dim
+    compile_cos_table = _repeat_sequence_storage(
+        per_sequence_cos_table,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        rows_per_batch=rows_per_batch,
+    )
+    compile_sin_table = _repeat_sequence_storage(
+        per_sequence_sin_table,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        rows_per_batch=rows_per_batch,
+    )
 
     golden_policy = ReferencePrecision.from_mode(golden_precision)
-    print(f"\nComputing CPU golden reference ({golden_policy.label})")
-    golden_out = run_decoder_reference(
-        token_embeds,
-        pos_weight,
-        all_weights,
-        model_cfg,
-        R_matrix,
-        cos_table,
-        sin_table,
-        mlen=mlen,
-        max_k_tiles=mram_tile_capacity,
-        precision=golden_policy,
-        trace=lambda i, x: _verbose(f"  After layer {i}: X_gold[0,:4] = {x[0, :4].tolist()}"),
-    )
-    print(f"  golden_out: {golden_out.shape}")
-    _verbose(f"  golden_out[0,:4]: {golden_out[0, :4].tolist()}")
-
-    print(f"\nComputing HF reference (float32, {n_layers} layer{'s' if n_layers != 1 else ''}, no quantization)")
-    with torch.no_grad():
-        hf_ground_truth = run_decoder_reference(
+    reference_backend = reference_backend.lower()
+    print(f"\nComputing CPU golden reference ({golden_policy.label}, backend={reference_backend})")
+    if reference_backend == "scheduled":
+        scheduled_cfg = ScheduledReferenceConfig(
+            seq_len=seq_len,
+            padded_seq_len=padded_seq_len,
+            batch_size=batch_size,
+            rows_per_batch=rows_per_batch,
+            hidden_size=hidden,
+            padded_hidden_size=padded_hidden,
+            inter_dim=inter,
+            padded_inter_dim=padded_inter,
+            head_dim=head_dim,
+            padded_head_dim=padded_head_dim,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            mlen=mlen,
+            blen=blen,
+            max_k_tiles=mram_tile_capacity,
+            attention_head_packing=head_packing is not None,
+            head_slot_dim=head_packing.head_slot_dim if head_packing is not None else padded_head_dim,
+            broadcast_amount=head_packing.broadcast_amount if head_packing is not None else None,
+            total_q_dim=padded_total_q_dim,
+        )
+        padded_golden_output = run_native_decoder_scheduled_reference(
+            compile_token_embeds,
+            compile_pos_weight,
+            compile_weights,
+            scheduled_cfg,
+            compile_R_matrix,
+            compile_cos_table,
+            compile_sin_table,
+            precision=golden_policy,
+            trace=lambda i, x: _verbose(f"  After layer {i}: X_gold[0,:4] = {x[0, :4].tolist()}"),
+        )
+        golden_out = _compact_active_sequence_rows(
+            padded_golden_output,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            rows_per_batch=rows_per_batch,
+            cols=hidden,
+        )
+    elif reference_backend == "legacy":
+        if batch_size != 1:
+            raise NotImplementedError("legacy reference_backend does not support batch_size > 1")
+        golden_out = run_decoder_reference(
             token_embeds,
             pos_weight,
             all_weights,
@@ -811,9 +1373,50 @@ def compile_native_hf_decoder(
             sin_table,
             mlen=mlen,
             max_k_tiles=mram_tile_capacity,
-            precision=ReferencePrecision.from_mode("hf_fp32"),
-            trace=lambda i, x: _verbose(f"  After layer {i}: X_hf[0,:4] = {x[0, :4].tolist()}"),
+            precision=golden_policy,
+            trace=lambda i, x: _verbose(f"  After layer {i}: X_gold[0,:4] = {x[0, :4].tolist()}"),
         )
+        padded_golden_output = _pad_2d(golden_out, padded_seq_len, padded_hidden)
+    else:
+        raise ValueError("reference_backend must be 'scheduled' or 'legacy'")
+    print(f"  golden_out: {golden_out.shape}")
+    _verbose(f"  golden_out[0,:4]: {golden_out[0, :4].tolist()}")
+
+    print(f"\nComputing HF reference (float32, {n_layers} layer{'s' if n_layers != 1 else ''}, no quantization)")
+    with torch.no_grad():
+        if batch_size == 1:
+            hf_ground_truth = run_decoder_reference(
+                token_embeds,
+                pos_weight,
+                all_weights,
+                model_cfg,
+                R_matrix,
+                cos_table,
+                sin_table,
+                mlen=mlen,
+                max_k_tiles=mram_tile_capacity,
+                precision=ReferencePrecision.from_mode("hf_fp32"),
+                trace=lambda i, x: _verbose(f"  After layer {i}: X_hf[0,:4] = {x[0, :4].tolist()}"),
+            )
+        else:
+            padded_hf_output = run_native_decoder_scheduled_reference(
+                compile_token_embeds,
+                compile_pos_weight,
+                compile_weights,
+                scheduled_cfg,
+                compile_R_matrix,
+                compile_cos_table,
+                compile_sin_table,
+                precision=ReferencePrecision.from_mode("hf_fp32"),
+                trace=lambda i, x: _verbose(f"  After layer {i}: X_hf[0,:4] = {x[0, :4].tolist()}"),
+            )
+            hf_ground_truth = _compact_active_sequence_rows(
+                padded_hf_output,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=hidden,
+            )
 
     print(f"  hf_ground_truth: {hf_ground_truth.shape}")
     _verbose(f"  hf_ground_truth[0,:4]: {hf_ground_truth[0, :4].tolist()}")
@@ -829,50 +1432,77 @@ def compile_native_hf_decoder(
         real_data_ratio=REAL_DATA_RATIO,
         mram_tile_capacity=mram_tile_capacity,
     )
+    if hlen is not None:
+        prog.hlen = hlen
+    if broadcast_amount is not None:
+        prog.broadcast_amount = broadcast_amount
+    checkpoints = StageCheckpointRecorder(enabled=stage_checkpoints)
 
     # Shared inputs
-    x_input = prog.input("X", shape=(padded_seq_len, padded_hidden))
-    pos_input = prog.input("POS", shape=(padded_seq_len, padded_hidden))
+    sequence_physical_shape = (compile_seq_rows, padded_hidden)
+    rope_table_physical_shape = (compile_seq_rows, rope_width)
+    x_input = prog.input("X", shape=(compile_seq_rows, padded_hidden), physical_shape=sequence_physical_shape)
+    pos_input = prog.input("POS", shape=(compile_seq_rows, padded_hidden), physical_shape=sequence_physical_shape)
 
     r_input = prog.input("R_rope", shape=(rope_width, rope_width))
-    cos_input = prog.input("COS", shape=(padded_seq_len, rope_width))
-    sin_input = prog.input("SIN", shape=(padded_seq_len, rope_width))
+    cos_input = prog.input("COS", shape=(compile_seq_rows, rope_width), physical_shape=rope_table_physical_shape)
+    sin_input = prog.input("SIN", shape=(compile_seq_rows, rope_width), physical_shape=rope_table_physical_shape)
     COS = prog.load_batch(cos_input, name="COS")
     SIN = prog.load_batch(sin_input, name="SIN")
 
+    # The legacy FFN template uses absolute low-VRAM regions for up/gate/scratch
+    # intermediates. Reserve that region before allocating reusable tensors
+    # (causal mask, X/POS, debug checkpoints) so FFN cannot clobber them.
+    ffn_physical_rows = max(compile_seq_rows, blen, mlen)
+    ffn_workspace_end = _ffn_absolute_workspace_end(ffn_physical_rows, padded_hidden, padded_inter)
+    _reserve_vram_until(prog, ffn_workspace_end, "_ffn_absolute_workspace_padding")
+
     # Causal mask: (mlen, mlen) with 0 on/below diagonal, -inf above
     causal_mask_data = torch.zeros(mlen, mlen)
-    causal_mask_data.masked_fill_(torch.triu(torch.ones(mlen, mlen), diagonal=1).bool(), float("-inf"))
+    causal_mask_data.masked_fill_(
+        torch.triu(torch.ones(mlen, mlen), diagonal=1).bool(), float('-inf')
+    )
     causal_mask_input = prog.input("causal_mask", shape=(mlen, mlen))
     CAUSAL_MASK = prog.load_batch(causal_mask_input, name="CAUSAL_MASK")
 
     # Per-layer weight inputs (order determines HBM layout)
     layer_inputs = []
     for i in range(n_layers):
-        layer_inputs.append(_register_layer_inputs(prog, i, compile_weights[i]))
+        layer_inputs.append(
+            _register_layer_inputs(
+                prog,
+                i,
+                compile_weights[i],
+                physical_shapes=_weight_physical_shapes_for_layer(
+                    i,
+                    compile_weights[i],
+                    head_packing=head_packing,
+                    padded_head_dim=padded_head_dim,
+                ),
+            )
+        )
 
     # Load activations to VRAM
     X_batch = prog.load_batch(x_input, name="X")
     POS_batch = prog.load_batch(pos_input, name="POS")
     ops.embedding_add(prog, X_batch, POS_batch)  # X += POS in-place
-
-    # VRAM layout hazard: ffn_asm writes gate/up intermediates at absolute
-    # address batch*hidden spanning up to batch*hidden + 2*inter*batch.
-    # The residual scratch buffer must be placed ABOVE this region.
-    _ffn_intermediate_end = padded_seq_len * padded_hidden + 2 * padded_inter * padded_seq_len
-    _current_bump = 2 * padded_seq_len * padded_hidden  # X + POS already allocated
-    _current_bump += 2 * padded_seq_len * rope_width  # COS + SIN loaded to VRAM
-    _current_bump += mlen * mlen  # CAUSAL_MASK loaded to VRAM
-    if _current_bump < _ffn_intermediate_end:
-        _pad_elems = _ffn_intermediate_end - _current_bump
-        # Allocate enough mlen-wide rows to cover the padding
-        _pad_rows = (_pad_elems + mlen - 1) // mlen
-        # Round up to mlen for VRAM alignment
-        _pad_rows = ((_pad_rows + mlen - 1) // mlen) * mlen
-        prog.alloc("_vram_padding", _pad_rows, mlen, strict=False)
+    checkpoints.record(
+        prog,
+        layer_idx=None,
+        stage="embedding_add",
+        tensor=X_batch,
+        active_shape=(checkpoint_rows, hidden),
+        semantic="token embedding plus position tensor",
+    )
 
     # Allocate scratch buffer for residual save/restore (reused across layers)
-    scratch = prog.alloc("residual_scratch", padded_seq_len, padded_hidden, strict=False)
+    scratch = prog.alloc(
+        "residual_scratch",
+        compile_seq_rows,
+        padded_hidden,
+        strict=False,
+        physical_shape=sequence_physical_shape,
+    )
 
     # Chain layers
     current = X_batch
@@ -898,8 +1528,16 @@ def compile_native_hf_decoder(
                 num_kv_heads,
                 ratio,
                 head_packing,
+                checkpoints,
+                checkpoint_rows,
+                hidden,
+                batch_size=batch_size,
+                rows_per_batch=rows_per_batch,
+                active_seq_len_per_batch=seq_len,
             )
         else:
+            if batch_size != 1:
+                raise NotImplementedError("native non-packed MHA decoder lowering does not yet support batch_size > 1")
             current_after_attn = _emit_attention_block(
                 prog,
                 current,
@@ -915,13 +1553,33 @@ def compile_native_hf_decoder(
                 num_heads,
                 num_kv_heads,
                 ratio,
+                checkpoints,
+                checkpoint_rows,
+                hidden,
             )
 
-        current = _emit_ffn_block(prog, current_after_attn, li, scratch)
+        current = _emit_ffn_block(
+            prog,
+            current_after_attn,
+            li,
+            scratch,
+            layer_idx=i,
+            checkpoint_recorder=checkpoints,
+            active_seq_len=checkpoint_rows,
+            active_hidden=hidden,
+        )
         prog.emit_comment(f"=== LAYER {i}/{n_layers} COMPLETE ===")
 
     # Final norm
     ops.rms_norm(prog, current, eps_offset=3, reci_hid_offset=4)
+    checkpoints.record(
+        prog,
+        layer_idx=n_layers - 1,
+        stage="final_norm",
+        tensor=current,
+        active_shape=(checkpoint_rows, hidden),
+        semantic="decoder final RMS norm output",
+    )
 
     isa_code = prog.compile()
     isa_code = _fix_large_immediates(isa_code)
@@ -943,6 +1601,7 @@ def compile_native_hf_decoder(
         for name, tensor in compile_weights[i].tensor_entries(i):
             input_tensors[name] = tensor
             data_order.append(name)
+    tensor_layouts = _tensor_layout_metadata(prog, input_tensors)
 
     # FPRAM layout (same as single-layer decoder):
     #   slot 0 = 0.0        (reserved)
@@ -958,13 +1617,15 @@ def compile_native_hf_decoder(
     o_vram_addr = prog.get_vram_addr(current.name)
 
     out_features = padded_hidden
+    comparison_rows = compile_seq_rows if batch_size > 1 else seq_len
 
     comparison_params = {
         "start_row_idx": o_vram_addr // mlen,
-        "num_rows": (seq_len * out_features) // mlen,
-        "num_batches": seq_len,
+        "num_rows": (comparison_rows * out_features) // mlen,
+        "num_batches": comparison_rows,
         "elements_per_batch": out_features,
         "row_dim": mlen,
+        "physical_rows": current.physical_shape[0],
         "use_stride_mode": out_features > mlen,
     }
 
@@ -975,38 +1636,83 @@ def compile_native_hf_decoder(
         "padded_hidden_size": padded_hidden,
         "padded_inter_dim": padded_inter,
         "num_layers": n_layers,
+        "batch_size": batch_size,
         "seq_len": seq_len,
         "padded_seq_len": padded_seq_len,
+        "rows_per_batch": rows_per_batch,
+        "compile_seq_rows": compile_seq_rows,
+        "active_rows": active_rows,
         "head_dim": head_dim,
         "padded_head_dim": padded_head_dim,
         "attention_head_packing": head_packing is not None,
         "attention_head_slot_dim": head_packing.head_slot_dim if head_packing is not None else padded_head_dim,
+        "attention_kv_storage_head_dim": padded_head_dim,
         "attention_broadcast_amount": head_packing.broadcast_amount if head_packing is not None else None,
         "num_heads": num_heads,
         "num_kv_heads": num_kv_heads,
         "mlen": mlen,
         "blen": blen,
+        "mram_tile_capacity": mram_tile_capacity,
+        "stage_checkpoints_enabled": stage_checkpoints,
+        "stage_checkpoint_count": len(checkpoints.checkpoints or []),
+        "reference_backend": reference_backend,
+        "golden_precision": golden_precision,
         "padding_enabled": padding_enabled,
         "isa_lines": len(lines),
     }
+    stage_checkpoint_metadata = checkpoints.metadata()
+    stage_checkpoint_metadata["compile_info"] = {
+        key: info[key]
+        for key in (
+            "model_type",
+            "hidden_size",
+            "inter_dim",
+            "padded_hidden_size",
+            "padded_inter_dim",
+            "num_layers",
+            "batch_size",
+            "seq_len",
+            "padded_seq_len",
+            "rows_per_batch",
+            "compile_seq_rows",
+            "active_rows",
+            "head_dim",
+            "padded_head_dim",
+            "attention_head_packing",
+            "attention_head_slot_dim",
+            "attention_kv_storage_head_dim",
+            "attention_broadcast_amount",
+            "num_heads",
+            "num_kv_heads",
+            "mlen",
+            "blen",
+            "mram_tile_capacity",
+        )
+    }
 
-    print(
-        f"\nCompilation complete: {info['isa_lines']} ISA lines, "
-        f"{n_layers} layers, output at VRAM row {o_vram_addr // mlen}"
-    )
+    print(f"\nCompilation complete: {info['isa_lines']} ISA lines, "
+          f"{n_layers} layers, output at VRAM row {o_vram_addr // mlen}")
     return {
         "isa": isa_code,
         "golden_output": golden_out,
-        "padded_golden_output": _pad_2d(golden_out, padded_seq_len, padded_hidden),
+        "padded_golden_output": padded_golden_output,
         "hf_ground_truth": hf_ground_truth,
         "input_tensors": input_tensors,
+        "tensor_layouts": tensor_layouts,
         "data_order": data_order,
         "fp_preload": fp_preload,
         "comparison_params": comparison_params,
         "info": info,
+        "stage_checkpoints": stage_checkpoint_metadata,
+        "sim_golden_result": {
+            "original_output": padded_golden_output,
+            "tensor_layouts": tensor_layouts,
+            "data_order": data_order,
+            "compile_info": info,
+            "stage_checkpoints": stage_checkpoint_metadata,
+        },
         "golden_precision": golden_precision,
+        "reference_backend": reference_backend,
     }
-
-
 # Backwards-compatible alias for older callers.
 compile_hf_model = compile_native_hf_decoder

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -9,15 +9,27 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+import torch.nn.functional as F
 
 from compiler.aten.model_extract import (
     LayerWeights,
+    VisionConnectorWeights,
+    VisionLayerWeights,
+    VisionPostNormWeights,
+    VisionConfig,
     embedding_module,
     extract_layer_weights,
     extract_model_config,
+    extract_vision_config,
+    extract_vision_connector_weights,
+    extract_vision_layer_weights,
+    extract_vision_patch_weights,
+    extract_vision_post_norm_weights,
     find_model_root,
+    find_vision_model,
 )
 import compiler.aten.ops as ops
+from compiler.asm_templates.gelu_asm import gelu_asm
 from asm_templates._imm import add_large_int as _add_large_int_lines
 from asm_templates._imm import load_large_int as _load_large_int_lines
 from compiler.aten.ops.registry import Backend, OpRegistry
@@ -27,6 +39,8 @@ from compiler.aten.reference import (
     ScheduledReferenceConfig,
     _ksplit_matmul,
     _make_rotate_half_matrix,
+    _round,
+    _scalar_preload_ref,
     make_rope_inputs,
     quantize_to_mxfp,
     run_decoder_reference,
@@ -39,6 +53,7 @@ __all__ = [
     "_make_rotate_half_matrix",
     "compile_hf_model",
     "compile_native_hf_decoder",
+    "compile_native_hf_vision_encoder",
     "quantize_to_mxfp",
 ]
 
@@ -90,6 +105,40 @@ class LayerInputVars:
     w_gate: Any
     w_up: Any
     w_down: Any
+
+
+@dataclass(frozen=True)
+class VisionLayerInputVars:
+    """PLENA input variables for one extracted vision layer."""
+
+    w_q_heads: list[Any]
+    w_k_heads: list[Any]
+    w_v_heads: list[Any]
+    w_o: Any
+    b_q_heads: list[Any]
+    b_k_heads: list[Any]
+    b_v_heads: list[Any]
+    b_o: Any
+    w_fc1: Any
+    w_fc2: Any
+    b_fc1: Any
+    b_fc2: Any
+    ln1_weight: Any
+    ln1_bias: Any
+    ln2_weight: Any
+    ln2_bias: Any
+
+
+@dataclass(frozen=True)
+class VisionPostNormInputVars:
+    weight: Any
+    bias: Any
+
+
+@dataclass(frozen=True)
+class VisionConnectorInputVars:
+    weight: Any
+    bias: Any | None
 
 
 @dataclass(frozen=True)
@@ -240,6 +289,106 @@ def _repeat_sequence_storage(
     return out.contiguous()
 
 
+def _repeat_feature_vector_storage(
+    vector: torch.Tensor,
+    *,
+    batch_size: int,
+    seq_len: int,
+    rows_per_batch: int,
+    cols: int,
+) -> torch.Tensor:
+    """Repeat a feature vector across active rows in padded per-batch slabs."""
+    if vector.dim() != 1:
+        raise ValueError(f"Expected 1D feature vector, got shape {tuple(vector.shape)}")
+    if vector.numel() > cols:
+        raise ValueError(f"Cannot pad feature vector with {vector.numel()} elements to {cols}")
+    out = torch.zeros(
+        (batch_size * rows_per_batch, cols),
+        dtype=vector.dtype,
+        device=vector.device,
+    )
+    for batch_idx in range(batch_size):
+        start = batch_idx * rows_per_batch
+        out[start:start + seq_len, : vector.numel()] = vector
+    return out.contiguous()
+
+
+@dataclass(frozen=True)
+class LazyRepeatedFeatureVector:
+    """Compact descriptor for vectors repeated across active padded rows."""
+
+    vector: torch.Tensor
+    batch_size: int
+    seq_len: int
+    rows_per_batch: int
+    cols: int
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return (self.batch_size * self.rows_per_batch, self.cols)
+
+    def numel(self) -> int:
+        rows, cols = self.shape
+        return rows * cols
+
+    def materialize(self) -> torch.Tensor:
+        return _repeat_feature_vector_storage(
+            self.vector,
+            batch_size=self.batch_size,
+            seq_len=self.seq_len,
+            rows_per_batch=self.rows_per_batch,
+            cols=self.cols,
+        )
+
+
+def _lazy_repeat_feature_vector_storage(
+    vector: torch.Tensor,
+    *,
+    batch_size: int,
+    seq_len: int,
+    rows_per_batch: int,
+    cols: int,
+) -> LazyRepeatedFeatureVector:
+    """Return a compact repeat descriptor instead of eagerly expanding storage."""
+    if vector.dim() != 1:
+        raise ValueError(f"Expected 1D feature vector, got shape {tuple(vector.shape)}")
+    if vector.numel() > cols:
+        raise ValueError(f"Cannot pad feature vector with {vector.numel()} elements to {cols}")
+    return LazyRepeatedFeatureVector(
+        vector=vector,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        rows_per_batch=rows_per_batch,
+        cols=cols,
+    )
+
+
+def _repeat_matrix_rows_storage(
+    matrix: torch.Tensor,
+    *,
+    batch_size: int,
+    seq_len: int,
+    rows_per_batch: int,
+    cols: int,
+) -> torch.Tensor:
+    """Pad and repeat a per-position matrix into per-batch row slabs."""
+    if matrix.dim() != 2:
+        raise ValueError(f"Expected 2D matrix, got shape {tuple(matrix.shape)}")
+    if matrix.shape[0] < seq_len:
+        raise ValueError(f"Matrix rows {matrix.shape[0]} cannot cover seq_len={seq_len}")
+    if matrix.shape[1] > cols:
+        raise ValueError(f"Cannot pad matrix with {matrix.shape[1]} cols to {cols}")
+    out = torch.zeros(
+        (batch_size * rows_per_batch, cols),
+        dtype=matrix.dtype,
+        device=matrix.device,
+    )
+    for batch_idx in range(batch_size):
+        start = batch_idx * rows_per_batch
+        out[start:start + seq_len, : matrix.shape[1]] = matrix[:seq_len]
+    return out.contiguous()
+
+
 def _compact_active_sequence_rows(
     tensor: torch.Tensor,
     *,
@@ -385,6 +534,105 @@ def _pad_decoder_weights_for_tiles(
     )
 
 
+def _pad_vector(vector: torch.Tensor, cols: int) -> torch.Tensor:
+    if vector.numel() > cols:
+        raise ValueError(f"Cannot pad vector of length {vector.numel()} to {cols}")
+    if vector.numel() == cols:
+        return vector.contiguous()
+    out = torch.zeros((cols,), dtype=vector.dtype, device=vector.device)
+    out[: vector.numel()] = vector
+    return out.contiguous()
+
+
+def _pad_vision_patch_weight_for_tiles(
+    weight: torch.Tensor,
+    *,
+    padded_k_col: int,
+    padded_hidden: int,
+) -> torch.Tensor:
+    return _pad_2d(weight, padded_k_col, padded_hidden)
+
+
+def _pad_vision_layer_weights_for_tiles(
+    weights: VisionLayerWeights,
+    *,
+    num_heads: int,
+    head_dim: int,
+    padded_hidden: int,
+    padded_inter: int,
+    padded_head_dim: int,
+    padded_total_q_dim: int,
+) -> VisionLayerWeights:
+    def pad_head_bias(bias: torch.Tensor) -> torch.Tensor:
+        out = torch.zeros((padded_total_q_dim,), dtype=bias.dtype, device=bias.device)
+        for h in range(num_heads):
+            src_start = h * head_dim
+            dst_start = h * padded_head_dim
+            out[dst_start:dst_start + head_dim] = bias[src_start:src_start + head_dim]
+        return out.contiguous()
+
+    return VisionLayerWeights(
+        w_q=_pad_q_weight_grouped(weights.w_q, num_heads, head_dim, padded_hidden, padded_head_dim),
+        w_k=_pad_q_weight_grouped(weights.w_k, num_heads, head_dim, padded_hidden, padded_head_dim),
+        w_v=_pad_q_weight_grouped(weights.w_v, num_heads, head_dim, padded_hidden, padded_head_dim),
+        w_o=_pad_o_weight_grouped(weights.w_o, num_heads, head_dim, padded_head_dim, padded_hidden),
+        b_q=pad_head_bias(weights.b_q),
+        b_k=pad_head_bias(weights.b_k),
+        b_v=pad_head_bias(weights.b_v),
+        b_o=_pad_vector(weights.b_o, padded_hidden),
+        w_fc1=_pad_2d(weights.w_fc1, padded_hidden, padded_inter),
+        w_fc2=_pad_2d(weights.w_fc2, padded_inter, padded_hidden),
+        b_fc1=_pad_vector(weights.b_fc1, padded_inter),
+        b_fc2=_pad_vector(weights.b_fc2, padded_hidden),
+        ln1_weight=_pad_vector(weights.ln1_weight, padded_hidden),
+        ln1_bias=_pad_vector(weights.ln1_bias, padded_hidden),
+        ln2_weight=_pad_vector(weights.ln2_weight, padded_hidden),
+        ln2_bias=_pad_vector(weights.ln2_bias, padded_hidden),
+        eps=weights.eps,
+    )
+
+
+def _pad_vision_post_norm_for_tiles(
+    weights: VisionPostNormWeights,
+    *,
+    padded_hidden: int,
+) -> VisionPostNormWeights:
+    return VisionPostNormWeights(
+        weight=_pad_vector(weights.weight, padded_hidden),
+        bias=_pad_vector(weights.bias, padded_hidden),
+        eps=weights.eps,
+    )
+
+
+def _pad_vision_connector_weight_for_tiles(
+    weights: VisionConnectorWeights,
+    *,
+    hidden: int,
+    padded_hidden: int,
+    padded_output_dim: int,
+) -> torch.Tensor:
+    """Pad connector projection rows by pixel-shuffle segment slot."""
+    scale_area = weights.scale_factor * weights.scale_factor
+    storage_input_dim = padded_hidden * scale_area
+    out = torch.zeros(
+        (storage_input_dim, padded_output_dim),
+        dtype=weights.weight.dtype,
+        device=weights.weight.device,
+    )
+    for segment_idx in range(scale_area):
+        src_start = segment_idx * hidden
+        src_end = src_start + hidden
+        dst_start = segment_idx * padded_hidden
+        out[dst_start:dst_start + hidden, :weights.output_dim] = weights.weight[src_start:src_end]
+    return out.contiguous()
+
+
+def _pad_optional_vector(vector: torch.Tensor | None, cols: int) -> torch.Tensor | None:
+    if vector is None:
+        return None
+    return _pad_vector(vector, cols)
+
+
 def _pad_rope_inputs_for_tiles(
     rope_matrix: torch.Tensor,
     cos_table: torch.Tensor,
@@ -457,8 +705,14 @@ def _apply_rope_projection(prog, x_var, rope_matrix, cos_var, sin_var, name):
     return x_var
 
 
-def _copy_into_vram_view(prog, source, name, rows, cols, vram_addr):
-    target = prog.alloc_at(name, rows, cols, vram_addr)
+def _copy_into_vram_view(prog, source, name, rows, cols, vram_addr, physical_shape=None):
+    target = prog.alloc_at(
+        name,
+        rows,
+        cols,
+        vram_addr,
+        physical_shape=physical_shape or source.physical_shape,
+    )
     prog.vram_fill_zero(target)
     prog.vram_add(target, source)
     return target
@@ -975,6 +1229,348 @@ def _emit_ffn_block(
     return out
 
 
+def _load_and_add(prog, target, input_var, name: str):
+    loaded = prog.load_batch(input_var, name=name)
+    prog.vram_add(target, loaded)
+    prog.free_tensor(loaded)
+    return target
+
+
+def _load_and_mul(prog, target, input_var, name: str):
+    loaded = prog.load_batch(input_var, name=name)
+    prog.vram_mul(target, loaded)
+    prog.free_tensor(loaded)
+    return target
+
+
+def _apply_vision_layer_norm(prog, current, gamma, beta, *, name: str):
+    ops.layer_norm(prog, current, eps_offset=3, reci_hid_offset=4)
+    _load_and_mul(prog, current, gamma, f"{name}_gamma")
+    _load_and_add(prog, current, beta, f"{name}_beta")
+    return current
+
+
+def _gelu_inplace(prog, tensor, *, const_one_fp_address: int = 5, const_1702_fp_address: int = 6):
+    scratch = prog.alloc(
+        f"gelu_scratch_{tensor.name}",
+        1,
+        prog.mlen,
+        strict=False,
+        physical_shape=(1, prog.mlen),
+    )
+    gp_regs = prog.register_allocator.allocate_gp(3)
+    try:
+        prog.emit(
+            gelu_asm(
+                const_one_fp_address=const_one_fp_address,
+                const_1702_fp_address=const_1702_fp_address,
+                alive_registers=gp_regs,
+                activation_base_address=prog.get_vram_addr(tensor.name),
+                scratchpad_base_address=prog.get_vram_addr(scratch.name),
+                vlen=prog.mlen,
+                batch_size=tensor.physical_shape[0],
+                hidden_dim=tensor.physical_shape[1],
+            )
+        )
+    finally:
+        prog.register_allocator.free_gp(gp_regs)
+        prog.free_tensor(scratch)
+    return tensor
+
+
+def _gelu_1702_fp_address(prog) -> int:
+    """FP SRAM slot for GELU's 1.702 constant, kept clear of im2col/softmax scratch."""
+    return prog._ONLINE_SOFTMAX_FPSRAM_BASE + 3 * prog.mlen
+
+
+def _emit_vision_attention_block(
+    prog,
+    current,
+    layer_inputs: VisionLayerInputVars,
+    scratch,
+    *,
+    layer_idx: int,
+    seq_len: int,
+    num_heads: int,
+    head_dim: int,
+    padded_head_dim: int,
+    padded_total_q_dim: int,
+    scale: float,
+    stop_after: str | None = None,
+):
+    prog.vram_fill_zero(scratch)
+    prog.vram_add(scratch, current)
+    _apply_vision_layer_norm(
+        prog,
+        current,
+        layer_inputs.ln1_weight,
+        layer_inputs.ln1_bias,
+        name=f"vision_l{layer_idx}_ln1",
+    )
+    emitted_stage = f"layer{layer_idx}_ln1"
+    if stop_after == emitted_stage:
+        return current, emitted_stage
+
+    O_full = prog.alloc(
+        f"V_O_full_{layer_idx}",
+        current.shape[0],
+        padded_total_q_dim,
+        strict=False,
+        physical_shape=(current.physical_shape[0], padded_total_q_dim),
+    )
+    prog.vram_fill_zero(O_full)
+    o_full_addr = prog.get_vram_addr(O_full.name)
+    o_head_stride = O_full.physical_shape[0] * prog.mlen
+
+    for h in range(num_heads):
+        Q_h = _linear_projection(
+            prog,
+            current,
+            layer_inputs.w_q_heads[h],
+            f"V_Q_{layer_idx}_h{h}",
+            physical_shape=(current.physical_shape[0], padded_head_dim),
+        )
+        _load_and_add(prog, Q_h, layer_inputs.b_q_heads[h], f"V_B_q_{layer_idx}_h{h}_load")
+
+        K_h = _linear_projection(
+            prog,
+            current,
+            layer_inputs.w_k_heads[h],
+            f"V_K_{layer_idx}_h{h}",
+            physical_shape=(current.physical_shape[0], padded_head_dim),
+        )
+        _load_and_add(prog, K_h, layer_inputs.b_k_heads[h], f"V_B_k_{layer_idx}_h{h}_load")
+
+        V_h = _linear_projection(
+            prog,
+            current,
+            layer_inputs.w_v_heads[h],
+            f"V_V_{layer_idx}_h{h}",
+            physical_shape=(current.physical_shape[0], padded_head_dim),
+        )
+        _load_and_add(prog, V_h, layer_inputs.b_v_heads[h], f"V_B_v_{layer_idx}_h{h}_load")
+
+        K_stored = prog.store(K_h, name=f"V_K_stored_{layer_idx}_h{h}")
+        V_stored = prog.store(V_h, name=f"V_V_stored_{layer_idx}_h{h}")
+        O_h = ops.flash_attention(
+            prog,
+            Q_h,
+            K_stored,
+            V_stored,
+            scale,
+            causal_mask=None,
+            batch_size=1,
+            seq_len=seq_len,
+            kv_seq_len=seq_len,
+        )
+
+        _copy_into_vram_view(
+            prog,
+            O_h,
+            f"V_O_dest_{layer_idx}_h{h}",
+            seq_len,
+            padded_head_dim,
+            o_full_addr + h * o_head_stride,
+            physical_shape=(O_full.physical_shape[0], padded_head_dim),
+        )
+        _free_named_tensors(prog, ("O", "S", "PV"))
+        for tensor in (Q_h, K_h, V_h):
+            prog.free_tensor(tensor)
+
+    emitted_stage = f"layer{layer_idx}_attn_o_full"
+    if stop_after == emitted_stage:
+        return O_full, emitted_stage
+
+    O_proj = _linear_projection(prog, O_full, layer_inputs.w_o, f"V_O_proj_{layer_idx}")
+    _load_and_add(prog, O_proj, layer_inputs.b_o, f"V_B_o_{layer_idx}_load")
+    emitted_stage = f"layer{layer_idx}_attn_proj"
+    if stop_after == emitted_stage:
+        return O_proj, emitted_stage
+
+    out = _add_residual(prog, O_proj, scratch)
+    return out, f"layer{layer_idx}_attn_residual"
+
+
+def _emit_vision_mlp_block(
+    prog,
+    current,
+    layer_inputs: VisionLayerInputVars,
+    scratch,
+    *,
+    layer_idx: int,
+    stop_after: str | None = None,
+):
+    prog.vram_fill_zero(scratch)
+    prog.vram_add(scratch, current)
+    _apply_vision_layer_norm(
+        prog,
+        current,
+        layer_inputs.ln2_weight,
+        layer_inputs.ln2_bias,
+        name=f"vision_l{layer_idx}_ln2",
+    )
+    emitted_stage = f"layer{layer_idx}_ln2"
+    if stop_after == emitted_stage:
+        return current, emitted_stage
+
+    fc1 = _linear_projection(prog, current, layer_inputs.w_fc1, f"V_FC1_{layer_idx}")
+    _load_and_add(prog, fc1, layer_inputs.b_fc1, f"V_B_fc1_{layer_idx}_load")
+    emitted_stage = f"layer{layer_idx}_fc1"
+    if stop_after == emitted_stage:
+        return fc1, emitted_stage
+
+    _gelu_inplace(prog, fc1, const_1702_fp_address=_gelu_1702_fp_address(prog))
+    emitted_stage = f"layer{layer_idx}_gelu"
+    if stop_after == emitted_stage:
+        return fc1, emitted_stage
+
+    fc2 = _linear_projection(prog, fc1, layer_inputs.w_fc2, f"V_FC2_{layer_idx}")
+    _load_and_add(prog, fc2, layer_inputs.b_fc2, f"V_B_fc2_{layer_idx}_load")
+    emitted_stage = f"layer{layer_idx}_fc2"
+    if stop_after == emitted_stage:
+        prog.free_tensor(fc1)
+        return fc2, emitted_stage
+
+    out = _add_residual(prog, fc2, scratch)
+    prog.free_tensor(fc1)
+    return out, f"layer{layer_idx}_mlp_residual"
+
+
+def _add_vram_row_chunk(
+    prog,
+    *,
+    source,
+    target,
+    source_addr: int,
+    target_addr: int,
+    name: str,
+):
+    src_view = prog.alloc_at(
+        f"{name}_src",
+        1,
+        prog.mlen,
+        source_addr,
+        physical_shape=(source.physical_shape[0], prog.mlen),
+    )
+    dst_view = prog.alloc_at(
+        f"{name}_dst",
+        1,
+        prog.mlen,
+        target_addr,
+        physical_shape=(target.physical_shape[0], prog.mlen),
+    )
+    prog.vram_add(dst_view, src_view, num_rows=1)
+    prog.free_tensor(src_view)
+    prog.free_tensor(dst_view)
+
+
+def _emit_vision_pixel_shuffle(
+    prog,
+    current,
+    *,
+    seq_len: int,
+    hidden: int,
+    padded_hidden: int,
+    scale_factor: int,
+    connector_rows: int,
+    connector_storage_dim: int,
+):
+    del hidden
+    grid = int(math.isqrt(seq_len))
+    if grid * grid != seq_len:
+        raise ValueError(f"vision connector pixel_shuffle requires square seq_len, got {seq_len}")
+    if grid % scale_factor != 0:
+        raise ValueError(
+            f"vision connector scale_factor={scale_factor} must divide patch grid {grid}x{grid}"
+        )
+    if padded_hidden % prog.mlen != 0:
+        raise ValueError(f"padded_hidden={padded_hidden} must be a multiple of MLEN={prog.mlen}")
+
+    out_grid = grid // scale_factor
+    connector_seq_len = seq_len // (scale_factor ** 2)
+    shuffled = prog.alloc(
+        "V_CONNECTOR_SHUFFLED",
+        connector_seq_len,
+        connector_storage_dim,
+        strict=False,
+        physical_shape=(connector_rows, connector_storage_dim),
+    )
+    prog.vram_fill_zero(shuffled)
+
+    source_base = prog.get_vram_addr(current.name)
+    target_base = prog.get_vram_addr(shuffled.name)
+    hidden_blocks = padded_hidden // prog.mlen
+
+    for out_y in range(out_grid):
+        for out_x in range(out_grid):
+            target_row = out_y * out_grid + out_x
+            for dy in range(scale_factor):
+                for dx in range(scale_factor):
+                    source_row = (out_y * scale_factor + dy) * grid + (out_x * scale_factor + dx)
+                    segment_idx = dy * scale_factor + dx
+                    for col_block in range(hidden_blocks):
+                        source_addr = (
+                            source_base
+                            + col_block * current.physical_shape[0] * prog.mlen
+                            + source_row * prog.mlen
+                        )
+                        target_col_block = segment_idx * hidden_blocks + col_block
+                        target_addr = (
+                            target_base
+                            + target_col_block * shuffled.physical_shape[0] * prog.mlen
+                            + target_row * prog.mlen
+                        )
+                        _add_vram_row_chunk(
+                            prog,
+                            source=current,
+                            target=shuffled,
+                            source_addr=source_addr,
+                            target_addr=target_addr,
+                            name=(
+                                f"V_connector_shuffle_o{target_row}_"
+                                f"s{segment_idx}_c{col_block}"
+                            ),
+                        )
+
+    return shuffled
+
+
+def _emit_vision_connector(
+    prog,
+    current,
+    connector_inputs: VisionConnectorInputVars,
+    *,
+    seq_len: int,
+    hidden: int,
+    padded_hidden: int,
+    scale_factor: int,
+    connector_rows: int,
+    connector_storage_dim: int,
+    padded_output_dim: int,
+):
+    shuffled = _emit_vision_pixel_shuffle(
+        prog,
+        current,
+        seq_len=seq_len,
+        hidden=hidden,
+        padded_hidden=padded_hidden,
+        scale_factor=scale_factor,
+        connector_rows=connector_rows,
+        connector_storage_dim=connector_storage_dim,
+    )
+    projected = _linear_projection(
+        prog,
+        shuffled,
+        connector_inputs.weight,
+        "V_CONNECTOR_OUT",
+        physical_shape=(connector_rows, padded_output_dim),
+    )
+    if connector_inputs.bias is not None:
+        _load_and_add(prog, projected, connector_inputs.bias, "V_CONNECTOR_B_load")
+    prog.free_tensor(shuffled)
+    return projected
+
+
 def _register_layer_inputs(
     prog,
     layer_idx: int,
@@ -1005,6 +1601,469 @@ def _register_layer_inputs(
     )
 
 
+def _register_vision_layer_inputs(
+    prog,
+    layer_idx: int,
+    weights: VisionLayerWeights,
+    *,
+    num_heads: int,
+    padded_head_dim: int,
+    compile_seq_rows: int,
+) -> VisionLayerInputVars:
+    w_q_heads = []
+    w_k_heads = []
+    w_v_heads = []
+    b_q_heads = []
+    b_k_heads = []
+    b_v_heads = []
+
+    for h in range(num_heads):
+        w_q_heads.append(
+            prog.input(
+                f"V_W_q_{layer_idx}_h{h}",
+                shape=(weights.w_q.shape[0], padded_head_dim),
+            )
+        )
+        w_k_heads.append(
+            prog.input(
+                f"V_W_k_{layer_idx}_h{h}",
+                shape=(weights.w_k.shape[0], padded_head_dim),
+            )
+        )
+        w_v_heads.append(
+            prog.input(
+                f"V_W_v_{layer_idx}_h{h}",
+                shape=(weights.w_v.shape[0], padded_head_dim),
+            )
+        )
+        b_q_heads.append(
+            prog.input(
+                f"V_B_q_{layer_idx}_h{h}",
+                shape=(compile_seq_rows, padded_head_dim),
+                physical_shape=(compile_seq_rows, padded_head_dim),
+            )
+        )
+        b_k_heads.append(
+            prog.input(
+                f"V_B_k_{layer_idx}_h{h}",
+                shape=(compile_seq_rows, padded_head_dim),
+                physical_shape=(compile_seq_rows, padded_head_dim),
+            )
+        )
+        b_v_heads.append(
+            prog.input(
+                f"V_B_v_{layer_idx}_h{h}",
+                shape=(compile_seq_rows, padded_head_dim),
+                physical_shape=(compile_seq_rows, padded_head_dim),
+            )
+        )
+
+    return VisionLayerInputVars(
+        w_q_heads=w_q_heads,
+        w_k_heads=w_k_heads,
+        w_v_heads=w_v_heads,
+        w_o=prog.input("V_W_o_%d" % layer_idx, shape=tuple(weights.w_o.shape)),
+        b_q_heads=b_q_heads,
+        b_k_heads=b_k_heads,
+        b_v_heads=b_v_heads,
+        b_o=prog.input(
+            "V_B_o_%d" % layer_idx,
+            shape=(compile_seq_rows, weights.b_o.numel()),
+            physical_shape=(compile_seq_rows, weights.b_o.numel()),
+        ),
+        w_fc1=prog.input("V_W_fc1_%d" % layer_idx, shape=tuple(weights.w_fc1.shape)),
+        w_fc2=prog.input("V_W_fc2_%d" % layer_idx, shape=tuple(weights.w_fc2.shape)),
+        b_fc1=prog.input(
+            "V_B_fc1_%d" % layer_idx,
+            shape=(compile_seq_rows, weights.b_fc1.numel()),
+            physical_shape=(compile_seq_rows, weights.b_fc1.numel()),
+        ),
+        b_fc2=prog.input(
+            "V_B_fc2_%d" % layer_idx,
+            shape=(compile_seq_rows, weights.b_fc2.numel()),
+            physical_shape=(compile_seq_rows, weights.b_fc2.numel()),
+        ),
+        ln1_weight=prog.input(
+            "V_LN1_weight_%d" % layer_idx,
+            shape=(compile_seq_rows, weights.ln1_weight.numel()),
+            physical_shape=(compile_seq_rows, weights.ln1_weight.numel()),
+        ),
+        ln1_bias=prog.input(
+            "V_LN1_bias_%d" % layer_idx,
+            shape=(compile_seq_rows, weights.ln1_bias.numel()),
+            physical_shape=(compile_seq_rows, weights.ln1_bias.numel()),
+        ),
+        ln2_weight=prog.input(
+            "V_LN2_weight_%d" % layer_idx,
+            shape=(compile_seq_rows, weights.ln2_weight.numel()),
+            physical_shape=(compile_seq_rows, weights.ln2_weight.numel()),
+        ),
+        ln2_bias=prog.input(
+            "V_LN2_bias_%d" % layer_idx,
+            shape=(compile_seq_rows, weights.ln2_bias.numel()),
+            physical_shape=(compile_seq_rows, weights.ln2_bias.numel()),
+        ),
+    )
+
+
+def _register_vision_post_norm_inputs(
+    prog,
+    weights: VisionPostNormWeights,
+    *,
+    compile_seq_rows: int,
+) -> VisionPostNormInputVars:
+    return VisionPostNormInputVars(
+        weight=prog.input(
+            "V_POST_LN_weight",
+            shape=(compile_seq_rows, weights.weight.numel()),
+            physical_shape=(compile_seq_rows, weights.weight.numel()),
+        ),
+        bias=prog.input(
+            "V_POST_LN_bias",
+            shape=(compile_seq_rows, weights.bias.numel()),
+            physical_shape=(compile_seq_rows, weights.bias.numel()),
+        ),
+    )
+
+
+def _register_vision_connector_inputs(
+    prog,
+    weights: VisionConnectorWeights,
+    *,
+    storage_input_dim: int,
+    padded_output_dim: int,
+    connector_rows: int,
+    has_bias: bool,
+) -> VisionConnectorInputVars:
+    return VisionConnectorInputVars(
+        weight=prog.input(
+            "V_CONNECTOR_W",
+            shape=(storage_input_dim, weights.output_dim),
+            physical_shape=(storage_input_dim, padded_output_dim),
+        ),
+        bias=(
+            prog.input(
+                "V_CONNECTOR_B",
+                shape=(connector_rows, padded_output_dim),
+                physical_shape=(connector_rows, padded_output_dim),
+            )
+            if has_bias else None
+        ),
+    )
+
+
+def _vision_position_ids(vision_model, *, batch_size: int, patches_h: int, patches_w: int, device) -> torch.Tensor:
+    """Match SmolVLM dynamic position bucketing for an all-valid patch mask."""
+    embeddings = vision_model.embeddings
+    num_patches_per_side = int(getattr(embeddings, "num_patches_per_side", patches_h))
+    boundaries = torch.arange(
+        1 / num_patches_per_side,
+        1.0,
+        1 / num_patches_per_side,
+        device=device,
+    )
+    nb_patches_h = torch.full((batch_size,), patches_h, device=device, dtype=torch.float32)
+    nb_patches_w = torch.full((batch_size,), patches_w, device=device, dtype=torch.float32)
+    step_h = 1.0 / nb_patches_h
+    step_w = 1.0 / nb_patches_w
+    h_indices = torch.arange(patches_h, device=device, dtype=torch.float32)
+    w_indices = torch.arange(patches_w, device=device, dtype=torch.float32)
+    fractional_coords_h = torch.clamp(h_indices[None, :] * step_h[:, None], max=(1.0 - 1e-6))
+    fractional_coords_w = torch.clamp(w_indices[None, :] * step_w[:, None], max=(1.0 - 1e-6))
+    bucket_coords_h = torch.bucketize(fractional_coords_h, boundaries, right=True)
+    bucket_coords_w = torch.bucketize(fractional_coords_w, boundaries, right=True)
+    pos_ids = bucket_coords_h[:, :, None] * num_patches_per_side + bucket_coords_w[:, None, :]
+    return pos_ids.reshape(batch_size, -1)
+
+
+def _pixel_values_to_raw_storage(pixel_values: torch.Tensor, *, w_padded: int) -> torch.Tensor:
+    """Convert B=1 NCHW pixels to conv2d_plena's raw HBM row layout."""
+    if pixel_values.shape[0] != 1:
+        raise NotImplementedError("native vision compile currently supports batch_size=1")
+    _, channels, height, width = pixel_values.shape
+    if w_padded < width:
+        raise ValueError(f"w_padded={w_padded} cannot cover image width {width}")
+    raw = torch.zeros((channels * height, w_padded), dtype=pixel_values.dtype, device=pixel_values.device)
+    for c in range(channels):
+        raw[c * height:(c + 1) * height, :width] = pixel_values[0, c]
+    return raw.contiguous()
+
+
+def _im2col_vision(pixel_values: torch.Tensor, *, patch_size: int) -> torch.Tensor:
+    col = F.unfold(pixel_values.float(), kernel_size=patch_size, stride=patch_size)
+    return col.permute(0, 2, 1).reshape(-1, pixel_values.shape[1] * patch_size * patch_size).contiguous()
+
+
+def _quantize_vision_pixels_like_hbm(
+    pixel_values: torch.Tensor,
+    *,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    if not precision.quantize_hbm:
+        return pixel_values
+    width = pixel_values.shape[-1]
+    w_padded = _ceil_to_multiple(width, 64)
+    raw = _pixel_values_to_raw_storage(pixel_values, w_padded=w_padded)
+    raw_q = precision.quantize(raw)
+    out = torch.zeros_like(pixel_values.float())
+    _, channels, height, _ = pixel_values.shape
+    for c in range(channels):
+        out[0, c] = raw_q[c * height:(c + 1) * height, :width]
+    return out
+
+
+def _layer_norm_ref(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float,
+    *,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    gamma = precision.quantize(weight)
+    beta = precision.quantize(bias)
+    y = _round_vision_intermediate(F.layer_norm(x.float(), (x.shape[-1],), eps=eps), precision)
+    y = _round_vision_intermediate(y.float() * gamma.float() + beta.float(), precision)
+    return y
+
+
+def _round_vision_intermediate(x: torch.Tensor, precision: ReferencePrecision) -> torch.Tensor:
+    return precision.from_inter(precision.to_inter(x))
+
+
+def _gelu_hw_ref(x: torch.Tensor, precision: ReferencePrecision) -> torch.Tensor:
+    # Match gelu_asm: each vector op writes BF16-like intermediate state before
+    # the next op consumes it.
+    step1 = _round_vision_intermediate(1.702 * x.float(), precision)
+    step2 = _round_vision_intermediate(-step1.float(), precision)
+    step3 = _round_vision_intermediate(torch.exp(step2.float()), precision)
+    step4 = _round_vision_intermediate(1.0 + step3.float(), precision)
+    step5 = _round_vision_intermediate(1.0 / step4.float(), precision)
+    return _round_vision_intermediate(x.float() * step5.float(), precision)
+
+
+def _vision_linear_ref(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    *,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    w = precision.quantize(weight)
+    b = precision.quantize(bias)
+    return _round_vision_intermediate(x.float() @ w.float() + b.float(), precision)
+
+
+def _vision_attention_ref(
+    x: torch.Tensor,
+    weights: VisionLayerWeights,
+    config: VisionConfig,
+    *,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    o_full = _vision_attention_heads_ref(x, weights, config, precision=precision)
+    return _vision_linear_ref(o_full, weights.w_o, weights.b_o, precision=precision)
+
+
+def _vision_attention_heads_ref(
+    x: torch.Tensor,
+    weights: VisionLayerWeights,
+    config: VisionConfig,
+    *,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    heads = []
+    for h in range(config.num_heads):
+        start = h * config.head_dim
+        end = start + config.head_dim
+        q = _vision_linear_ref(x, weights.w_q[:, start:end], weights.b_q[start:end], precision=precision)
+        k = _vision_linear_ref(x, weights.w_k[:, start:end], weights.b_k[start:end], precision=precision)
+        v = _vision_linear_ref(x, weights.w_v[:, start:end], weights.b_v[start:end], precision=precision)
+        scores = _round(q.float() @ k.float().T, precision)
+        scale = _scalar_preload_ref(1.0 / math.sqrt(config.head_dim), precision)
+        scores = _round(scores.float() * scale, precision)
+        attn = _round(torch.softmax(scores.float(), dim=-1), precision)
+        heads.append(_round(attn.float() @ v.float(), precision))
+    return torch.cat(heads, dim=-1)
+
+
+def _pad_vision_attention_heads_ref(
+    o_full: torch.Tensor,
+    *,
+    num_heads: int,
+    head_dim: int,
+    padded_head_dim: int | None,
+) -> torch.Tensor:
+    if padded_head_dim is None or padded_head_dim == head_dim:
+        return o_full
+    out = torch.zeros(
+        o_full.shape[0],
+        num_heads * padded_head_dim,
+        dtype=o_full.dtype,
+        device=o_full.device,
+    )
+    for h in range(num_heads):
+        src_start = h * head_dim
+        dst_start = h * padded_head_dim
+        out[:, dst_start:dst_start + head_dim] = o_full[:, src_start:src_start + head_dim]
+    return out.contiguous()
+
+
+def _run_vision_reference(
+    pixel_values: torch.Tensor,
+    position_embeddings: torch.Tensor,
+    patch_weights,
+    all_weights: list[VisionLayerWeights],
+    post_norm: VisionPostNormWeights,
+    config: VisionConfig,
+    *,
+    precision: ReferencePrecision,
+    gelu_mode: str,
+    padded_head_dim: int | None = None,
+) -> torch.Tensor:
+    return _run_vision_reference_trace(
+        pixel_values,
+        position_embeddings,
+        patch_weights,
+        all_weights,
+        post_norm,
+        config,
+        precision=precision,
+        gelu_mode=gelu_mode,
+        padded_head_dim=padded_head_dim,
+    )["post_ln"]
+
+
+def _run_vision_reference_trace(
+    pixel_values: torch.Tensor,
+    position_embeddings: torch.Tensor,
+    patch_weights,
+    all_weights: list[VisionLayerWeights],
+    post_norm: VisionPostNormWeights,
+    config: VisionConfig,
+    *,
+    precision: ReferencePrecision,
+    gelu_mode: str,
+    padded_head_dim: int | None = None,
+) -> dict[str, torch.Tensor]:
+    """Return hardware-shaped vision reference values at compiler stop points."""
+    trace: dict[str, torch.Tensor] = {}
+    patch_w = precision.quantize(patch_weights.weight_2d)
+    patch_bias_pos = precision.quantize(position_embeddings + patch_weights.bias.detach().float().view(1, -1))
+    pixel_values = _quantize_vision_pixels_like_hbm(pixel_values, precision=precision)
+    x_col = _round_vision_intermediate(_im2col_vision(pixel_values, patch_size=config.patch_size), precision)
+    trace["patch_im2col"] = x_col.float().contiguous()
+    x = _round_vision_intermediate(x_col.float() @ patch_w.float(), precision)
+    trace["patch"] = x.float().contiguous()
+    x = _round_vision_intermediate(x.float() + patch_bias_pos.float(), precision)
+    trace["patch_bias"] = x.float().contiguous()
+
+    for layer_idx, layer in enumerate(all_weights):
+        residual = x
+        x_norm = _layer_norm_ref(
+            x,
+            layer.ln1_weight,
+            layer.ln1_bias,
+            layer.eps,
+            precision=precision,
+        )
+        trace[f"layer{layer_idx}_ln1"] = x_norm.float().contiguous()
+        attn_heads = _vision_attention_heads_ref(
+            x_norm,
+            layer,
+            config,
+            precision=precision,
+        )
+        trace[f"layer{layer_idx}_attn_o_full"] = _pad_vision_attention_heads_ref(
+            attn_heads,
+            num_heads=config.num_heads,
+            head_dim=config.head_dim,
+            padded_head_dim=padded_head_dim,
+        ).float().contiguous()
+        attn = _vision_linear_ref(attn_heads, layer.w_o, layer.b_o, precision=precision)
+        trace[f"layer{layer_idx}_attn_proj"] = attn.float().contiguous()
+        x = _round_vision_intermediate(residual.float() + attn.float(), precision)
+        trace[f"layer{layer_idx}_attn_residual"] = x.float().contiguous()
+
+        residual = x
+        x_norm = _layer_norm_ref(
+            x,
+            layer.ln2_weight,
+            layer.ln2_bias,
+            layer.eps,
+            precision=precision,
+        )
+        trace[f"layer{layer_idx}_ln2"] = x_norm.float().contiguous()
+        fc1 = _vision_linear_ref(x_norm, layer.w_fc1, layer.b_fc1, precision=precision)
+        trace[f"layer{layer_idx}_fc1"] = fc1.float().contiguous()
+        if gelu_mode == "hardware":
+            act = _gelu_hw_ref(fc1, precision)
+        else:
+            act = _round_vision_intermediate(F.gelu(fc1.float(), approximate="tanh"), precision)
+        trace[f"layer{layer_idx}_gelu"] = act.float().contiguous()
+        mlp = _vision_linear_ref(act, layer.w_fc2, layer.b_fc2, precision=precision)
+        trace[f"layer{layer_idx}_fc2"] = mlp.float().contiguous()
+        x = _round_vision_intermediate(residual.float() + mlp.float(), precision)
+        trace[f"layer{layer_idx}_mlp_residual"] = x.float().contiguous()
+
+    x = _layer_norm_ref(
+        x,
+        post_norm.weight,
+        post_norm.bias,
+        post_norm.eps,
+        precision=precision,
+    )
+    trace["post_ln"] = x.float().contiguous()
+    return trace
+
+
+def _vision_pixel_shuffle_ref(x: torch.Tensor, scale_factor: int) -> torch.Tensor:
+    """Match SmolVLMConnector.pixel_shuffle for compact sequence tensors."""
+    if x.dim() == 2:
+        x = x.unsqueeze(0)
+        squeeze = True
+    elif x.dim() == 3:
+        squeeze = False
+    else:
+        raise ValueError(f"Expected 2D/3D vision sequence tensor, got {tuple(x.shape)}")
+
+    batch_size, seq_len, embed_dim = x.shape
+    height = width = int(math.isqrt(seq_len))
+    if height * width != seq_len:
+        raise ValueError(f"pixel_shuffle requires square seq_len, got {seq_len}")
+    if height % scale_factor != 0 or width % scale_factor != 0:
+        raise ValueError(
+            f"pixel_shuffle scale_factor={scale_factor} must divide grid {height}x{width}"
+        )
+
+    y = x.view(batch_size, height, width, embed_dim)
+    y = y.view(batch_size, height, width // scale_factor, embed_dim * scale_factor)
+    y = y.permute(0, 2, 1, 3)
+    y = y.reshape(
+        batch_size,
+        width // scale_factor,
+        height // scale_factor,
+        embed_dim * (scale_factor ** 2),
+    )
+    y = y.permute(0, 2, 1, 3)
+    y = y.reshape(batch_size, seq_len // (scale_factor ** 2), embed_dim * (scale_factor ** 2))
+    return y[0].contiguous() if squeeze else y.contiguous()
+
+
+def _run_vision_connector_reference(
+    encoder_output: torch.Tensor,
+    weights: VisionConnectorWeights,
+    *,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    shuffled = _vision_pixel_shuffle_ref(encoder_output, weights.scale_factor)
+    w = precision.quantize(weights.weight)
+    y = shuffled.float() @ w.float()
+    if weights.bias is not None:
+        y = y + precision.quantize(weights.bias).float()
+    return _round_vision_intermediate(y, precision).float().contiguous()
+
+
 def _weight_physical_shapes_for_layer(
     layer_idx: int,
     weights: LayerWeights,
@@ -1028,7 +2087,10 @@ def _tensor_layout_metadata(prog, input_tensors: dict[str, torch.Tensor]) -> dic
         hbm_layout = prog.hbm_matrices.get(name)
         if hbm_layout is None:
             continue
-        source_shape = tuple(int(dim) for dim in tensor.shape)
+        tensor_shape = getattr(tensor, "shape", None)
+        if tensor_shape is None:
+            continue
+        source_shape = tuple(int(dim) for dim in tensor_shape)
         storage_shape = tuple(int(dim) for dim in (hbm_layout.physical_shape or hbm_layout.full_shape))
         if len(source_shape) < 2 or len(storage_shape) < 2:
             continue
@@ -1040,6 +2102,667 @@ def _tensor_layout_metadata(prog, input_tensors: dict[str, torch.Tensor]) -> dic
             "storage_row_elements": storage_shape[-1],
         }
     return layouts
+
+
+# ---------------------------------------------------------------------------
+# Native vision compilation
+# ---------------------------------------------------------------------------
+def compile_native_hf_vision_encoder(
+    model,
+    seq_len: int = 64,
+    batch_size: int = 1,
+    hidden_size: int | None = None,
+    inter_dim: int | None = None,
+    num_layers: int | None = None,
+    layer_idx_start: int = 0,
+    mlen: int = 64,
+    blen: int = 4,
+    mram_tile_capacity: int = 4,
+    seed: int = 42,
+    golden_precision: str = "hardware",
+    reference_backend: str = "scheduled",
+    include_connector: bool = True,
+    stop_after: str | None = None,
+    verbose: bool = False,
+    **_unused,
+) -> dict:
+    """Compile a HuggingFace SigLIP/ViT vision encoder to PLENA ISA metadata."""
+    del reference_backend
+
+    def _verbose(message: str = ""):
+        if verbose:
+            print(message)
+
+    if batch_size != 1:
+        raise NotImplementedError("native vision compile currently supports batch_size=1")
+    if seq_len <= 0:
+        raise ValueError(f"seq_len must be positive, got {seq_len}")
+
+    vision_model = find_vision_model(model)
+    model_cfg = extract_vision_config(model)
+    if hidden_size is not None and hidden_size != model_cfg.hidden_size:
+        raise ValueError(
+            f"compile_native_hf_vision_encoder currently supports native hidden size only: "
+            f"requested {hidden_size}, model has {model_cfg.hidden_size}"
+        )
+    if inter_dim is not None and inter_dim != model_cfg.inter_dim:
+        raise ValueError(
+            f"compile_native_hf_vision_encoder currently supports native inter_dim only: "
+            f"requested {inter_dim}, model has {model_cfg.inter_dim}"
+        )
+
+    grid = int(math.isqrt(seq_len))
+    if grid * grid != seq_len:
+        raise ValueError(
+            f"vision seq_len must be a square patch count for now, got {seq_len}"
+        )
+    image_h = grid * model_cfg.patch_size
+    image_w = image_h
+    patches_h = grid
+    patches_w = grid
+    w_padded = _ceil_to_multiple(image_w, 64)
+    k_col = model_cfg.num_channels * model_cfg.patch_size * model_cfg.patch_size
+
+    hidden = model_cfg.hidden_size
+    inter = model_cfg.inter_dim
+    head_dim = model_cfg.head_dim
+    num_heads = model_cfg.num_heads
+    padded_seq_len = _ceil_to_multiple(seq_len, blen)
+    rows_per_batch = max(mlen, padded_seq_len)
+    compile_seq_rows = rows_per_batch
+    padded_hidden = _ceil_to_multiple(hidden, mlen)
+    padded_inter = _ceil_to_multiple(inter, mlen)
+    padded_head_dim = _ceil_to_multiple(head_dim, mlen)
+    padded_total_q_dim = num_heads * padded_head_dim
+    padded_k_col = _ceil_to_multiple(k_col, mlen)
+    scale = 1.0 / math.sqrt(head_dim)
+    connector_weights = extract_vision_connector_weights(model, model_cfg) if include_connector else None
+    connector_seq_len = seq_len
+    connector_rows = rows_per_batch
+    connector_storage_dim = padded_hidden
+    connector_output_dim = hidden
+    padded_connector_output_dim = padded_hidden
+    if connector_weights is not None:
+        connector_scale = connector_weights.scale_factor
+        if grid % connector_scale != 0:
+            raise ValueError(
+                f"vision connector scale_factor={connector_scale} must divide patch grid {grid}x{grid}"
+            )
+        connector_seq_len = seq_len // (connector_scale ** 2)
+        connector_padded_seq_len = _ceil_to_multiple(connector_seq_len, blen)
+        connector_rows = max(mlen, connector_padded_seq_len)
+        connector_storage_dim = padded_hidden * (connector_scale ** 2)
+        connector_output_dim = connector_weights.output_dim
+        padded_connector_output_dim = _ceil_to_multiple(connector_output_dim, mlen)
+
+    layers = vision_model.encoder.layers
+    n_layers = num_layers if num_layers is not None else len(layers)
+    assert layer_idx_start + n_layers <= len(layers), (
+        f"Requested vision layers [{layer_idx_start}, {layer_idx_start + n_layers}) "
+        f"but model only has {len(layers)} layers"
+    )
+
+    print("=" * 80)
+    print(f"Vision Compiler - {model_cfg.model_type} ({n_layers} layer{'s' if n_layers != 1 else ''})")
+    print(
+        f"  vision: hidden={hidden}, inter={inter}, heads={num_heads}, "
+        f"head_dim={head_dim}, patch={model_cfg.patch_size}, channels={model_cfg.num_channels}"
+    )
+    print(
+        f"  compile: batch_size={batch_size}, seq_len={seq_len}, image={image_h}x{image_w}, "
+        f"mlen={mlen}, blen={blen}, mram_tile_capacity={mram_tile_capacity}"
+    )
+    print(
+        "  tile padding: "
+        f"seq_len={seq_len}->{padded_seq_len}, hidden={hidden}->{padded_hidden}, "
+        f"inter={inter}->{padded_inter}, head_dim={head_dim}->{padded_head_dim}, "
+        f"total_q_dim={model_cfg.total_q_dim}->{padded_total_q_dim}, k_col={k_col}->{padded_k_col}"
+    )
+    if connector_weights is not None:
+        print(
+            "  connector: "
+            f"pixel_shuffle scale={connector_weights.scale_factor}, "
+            f"seq_len={seq_len}->{connector_seq_len}, "
+            f"proj={connector_storage_dim}->{connector_output_dim}"
+        )
+    print("=" * 80)
+
+    print(f"\nExtracting vision weights from layers {layer_idx_start}..{layer_idx_start + n_layers - 1}...")
+    patch_weights = extract_vision_patch_weights(vision_model, model_cfg)
+    all_weights = [
+        extract_vision_layer_weights(layers[layer_idx_start + i], model_cfg)
+        for i in range(n_layers)
+    ]
+    post_norm = extract_vision_post_norm_weights(vision_model, model_cfg)
+    compile_patch_weight = _pad_vision_patch_weight_for_tiles(
+        patch_weights.weight_2d,
+        padded_k_col=padded_k_col,
+        padded_hidden=padded_hidden,
+    )
+    compile_weights = [
+        _pad_vision_layer_weights_for_tiles(
+            w,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            padded_hidden=padded_hidden,
+            padded_inter=padded_inter,
+            padded_head_dim=padded_head_dim,
+            padded_total_q_dim=padded_total_q_dim,
+        )
+        for w in all_weights
+    ]
+    compile_post_norm = _pad_vision_post_norm_for_tiles(post_norm, padded_hidden=padded_hidden)
+    compile_connector_weight = None
+    compile_connector_bias = None
+    if connector_weights is not None:
+        compile_connector_weight = _pad_vision_connector_weight_for_tiles(
+            connector_weights,
+            hidden=hidden,
+            padded_hidden=padded_hidden,
+            padded_output_dim=padded_connector_output_dim,
+        )
+        compile_connector_bias = _pad_optional_vector(
+            connector_weights.bias,
+            padded_connector_output_dim,
+        )
+    eps = post_norm.eps
+
+    torch.manual_seed(seed)
+    pixel_values = torch.randn(batch_size, model_cfg.num_channels, image_h, image_w)
+    raw_pixels = _pixel_values_to_raw_storage(pixel_values, w_padded=w_padded)
+    position_ids = _vision_position_ids(
+        vision_model,
+        batch_size=batch_size,
+        patches_h=patches_h,
+        patches_w=patches_w,
+        device=pixel_values.device,
+    )
+    position_embeddings = vision_model.embeddings.position_embedding(position_ids)[0].detach().float()
+    patch_bias_pos = position_embeddings + patch_weights.bias.detach().float().view(1, -1)
+    compile_patch_bias_pos = _repeat_matrix_rows_storage(
+        _pad_2d(patch_bias_pos, seq_len, padded_hidden),
+        batch_size=batch_size,
+        seq_len=seq_len,
+        rows_per_batch=rows_per_batch,
+        cols=padded_hidden,
+    )
+
+    golden_policy = ReferencePrecision.from_mode(golden_precision)
+    requested_stop = None if stop_after in (None, "", "final") else str(stop_after).lower().replace("-", "_")
+    print(f"\nComputing CPU golden vision reference ({golden_policy.label})")
+    encoder_trace = _run_vision_reference_trace(
+        pixel_values,
+        position_embeddings,
+        patch_weights,
+        all_weights,
+        post_norm,
+        model_cfg,
+        precision=golden_policy,
+        gelu_mode="hardware",
+        padded_head_dim=padded_head_dim,
+    )
+    encoder_hf_trace = _run_vision_reference_trace(
+        pixel_values,
+        position_embeddings,
+        patch_weights,
+        all_weights,
+        post_norm,
+        model_cfg,
+        precision=ReferencePrecision.from_mode("hf_fp32"),
+        gelu_mode="hf",
+        padded_head_dim=padded_head_dim,
+    )
+    default_output_stage = "connector" if connector_weights is not None else "post_ln"
+    output_stage = requested_stop or default_output_stage
+    valid_stages = set(encoder_trace)
+    if connector_weights is not None:
+        valid_stages.update({"connector_shuffle", "connector"})
+    if output_stage not in valid_stages:
+        raise ValueError(
+            f"Unsupported vision stop_after={stop_after!r}; valid stages are: "
+            f"{', '.join(sorted(valid_stages))}"
+        )
+
+    encoder_golden_out = encoder_trace["post_ln"]
+    encoder_hf_ground_truth = encoder_hf_trace["post_ln"]
+    if output_stage in encoder_trace:
+        golden_out = encoder_trace[output_stage]
+        hf_ground_truth = encoder_hf_trace[output_stage]
+        output_seq_len = seq_len
+        if output_stage == "patch_im2col":
+            output_rows = _ceil_to_multiple(seq_len, blen)
+            output_hidden = k_col
+            output_padded_hidden = padded_k_col
+        elif output_stage.endswith("_attn_o_full"):
+            output_rows = rows_per_batch
+            output_hidden = padded_total_q_dim
+            output_padded_hidden = padded_total_q_dim
+        elif output_stage.endswith("_fc1") or output_stage.endswith("_gelu"):
+            output_rows = rows_per_batch
+            output_hidden = inter
+            output_padded_hidden = padded_inter
+        else:
+            output_rows = rows_per_batch
+            output_hidden = hidden
+            output_padded_hidden = padded_hidden
+    elif output_stage == "connector_shuffle":
+        golden_out = _vision_pixel_shuffle_ref(
+            encoder_golden_out,
+            connector_weights.scale_factor,
+        )
+        hf_ground_truth = _vision_pixel_shuffle_ref(
+            encoder_hf_ground_truth,
+            connector_weights.scale_factor,
+        )
+        output_seq_len = connector_seq_len
+        output_rows = connector_rows
+        output_hidden = connector_weights.input_dim
+        output_padded_hidden = connector_storage_dim
+    elif output_stage == "connector":
+        golden_out = _run_vision_connector_reference(
+            encoder_golden_out,
+            connector_weights,
+            precision=golden_policy,
+        )
+        hf_ground_truth = _run_vision_connector_reference(
+            encoder_hf_ground_truth,
+            connector_weights,
+            precision=ReferencePrecision.from_mode("hf_fp32"),
+        )
+        output_seq_len = connector_seq_len
+        output_rows = connector_rows
+        output_hidden = connector_output_dim
+        output_padded_hidden = padded_connector_output_dim
+    else:
+        raise AssertionError(f"Unhandled vision output stage {output_stage!r}")
+    padded_golden_output = _pad_batched_sequence_storage(
+        golden_out,
+        batch_size=batch_size,
+        seq_len=output_seq_len,
+        rows_per_batch=output_rows,
+        cols=output_padded_hidden,
+    )
+    print(f"  golden_out: {golden_out.shape}")
+    _verbose(f"  golden_out[0,:4]: {golden_out[0, :4].tolist()}")
+
+    print("\n--- PLENA Vision Backend (ISA generation) ---")
+    registry = OpRegistry.load()
+    registry.set_backend(Backend.PLENA)
+
+    prog = PlenaCompiler(
+        mlen=mlen,
+        blen=blen,
+        real_data_ratio=REAL_DATA_RATIO,
+        mram_tile_capacity=mram_tile_capacity,
+    )
+
+    sequence_physical_shape = (compile_seq_rows, padded_hidden)
+    input_raw_var = prog.input("V_PIXELS", shape=tuple(raw_pixels.shape))
+    patch_w_var = prog.input(
+        "V_PATCH_W",
+        shape=(k_col, hidden),
+        physical_shape=(padded_k_col, padded_hidden),
+    )
+    patch_bias_pos_var = prog.input(
+        "V_PATCH_BIAS_POS",
+        shape=(compile_seq_rows, padded_hidden),
+        physical_shape=sequence_physical_shape,
+    )
+
+    layer_inputs = [
+        _register_vision_layer_inputs(
+            prog,
+            i,
+            compile_weights[i],
+            num_heads=num_heads,
+            padded_head_dim=padded_head_dim,
+            compile_seq_rows=compile_seq_rows,
+        )
+        for i in range(n_layers)
+    ]
+    post_norm_inputs = _register_vision_post_norm_inputs(
+        prog,
+        compile_post_norm,
+        compile_seq_rows=compile_seq_rows,
+    )
+    connector_inputs = None
+    if connector_weights is not None:
+        connector_inputs = _register_vision_connector_inputs(
+            prog,
+            connector_weights,
+            storage_input_dim=connector_storage_dim,
+            padded_output_dim=padded_connector_output_dim,
+            connector_rows=connector_rows,
+            has_bias=compile_connector_bias is not None,
+        )
+
+    conv_out = ops.conv2d(
+        prog,
+        input_raw_var,
+        patch_w_var,
+        C_in=model_cfg.num_channels,
+        H=image_h,
+        W=image_w,
+        K=model_cfg.patch_size,
+        OH=patches_h,
+        OW=patches_w,
+        M=seq_len,
+        W_padded=w_padded,
+        fp_one_reg=5,
+        stride=model_cfg.patch_size,
+        return_im2col=output_stage == "patch_im2col",
+    )
+    if output_stage == "patch_im2col":
+        current = conv_out
+        emitted_stage = "patch_im2col"
+    else:
+        current = prog.alloc(
+            "V_PATCH_OUT",
+            compile_seq_rows,
+            padded_hidden,
+            strict=False,
+            physical_shape=sequence_physical_shape,
+        )
+        prog.vram_fill_zero(current)
+        prog.vram_add(current, conv_out, num_rows=seq_len)
+        prog.free_tensor(conv_out)
+        emitted_stage = "patch"
+
+    if output_stage not in {"patch_im2col", "patch"}:
+        _load_and_add(prog, current, patch_bias_pos_var, "V_PATCH_BIAS_POS_load")
+        emitted_stage = "patch_bias"
+
+    if output_stage not in {"patch_im2col", "patch", "patch_bias"}:
+        scratch = prog.alloc(
+            "vision_residual_scratch",
+            compile_seq_rows,
+            padded_hidden,
+            strict=False,
+            physical_shape=sequence_physical_shape,
+        )
+
+        for i, li in enumerate(layer_inputs):
+            prog.emit_comment(f"=== VISION LAYER {i}/{n_layers} START ===")
+            current, emitted_stage = _emit_vision_attention_block(
+                prog,
+                current,
+                li,
+                scratch,
+                layer_idx=i,
+                seq_len=seq_len,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                padded_head_dim=padded_head_dim,
+                padded_total_q_dim=padded_total_q_dim,
+                scale=scale,
+                stop_after=output_stage,
+            )
+            if output_stage == emitted_stage:
+                break
+
+            current, emitted_stage = _emit_vision_mlp_block(
+                prog,
+                current,
+                li,
+                scratch,
+                layer_idx=i,
+                stop_after=output_stage,
+            )
+            prog.emit_comment(f"=== VISION LAYER {i}/{n_layers} COMPLETE ===")
+            if output_stage == emitted_stage:
+                break
+
+        if output_stage == "post_ln" or output_stage in {"connector_shuffle", "connector"}:
+            _apply_vision_layer_norm(
+                prog,
+                current,
+                post_norm_inputs.weight,
+                post_norm_inputs.bias,
+                name="vision_post_ln",
+            )
+            emitted_stage = "post_ln"
+
+        if output_stage == "connector_shuffle":
+            current = _emit_vision_pixel_shuffle(
+                prog,
+                current,
+                seq_len=seq_len,
+                hidden=hidden,
+                padded_hidden=padded_hidden,
+                scale_factor=connector_weights.scale_factor,
+                connector_rows=connector_rows,
+                connector_storage_dim=connector_storage_dim,
+            )
+            emitted_stage = "connector_shuffle"
+        elif output_stage == "connector":
+            if connector_inputs is None:
+                raise ValueError("connector stop requested but model has no connector")
+            current = _emit_vision_connector(
+                prog,
+                current,
+                connector_inputs,
+                seq_len=seq_len,
+                hidden=hidden,
+                padded_hidden=padded_hidden,
+                scale_factor=connector_weights.scale_factor,
+                connector_rows=connector_rows,
+                connector_storage_dim=connector_storage_dim,
+                padded_output_dim=padded_connector_output_dim,
+            )
+            emitted_stage = "connector"
+
+    if emitted_stage != output_stage:
+        raise AssertionError(f"Vision compiler emitted {emitted_stage!r}, expected {output_stage!r}")
+
+    isa_code = prog.compile()
+    isa_code = _fix_large_immediates(isa_code)
+    lines = isa_code.splitlines()
+    print(f"\nGenerated {len(lines)} lines of vision ISA code")
+
+    input_tensors = {
+        "V_PIXELS": raw_pixels.float(),
+        "V_PATCH_W": patch_weights.weight_2d,
+        "V_PATCH_BIAS_POS": compile_patch_bias_pos,
+    }
+    data_order = ["V_PIXELS", "V_PATCH_W", "V_PATCH_BIAS_POS"]
+    for i, w in enumerate(compile_weights):
+        for h in range(num_heads):
+            start = h * padded_head_dim
+            end = start + padded_head_dim
+            for prefix, tensor in (
+                ("V_W_q", w.w_q[:, start:end]),
+                ("V_W_k", w.w_k[:, start:end]),
+                ("V_W_v", w.w_v[:, start:end]),
+            ):
+                name = f"{prefix}_{i}_h{h}"
+                input_tensors[name] = tensor
+                data_order.append(name)
+            for prefix, vector in (
+                ("V_B_q", w.b_q[start:end]),
+                ("V_B_k", w.b_k[start:end]),
+                ("V_B_v", w.b_v[start:end]),
+            ):
+                name = f"{prefix}_{i}_h{h}"
+                input_tensors[name] = _lazy_repeat_feature_vector_storage(
+                    vector,
+                    batch_size=batch_size,
+                    seq_len=seq_len,
+                    rows_per_batch=rows_per_batch,
+                    cols=padded_head_dim,
+                )
+                data_order.append(name)
+
+        for name, tensor in (
+            (f"V_W_o_{i}", w.w_o),
+            (f"V_B_o_{i}", _lazy_repeat_feature_vector_storage(
+                w.b_o,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=padded_hidden,
+            )),
+            (f"V_W_fc1_{i}", w.w_fc1),
+            (f"V_W_fc2_{i}", w.w_fc2),
+            (f"V_B_fc1_{i}", _lazy_repeat_feature_vector_storage(
+                w.b_fc1,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=padded_inter,
+            )),
+            (f"V_B_fc2_{i}", _lazy_repeat_feature_vector_storage(
+                w.b_fc2,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=padded_hidden,
+            )),
+            (f"V_LN1_weight_{i}", _lazy_repeat_feature_vector_storage(
+                w.ln1_weight,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=padded_hidden,
+            )),
+            (f"V_LN1_bias_{i}", _lazy_repeat_feature_vector_storage(
+                w.ln1_bias,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=padded_hidden,
+            )),
+            (f"V_LN2_weight_{i}", _lazy_repeat_feature_vector_storage(
+                w.ln2_weight,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=padded_hidden,
+            )),
+            (f"V_LN2_bias_{i}", _lazy_repeat_feature_vector_storage(
+                w.ln2_bias,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                rows_per_batch=rows_per_batch,
+                cols=padded_hidden,
+            )),
+        ):
+            input_tensors[name] = tensor
+            data_order.append(name)
+
+    for name, tensor in (
+        ("V_POST_LN_weight", _lazy_repeat_feature_vector_storage(
+            compile_post_norm.weight,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            rows_per_batch=rows_per_batch,
+            cols=padded_hidden,
+        )),
+        ("V_POST_LN_bias", _lazy_repeat_feature_vector_storage(
+            compile_post_norm.bias,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            rows_per_batch=rows_per_batch,
+            cols=padded_hidden,
+        )),
+    ):
+        input_tensors[name] = tensor
+        data_order.append(name)
+    if connector_weights is not None:
+        input_tensors["V_CONNECTOR_W"] = compile_connector_weight
+        data_order.append("V_CONNECTOR_W")
+        if compile_connector_bias is not None:
+            input_tensors["V_CONNECTOR_B"] = _lazy_repeat_feature_vector_storage(
+                compile_connector_bias,
+                batch_size=batch_size,
+                seq_len=connector_seq_len,
+                rows_per_batch=connector_rows,
+                cols=padded_connector_output_dim,
+            )
+            data_order.append("V_CONNECTOR_B")
+
+    tensor_layouts = _tensor_layout_metadata(prog, input_tensors)
+    gelu_1702_fp_address = prog._ONLINE_SOFTMAX_FPSRAM_BASE + 3 * mlen
+    fp_preload = [0.0, scale, float("-inf"), eps, 1.0 / hidden, 1.0, 1.702] + [0.0] * 3
+    if len(fp_preload) <= gelu_1702_fp_address:
+        fp_preload.extend([0.0] * (gelu_1702_fp_address + 1 - len(fp_preload)))
+    fp_preload[gelu_1702_fp_address] = 1.702
+
+    o_vram_addr = prog.get_vram_addr(current.name)
+    comparison_rows = output_seq_len
+    comparison_params = {
+        "start_row_idx": o_vram_addr // mlen,
+        "num_rows": (comparison_rows * output_padded_hidden) // mlen,
+        "num_batches": comparison_rows,
+        "elements_per_batch": output_padded_hidden,
+        "row_dim": mlen,
+        "physical_rows": current.physical_shape[0],
+        "use_stride_mode": output_padded_hidden > mlen,
+    }
+
+    info = {
+        "model_type": model_cfg.model_type,
+        "component": "vision",
+        "hidden_size": hidden,
+        "inter_dim": inter,
+        "padded_hidden_size": padded_hidden,
+        "padded_inter_dim": padded_inter,
+        "num_layers": n_layers,
+        "batch_size": batch_size,
+        "seq_len": seq_len,
+        "padded_seq_len": padded_seq_len,
+        "output_seq_len": output_seq_len,
+        "output_hidden_size": output_hidden,
+        "padded_output_hidden_size": output_padded_hidden,
+        "compile_seq_rows": compile_seq_rows,
+        "output_rows": output_rows,
+        "image_h": image_h,
+        "image_w": image_w,
+        "patch_size": model_cfg.patch_size,
+        "num_channels": model_cfg.num_channels,
+        "head_dim": head_dim,
+        "padded_head_dim": padded_head_dim,
+        "num_heads": num_heads,
+        "mlen": mlen,
+        "blen": blen,
+        "mram_tile_capacity": mram_tile_capacity,
+        "include_connector": connector_weights is not None,
+        "vision_output_stage": output_stage,
+        "vision_stop_after": requested_stop,
+        "golden_precision": golden_precision,
+        "isa_lines": len(lines),
+    }
+    if connector_weights is not None:
+        info.update(
+            {
+                "connector_scale_factor": connector_weights.scale_factor,
+                "connector_input_dim": connector_weights.input_dim,
+                "connector_storage_input_dim": connector_storage_dim,
+                "connector_output_dim": connector_output_dim,
+            }
+        )
+
+    print(f"\nVision compilation complete: {info['isa_lines']} ISA lines, "
+          f"{n_layers} layers, output at VRAM row {o_vram_addr // mlen}")
+    return {
+        "isa": isa_code,
+        "golden_output": golden_out,
+        "padded_golden_output": padded_golden_output,
+        "hf_ground_truth": hf_ground_truth,
+        "input_tensors": input_tensors,
+        "tensor_layouts": tensor_layouts,
+        "data_order": data_order,
+        "fp_preload": fp_preload,
+        "comparison_params": comparison_params,
+        "info": info,
+        "sim_golden_result": {
+            "original_output": padded_golden_output,
+            "tensor_layouts": tensor_layouts,
+            "data_order": data_order,
+            "compile_info": info,
+        },
+        "golden_precision": golden_precision,
+        "reference_backend": "vision_scheduled",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1064,8 +2787,35 @@ def compile_native_hf_decoder(
     reference_backend: str = "scheduled",
     stage_checkpoints: bool = False,
     verbose: bool = False,
+    component: str = "decoder",
+    vision_stop_after: str | None = None,
+    decoder_input_embeds: torch.Tensor | None = None,
 ) -> dict:
     """Compile a HuggingFace decoder model at native dimensions to PLENA ISA metadata."""
+    component = component.lower()
+    if component in {"vision", "vision_model", "vision_encoder"}:
+        return compile_native_hf_vision_encoder(
+            model,
+            seq_len=seq_len,
+            batch_size=batch_size,
+            hidden_size=hidden_size,
+            inter_dim=inter_dim,
+            num_layers=num_layers,
+            layer_idx_start=layer_idx_start,
+            mlen=mlen,
+            blen=blen,
+            mram_tile_capacity=mram_tile_capacity,
+            seed=seed,
+            golden_precision=golden_precision,
+            reference_backend=reference_backend,
+            include_connector=component != "vision_encoder",
+            stop_after=vision_stop_after,
+            stage_checkpoints=stage_checkpoints,
+            verbose=verbose,
+        )
+    if component not in {"decoder", "text", "text_decoder"}:
+        raise ValueError("component must be 'decoder' or 'vision'")
+
     def _verbose(message: str = ""):
         if verbose:
             print(message)
@@ -1215,7 +2965,38 @@ def compile_native_hf_decoder(
 
     torch.manual_seed(seed)
 
-    if embed is not None:
+    decoder_input_source = "decoder_input_embeds" if decoder_input_embeds is not None else None
+    if decoder_input_embeds is not None:
+        token_embeds = decoder_input_embeds.detach().float()
+        if token_embeds.dim() == 2:
+            if batch_size != 1:
+                raise ValueError(
+                    f"2D decoder_input_embeds are only valid for batch_size=1, got {batch_size}"
+                )
+            if token_embeds.shape[0] != seq_len:
+                raise ValueError(
+                    f"Expected decoder_input_embeds shape ({seq_len}, C), got {tuple(token_embeds.shape)}"
+                )
+        elif token_embeds.dim() == 3:
+            if token_embeds.shape[0] != batch_size or token_embeds.shape[1] != seq_len:
+                raise ValueError(
+                    f"Expected decoder_input_embeds shape ({batch_size}, {seq_len}, C), "
+                    f"got {tuple(token_embeds.shape)}"
+                )
+        else:
+            raise ValueError(
+                f"Expected decoder_input_embeds to be 2D or 3D, got shape {tuple(token_embeds.shape)}"
+            )
+        if token_embeds.shape[-1] < hidden:
+            raise ValueError(
+                f"decoder_input_embeds hidden dim {token_embeds.shape[-1]} is smaller than model hidden {hidden}"
+            )
+        if batch_size == 1 and token_embeds.dim() == 3:
+            token_embeds = token_embeds.squeeze(0)
+        token_embeds = token_embeds[..., :hidden].contiguous()
+        _verbose(f"\nDecoder input override: token_embeds={token_embeds.shape}")
+    elif embed is not None:
+        decoder_input_source = "embed_tokens"
         input_shape = (seq_len,) if batch_size == 1 else (batch_size, seq_len)
         input_ids = torch.randint(0, model_cfg.vocab_size or 32000, input_shape)
         with torch.no_grad():
@@ -1231,6 +3012,7 @@ def compile_native_hf_decoder(
             f"token_embeds={token_embeds.shape}"
         )
     else:
+        decoder_input_source = "random"
         token_embeds = torch.randn(seq_len, hidden) if batch_size == 1 else torch.randn(batch_size, seq_len, hidden)
         print(f"\nNo embed_tokens found; using random token_embeds: {token_embeds.shape}")
 
@@ -1628,6 +3410,7 @@ def compile_native_hf_decoder(
         "stage_checkpoint_count": len(checkpoints.checkpoints or []),
         "reference_backend": reference_backend,
         "golden_precision": golden_precision,
+        "decoder_input_source": decoder_input_source,
         "padding_enabled": padding_enabled,
         "isa_lines": len(lines),
     }

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -2743,6 +2743,10 @@ def compile_native_hf_vision_encoder(
 
     print(f"\nVision compilation complete: {info['isa_lines']} ISA lines, "
           f"{n_layers} layers, output at VRAM row {o_vram_addr // mlen}")
+    hbm_addrs = {}
+    for name, inp in prog._inputs.items():
+        if hasattr(inp, "hbm_addr"):
+            hbm_addrs[name] = inp.hbm_addr
     return {
         "isa": isa_code,
         "golden_output": golden_out,
@@ -2754,6 +2758,7 @@ def compile_native_hf_vision_encoder(
         "fp_preload": fp_preload,
         "comparison_params": comparison_params,
         "info": info,
+        "hbm_addrs": hbm_addrs,
         "sim_golden_result": {
             "original_output": padded_golden_output,
             "tensor_layouts": tensor_layouts,

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -1,5 +1,7 @@
 """HuggingFace decoder model to PLENA ISA compiler."""
 
+from __future__ import annotations
+
 import math
 import re
 from dataclasses import dataclass
@@ -83,6 +85,209 @@ class LayerInputVars:
     w_down: Any
 
 
+@dataclass(frozen=True)
+class AttentionHeadPacking:
+    """Packed-head layout for D < MLEN attention lowering."""
+
+    enabled: bool
+    hlen: int
+    broadcast_amount: int
+    head_slot_dim: int
+    group_width: int
+    total_q_dim: int
+
+
+def _ceil_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _pad_2d(tensor: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+    """Zero-pad a 2D tensor to the requested shape, preserving the top-left data."""
+    src_rows, src_cols = tensor.shape
+    if src_rows > rows or src_cols > cols:
+        raise ValueError(f"Cannot pad tensor of shape {tuple(tensor.shape)} to smaller shape {(rows, cols)}")
+    if src_rows == rows and src_cols == cols:
+        return tensor.contiguous()
+    out = torch.zeros((rows, cols), dtype=tensor.dtype, device=tensor.device)
+    out[:src_rows, :src_cols] = tensor
+    return out.contiguous()
+
+
+def _pad_q_weight_grouped(weight: torch.Tensor, num_heads: int, head_dim: int, padded_hidden: int, padded_head_dim: int):
+    """Pad Q weights while keeping each head in its own padded head block."""
+    hidden, _ = weight.shape
+    out = torch.zeros((padded_hidden, num_heads * padded_head_dim), dtype=weight.dtype, device=weight.device)
+    for h in range(num_heads):
+        src_start = h * head_dim
+        dst_start = h * padded_head_dim
+        out[:hidden, dst_start:dst_start + head_dim] = weight[:, src_start:src_start + head_dim]
+    return out.contiguous()
+
+
+def _pad_o_weight_grouped(weight: torch.Tensor, num_heads: int, head_dim: int, padded_head_dim: int, padded_hidden: int):
+    """Pad O-projection weights from packed native heads into padded head blocks."""
+    _, hidden = weight.shape
+    out = torch.zeros((num_heads * padded_head_dim, padded_hidden), dtype=weight.dtype, device=weight.device)
+    for h in range(num_heads):
+        src_start = h * head_dim
+        dst_start = h * padded_head_dim
+        out[dst_start:dst_start + head_dim, :hidden] = weight[src_start:src_start + head_dim, :]
+    return out.contiguous()
+
+
+def _pad_q_weight_grouped_by_kv(
+    weight: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    padded_hidden: int,
+    group_width: int,
+    head_slot_dim: int,
+):
+    """Pad Q weights into KV-group MLEN rows with HLEN-sized head slots."""
+    hidden, _ = weight.shape
+    if num_heads % num_kv_heads != 0:
+        raise ValueError(f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads})")
+    ratio = num_heads // num_kv_heads
+    if ratio * head_slot_dim > group_width:
+        raise ValueError(
+            f"Q head slots do not fit one group: ratio={ratio}, "
+            f"head_slot_dim={head_slot_dim}, group_width={group_width}"
+        )
+    out = torch.zeros((padded_hidden, num_kv_heads * group_width), dtype=weight.dtype, device=weight.device)
+    for h in range(num_heads):
+        kv_h = h // ratio
+        lane = h % ratio
+        src_start = h * head_dim
+        dst_start = kv_h * group_width + lane * head_slot_dim
+        out[:hidden, dst_start:dst_start + head_dim] = weight[:, src_start:src_start + head_dim]
+    return out.contiguous()
+
+
+def _pad_o_weight_grouped_by_kv(
+    weight: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    group_width: int,
+    head_slot_dim: int,
+    padded_hidden: int,
+):
+    """Pad O weights from KV-group HLEN head slots into hidden projection."""
+    _, hidden = weight.shape
+    if num_heads % num_kv_heads != 0:
+        raise ValueError(f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads})")
+    ratio = num_heads // num_kv_heads
+    if ratio * head_slot_dim > group_width:
+        raise ValueError(
+            f"O head slots do not fit one group: ratio={ratio}, "
+            f"head_slot_dim={head_slot_dim}, group_width={group_width}"
+        )
+    out = torch.zeros((num_kv_heads * group_width, padded_hidden), dtype=weight.dtype, device=weight.device)
+    for h in range(num_heads):
+        kv_h = h // ratio
+        lane = h % ratio
+        src_start = h * head_dim
+        dst_start = kv_h * group_width + lane * head_slot_dim
+        out[dst_start:dst_start + head_dim, :hidden] = weight[src_start:src_start + head_dim, :]
+    return out.contiguous()
+
+
+def _pad_decoder_weights_for_tiles(
+    weights: LayerWeights,
+    model_cfg,
+    *,
+    padded_hidden: int,
+    padded_inter: int,
+    padded_head_dim: int,
+    head_packing: AttentionHeadPacking | None = None,
+) -> LayerWeights:
+    head_dim = model_cfg.head_dim
+    num_heads = model_cfg.num_heads
+    num_kv_heads = model_cfg.num_kv_heads
+
+    if head_packing is not None and head_packing.enabled:
+        w_q = _pad_q_weight_grouped_by_kv(
+            weights.w_q,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            padded_hidden,
+            head_packing.group_width,
+            head_packing.head_slot_dim,
+        )
+        w_o = _pad_o_weight_grouped_by_kv(
+            weights.w_o,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            head_packing.group_width,
+            head_packing.head_slot_dim,
+            padded_hidden,
+        )
+    else:
+        w_q = _pad_q_weight_grouped(weights.w_q, num_heads, head_dim, padded_hidden, padded_head_dim)
+        w_o = _pad_o_weight_grouped(weights.w_o, num_heads, head_dim, padded_head_dim, padded_hidden)
+
+    return LayerWeights(
+        w_q=w_q,
+        w_o=w_o,
+        w_k_heads=[_pad_2d(w, padded_hidden, padded_head_dim) for w in weights.w_k_heads],
+        w_v_heads=[_pad_2d(w, padded_hidden, padded_head_dim) for w in weights.w_v_heads],
+        w_gate=_pad_2d(weights.w_gate, padded_hidden, padded_inter),
+        w_up=_pad_2d(weights.w_up, padded_hidden, padded_inter),
+        w_down=_pad_2d(weights.w_down, padded_inter, padded_hidden),
+        eps=weights.eps,
+    )
+
+
+def _pad_rope_inputs_for_tiles(
+    rope_matrix: torch.Tensor,
+    cos_table: torch.Tensor,
+    sin_table: torch.Tensor,
+    *,
+    padded_seq_len: int,
+    padded_head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return (
+        _pad_2d(rope_matrix, padded_head_dim, padded_head_dim),
+        _pad_2d(cos_table, padded_seq_len, padded_head_dim),
+        _pad_2d(sin_table, padded_seq_len, padded_head_dim),
+    )
+
+
+def _pad_rope_inputs_for_head_slots(
+    rope_matrix: torch.Tensor,
+    cos_table: torch.Tensor,
+    sin_table: torch.Tensor,
+    *,
+    padded_seq_len: int,
+    group_width: int,
+    head_slot_dim: int,
+    broadcast_amount: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build an MLEN-wide RoPE table repeated into each packed head lane."""
+    head_dim = rope_matrix.shape[0]
+    if broadcast_amount * head_slot_dim != group_width:
+        raise ValueError(
+            f"broadcast_amount*head_slot_dim must equal group_width "
+            f"({broadcast_amount}*{head_slot_dim} != {group_width})"
+        )
+    if head_dim > head_slot_dim:
+        raise ValueError(f"head_dim {head_dim} exceeds head_slot_dim {head_slot_dim}")
+
+    r = torch.zeros((group_width, group_width), dtype=rope_matrix.dtype, device=rope_matrix.device)
+    cos = torch.zeros((padded_seq_len, group_width), dtype=cos_table.dtype, device=cos_table.device)
+    sin = torch.zeros((padded_seq_len, group_width), dtype=sin_table.dtype, device=sin_table.device)
+    seq = cos_table.shape[0]
+    for lane in range(broadcast_amount):
+        start = lane * head_slot_dim
+        r[start:start + head_dim, start:start + head_dim] = rope_matrix
+        cos[:seq, start:start + head_dim] = cos_table
+        sin[:seq, start:start + head_dim] = sin_table
+    return r.contiguous(), cos.contiguous(), sin.contiguous()
+
+
 def _save_residual_and_norm(prog, source, scratch):
     """Emit the common decoder pre-norm residual prologue."""
     prog.vram_fill_zero(scratch)
@@ -95,7 +300,9 @@ def _add_residual(prog, target, scratch):
     return target
 
 
-def _linear_projection(prog, input_var, weight_var, name: str):
+def _linear_projection(prog, input_var, weight_var, name: str, physical_shape: tuple[int, int] | None = None):
+    if physical_shape is not None:
+        return prog.linear_projection(input_var, weight_var, name=name, physical_shape=physical_shape)
     return ops.linear(prog, input_var, weight_var, name=name)
 
 
@@ -121,21 +328,37 @@ def _free_named_tensors(prog, names):
             prog._tensors.pop(name, None)
 
 
-def _emit_kv_stores(prog, current, layer_inputs, rope_inputs, layer_idx, num_kv_heads):
+def _emit_kv_stores(
+    prog,
+    current,
+    layer_inputs,
+    rope_inputs,
+    layer_idx,
+    num_kv_heads,
+    physical_rows: int | None = None,
+):
     rope_matrix, cos_var, sin_var = rope_inputs
     kv_stored = []
     for kv_h in range(num_kv_heads):
+        kv_physical_shape = None
+        if physical_rows is not None:
+            kv_physical_shape = (physical_rows, layer_inputs.w_k_heads[kv_h].physical_shape[1])
         K_h = _linear_projection(
             prog,
             current,
             layer_inputs.w_k_heads[kv_h],
             f"K_{layer_idx}_h{kv_h}",
+            physical_shape=kv_physical_shape,
         )
+        v_physical_shape = None
+        if physical_rows is not None:
+            v_physical_shape = (physical_rows, layer_inputs.w_v_heads[kv_h].physical_shape[1])
         V_h = _linear_projection(
             prog,
             current,
             layer_inputs.w_v_heads[kv_h],
             f"V_{layer_idx}_h{kv_h}",
+            physical_shape=v_physical_shape,
         )
 
         _apply_rope_projection(
@@ -155,6 +378,101 @@ def _emit_kv_stores(prog, current, layer_inputs, rope_inputs, layer_idx, num_kv_
         prog.free_tensor(V_h)
 
     return kv_stored
+
+
+def _emit_packed_attention_block(
+    prog,
+    current,
+    layer_inputs,
+    rope_inputs,
+    causal_mask,
+    scratch,
+    scale,
+    layer_idx,
+    seq_len,
+    head_dim,
+    num_kv_heads,
+    ratio,
+    head_packing: AttentionHeadPacking,
+):
+    _save_residual_and_norm(prog, current, scratch)
+
+    q_physical_shape = (max(prog.mlen, seq_len), head_packing.total_q_dim)
+    Q = _linear_projection(
+        prog,
+        current,
+        layer_inputs.w_q,
+        f"Q_{layer_idx}",
+        physical_shape=q_physical_shape,
+    )
+    q_full_addr = prog.get_vram_addr(Q.name)
+
+    O_full = prog.alloc(
+        f"O_full_{layer_idx}",
+        seq_len,
+        head_packing.total_q_dim,
+        strict=False,
+        physical_shape=(max(prog.mlen, seq_len), head_packing.total_q_dim),
+    )
+    o_full_addr = prog.get_vram_addr(O_full.name)
+
+    kv_stored = _emit_kv_stores(
+        prog,
+        current,
+        layer_inputs,
+        rope_inputs,
+        layer_idx,
+        num_kv_heads,
+        physical_rows=max(prog.mlen, seq_len),
+    )
+
+    scratch_rows = prog.mlen * (head_packing.broadcast_amount + ratio)
+    attn_scratch = prog.alloc(
+        f"packed_attn_scratch_{layer_idx}",
+        scratch_rows,
+        prog.mlen,
+        strict=True,
+    )
+    attn_scratch_addr = prog.get_vram_addr(attn_scratch.name)
+
+    rope_matrix, cos_var, sin_var = rope_inputs
+    q_group_stride = Q.physical_shape[0] * prog.mlen
+    o_group_stride = O_full.physical_shape[0] * prog.mlen
+    for kv_h in range(num_kv_heads):
+        q_group_addr = q_full_addr + kv_h * q_group_stride
+        Q_group = prog.alloc_at(
+            f"Q_group{kv_h}_{layer_idx}",
+            seq_len,
+            prog.mlen,
+            q_group_addr,
+            physical_shape=(Q.physical_shape[0], prog.mlen),
+        )
+        _apply_rope_projection(
+            prog,
+            Q_group,
+            rope_matrix,
+            cos_var,
+            sin_var,
+            f"Q_rot_{layer_idx}_g{kv_h}",
+        )
+
+        K_stored, V_stored = kv_stored[kv_h]
+        prog.flash_attention_packed_group(
+            Q_group,
+            K_stored,
+            V_stored,
+            group_heads=ratio,
+            head_slot_dim=head_packing.head_slot_dim,
+            output_base_address=o_full_addr + kv_h * o_group_stride,
+            scratch_base_address=attn_scratch_addr,
+            broadcast_amount=head_packing.broadcast_amount,
+            scale=scale,
+            causal_mask=True,
+        )
+
+    prog.free_tensor(attn_scratch)
+    O_proj = _linear_projection(prog, O_full, layer_inputs.w_o, f"O_proj_{layer_idx}")
+    return _add_residual(prog, O_proj, scratch)
 
 
 def _emit_attention_block(
@@ -178,7 +496,7 @@ def _emit_attention_block(
     Q = _linear_projection(prog, current, layer_inputs.w_q, f"Q_{layer_idx}")
     q_full_addr = prog.get_vram_addr(Q.name)
 
-    O_full = prog.alloc(f"O_full_{layer_idx}", seq_len, total_q_dim)
+    O_full = prog.alloc(f"O_full_{layer_idx}", seq_len, total_q_dim, strict=False)
     o_full_addr = prog.get_vram_addr(O_full.name)
 
     kv_stored = _emit_kv_stores(
@@ -266,10 +584,15 @@ def _register_layer_inputs(prog, layer_idx: int, weights: LayerWeights) -> Layer
 def compile_native_hf_decoder(
     model,
     seq_len: int = 64,
+    hidden_size: int | None = None,
+    inter_dim: int | None = None,
     num_layers: int | None = None,
     layer_idx_start: int = 0,
     mlen: int = 64,
     blen: int = 4,
+    hlen: int | None = None,
+    broadcast_amount: int | None = None,
+    attention_head_packing: bool | None = None,
     mram_tile_capacity: int = 4,
     seed: int = 42,
     golden_precision: str = "hardware",
@@ -282,6 +605,16 @@ def compile_native_hf_decoder(
             print(message)
 
     model_cfg = extract_model_config(model)
+    if hidden_size is not None and hidden_size != model_cfg.hidden_size:
+        raise ValueError(
+            f"compile_native_hf_decoder currently supports native hidden size only: "
+            f"requested {hidden_size}, model has {model_cfg.hidden_size}"
+        )
+    if inter_dim is not None and inter_dim != model_cfg.inter_dim:
+        raise ValueError(
+            f"compile_native_hf_decoder currently supports native inter_dim only: "
+            f"requested {inter_dim}, model has {model_cfg.inter_dim}"
+        )
     hidden = model_cfg.hidden_size
     inter = model_cfg.inter_dim
     num_heads = model_cfg.num_heads
@@ -289,6 +622,47 @@ def compile_native_hf_decoder(
     head_dim = model_cfg.head_dim
     total_q_dim = model_cfg.total_q_dim
     ratio = model_cfg.head_ratio
+    # Rows only need enough physical lanes for the matrix writeback group
+    # (BLEN), not a full MLEN block. Columns/K dimensions still use MLEN
+    # until the vector, norm, RoPE, and FFN templates learn true tail masks.
+    padded_seq_len = _ceil_to_multiple(seq_len, blen)
+    padded_hidden = _ceil_to_multiple(hidden, mlen)
+    padded_inter = _ceil_to_multiple(inter, mlen)
+    padded_head_dim = _ceil_to_multiple(head_dim, mlen)
+    if attention_head_packing is None:
+        attention_head_packing = hlen is not None and broadcast_amount is not None and head_dim < mlen
+    if attention_head_packing:
+        if hlen is None or broadcast_amount is None:
+            raise ValueError("attention_head_packing requires hlen and broadcast_amount")
+        if hlen <= 0 or broadcast_amount <= 0:
+            raise ValueError(f"hlen and broadcast_amount must be positive, got {hlen}, {broadcast_amount}")
+        if broadcast_amount * hlen != mlen:
+            raise ValueError(
+                f"Packed attention requires broadcast_amount*hlen == mlen "
+                f"({broadcast_amount}*{hlen} != {mlen})"
+            )
+        if head_dim > hlen:
+            raise ValueError(f"head_dim={head_dim} exceeds hlen={hlen}; cannot head-pack")
+        if ratio > broadcast_amount:
+            raise ValueError(f"GQA ratio={ratio} exceeds broadcast_amount={broadcast_amount}")
+        head_packing = AttentionHeadPacking(
+            enabled=True,
+            hlen=hlen,
+            broadcast_amount=broadcast_amount,
+            head_slot_dim=hlen,
+            group_width=mlen,
+            total_q_dim=num_kv_heads * mlen,
+        )
+    else:
+        head_packing = None
+    padded_total_q_dim = head_packing.total_q_dim if head_packing is not None else num_heads * padded_head_dim
+    padding_enabled = (
+        padded_seq_len != seq_len
+        or padded_hidden != hidden
+        or padded_inter != inter
+        or padded_head_dim != head_dim
+        or head_packing is not None
+    )
 
     root = find_model_root(model)
     layers = root.layers
@@ -310,6 +684,23 @@ def compile_native_hf_decoder(
         f"  compile: seq_len={seq_len}, mlen={mlen}, blen={blen}, "
         f"mram_tile_capacity={mram_tile_capacity}, total_q_dim={total_q_dim}"
     )
+    if padding_enabled:
+        print(
+            "  tile padding: "
+            f"seq_len={seq_len}->{padded_seq_len}, "
+            f"hidden={hidden}->{padded_hidden}, "
+            f"inter={inter}->{padded_inter}, "
+            f"head_dim={head_dim}->{padded_head_dim}, "
+            f"total_q_dim={total_q_dim}->{padded_total_q_dim}"
+        )
+    if head_packing is not None:
+        print(
+            "  attention head packing: "
+            f"head_dim={head_dim}, hlen={head_packing.hlen}, "
+            f"broadcast_amount={head_packing.broadcast_amount}, "
+            f"group_width={head_packing.group_width}, "
+            f"q_groups={num_kv_heads}"
+        )
     print("=" * 80)
 
     # ----------------------------------------------------------- weights
@@ -324,6 +715,17 @@ def compile_native_hf_decoder(
             f"W_gate={w.w_gate.shape}, "
             f"K_heads={len(w.w_k_heads)}x{w.w_k_heads[0].shape}, eps={w.eps}"
         )
+    compile_weights = [
+        _pad_decoder_weights_for_tiles(
+            w,
+            model_cfg,
+            padded_hidden=padded_hidden,
+            padded_inter=padded_inter,
+            padded_head_dim=padded_head_dim,
+            head_packing=head_packing,
+        )
+        for w in all_weights
+    ]
 
     eps = all_weights[0].eps
 
@@ -345,6 +747,8 @@ def compile_native_hf_decoder(
     # Llama-style models use RoPE (not learned position embeddings).
     # Set pos_weight to zeros so embedding_add is a no-op for position.
     pos_weight = torch.zeros(seq_len, hidden)
+    compile_token_embeds = _pad_2d(token_embeds, padded_seq_len, padded_hidden)
+    compile_pos_weight = _pad_2d(pos_weight, padded_seq_len, padded_hidden)
 
     _verbose(f"pos_weight: zeros {pos_weight.shape} (RoPE model; learned position add is a no-op)")
     for i in range(n_layers):
@@ -356,6 +760,26 @@ def compile_native_hf_decoder(
     print(f"attn_scale: {scale:.6f}")
 
     R_matrix, cos_table, sin_table = make_rope_inputs(seq_len, model_cfg)
+    if head_packing is not None:
+        compile_R_matrix, compile_cos_table, compile_sin_table = _pad_rope_inputs_for_head_slots(
+            R_matrix,
+            cos_table,
+            sin_table,
+            padded_seq_len=padded_seq_len,
+            group_width=head_packing.group_width,
+            head_slot_dim=head_packing.head_slot_dim,
+            broadcast_amount=head_packing.broadcast_amount,
+        )
+        rope_width = head_packing.group_width
+    else:
+        compile_R_matrix, compile_cos_table, compile_sin_table = _pad_rope_inputs_for_tiles(
+            R_matrix,
+            cos_table,
+            sin_table,
+            padded_seq_len=padded_seq_len,
+            padded_head_dim=padded_head_dim,
+        )
+        rope_width = padded_head_dim
 
     golden_policy = ReferencePrecision.from_mode(golden_precision)
     print(f"\nComputing CPU golden reference ({golden_policy.label})")
@@ -407,12 +831,12 @@ def compile_native_hf_decoder(
     )
 
     # Shared inputs
-    x_input = prog.input("X", shape=(seq_len, hidden))
-    pos_input = prog.input("POS", shape=(seq_len, hidden))
+    x_input = prog.input("X", shape=(padded_seq_len, padded_hidden))
+    pos_input = prog.input("POS", shape=(padded_seq_len, padded_hidden))
 
-    r_input = prog.input("R_rope", shape=(head_dim, head_dim))
-    cos_input = prog.input("COS", shape=(seq_len, head_dim))
-    sin_input = prog.input("SIN", shape=(seq_len, head_dim))
+    r_input = prog.input("R_rope", shape=(rope_width, rope_width))
+    cos_input = prog.input("COS", shape=(padded_seq_len, rope_width))
+    sin_input = prog.input("SIN", shape=(padded_seq_len, rope_width))
     COS = prog.load_batch(cos_input, name="COS")
     SIN = prog.load_batch(sin_input, name="SIN")
 
@@ -425,7 +849,7 @@ def compile_native_hf_decoder(
     # Per-layer weight inputs (order determines HBM layout)
     layer_inputs = []
     for i in range(n_layers):
-        layer_inputs.append(_register_layer_inputs(prog, i, all_weights[i]))
+        layer_inputs.append(_register_layer_inputs(prog, i, compile_weights[i]))
 
     # Load activations to VRAM
     X_batch = prog.load_batch(x_input, name="X")
@@ -435,9 +859,9 @@ def compile_native_hf_decoder(
     # VRAM layout hazard: ffn_asm writes gate/up intermediates at absolute
     # address batch*hidden spanning up to batch*hidden + 2*inter*batch.
     # The residual scratch buffer must be placed ABOVE this region.
-    _ffn_intermediate_end = seq_len * hidden + 2 * inter * seq_len
-    _current_bump = 2 * seq_len * hidden  # X + POS already allocated
-    _current_bump += 2 * seq_len * head_dim  # COS + SIN loaded to VRAM
+    _ffn_intermediate_end = padded_seq_len * padded_hidden + 2 * padded_inter * padded_seq_len
+    _current_bump = 2 * padded_seq_len * padded_hidden  # X + POS already allocated
+    _current_bump += 2 * padded_seq_len * rope_width  # COS + SIN loaded to VRAM
     _current_bump += mlen * mlen  # CAUSAL_MASK loaded to VRAM
     if _current_bump < _ffn_intermediate_end:
         _pad_elems = _ffn_intermediate_end - _current_bump
@@ -448,7 +872,7 @@ def compile_native_hf_decoder(
         prog.alloc("_vram_padding", _pad_rows, mlen, strict=False)
 
     # Allocate scratch buffer for residual save/restore (reused across layers)
-    scratch = prog.alloc("residual_scratch", seq_len, hidden)
+    scratch = prog.alloc("residual_scratch", padded_seq_len, padded_hidden, strict=False)
 
     # Chain layers
     current = X_batch
@@ -459,22 +883,39 @@ def compile_native_hf_decoder(
         # Layer progress marker (visible in non-quiet emulator output)
         prog.emit_comment(f"=== LAYER {i}/{n_layers} START ===")
 
-        current_after_attn = _emit_attention_block(
-            prog,
-            current,
-            li,
-            (r_input, COS, SIN),
-            CAUSAL_MASK,
-            scratch,
-            scale,
-            i,
-            seq_len,
-            head_dim,
-            total_q_dim,
-            num_heads,
-            num_kv_heads,
-            ratio,
-        )
+        if head_packing is not None:
+            current_after_attn = _emit_packed_attention_block(
+                prog,
+                current,
+                li,
+                (r_input, COS, SIN),
+                CAUSAL_MASK,
+                scratch,
+                scale,
+                i,
+                padded_seq_len,
+                head_dim,
+                num_kv_heads,
+                ratio,
+                head_packing,
+            )
+        else:
+            current_after_attn = _emit_attention_block(
+                prog,
+                current,
+                li,
+                (r_input, COS, SIN),
+                CAUSAL_MASK,
+                scratch,
+                scale,
+                i,
+                padded_seq_len,
+                padded_head_dim,
+                padded_total_q_dim,
+                num_heads,
+                num_kv_heads,
+                ratio,
+            )
 
         current = _emit_ffn_block(prog, current_after_attn, li, scratch)
         prog.emit_comment(f"=== LAYER {i}/{n_layers} COMPLETE ===")
@@ -488,12 +929,18 @@ def compile_native_hf_decoder(
     print(f"\nGenerated {len(lines)} lines of ISA code")
 
     # ----------------------------------------------------------- build return
-    input_tensors = {"X": token_embeds, "POS": pos_weight, "R_rope": R_matrix, "COS": cos_table, "SIN": sin_table}
+    input_tensors = {
+        "X": compile_token_embeds,
+        "POS": compile_pos_weight,
+        "R_rope": compile_R_matrix,
+        "COS": compile_cos_table,
+        "SIN": compile_sin_table,
+    }
     data_order = ["X", "POS", "R_rope", "COS", "SIN"]
     input_tensors["causal_mask"] = causal_mask_data
     data_order.append("causal_mask")
     for i in range(n_layers):
-        for name, tensor in all_weights[i].tensor_entries(i):
+        for name, tensor in compile_weights[i].tensor_entries(i):
             input_tensors[name] = tensor
             data_order.append(name)
 
@@ -510,7 +957,7 @@ def compile_native_hf_decoder(
     # Result is at current's VRAM location
     o_vram_addr = prog.get_vram_addr(current.name)
 
-    out_features = hidden
+    out_features = padded_hidden
 
     comparison_params = {
         "start_row_idx": o_vram_addr // mlen,
@@ -525,13 +972,21 @@ def compile_native_hf_decoder(
         "model_type": model_cfg.model_type,
         "hidden_size": hidden,
         "inter_dim": inter,
+        "padded_hidden_size": padded_hidden,
+        "padded_inter_dim": padded_inter,
         "num_layers": n_layers,
         "seq_len": seq_len,
+        "padded_seq_len": padded_seq_len,
         "head_dim": head_dim,
+        "padded_head_dim": padded_head_dim,
+        "attention_head_packing": head_packing is not None,
+        "attention_head_slot_dim": head_packing.head_slot_dim if head_packing is not None else padded_head_dim,
+        "attention_broadcast_amount": head_packing.broadcast_amount if head_packing is not None else None,
         "num_heads": num_heads,
         "num_kv_heads": num_kv_heads,
         "mlen": mlen,
         "blen": blen,
+        "padding_enabled": padding_enabled,
         "isa_lines": len(lines),
     }
 
@@ -542,6 +997,7 @@ def compile_native_hf_decoder(
     return {
         "isa": isa_code,
         "golden_output": golden_out,
+        "padded_golden_output": _pad_2d(golden_out, padded_seq_len, padded_hidden),
         "hf_ground_truth": hf_ground_truth,
         "input_tensors": input_tensors,
         "data_order": data_order,

--- a/aten/reference.py
+++ b/aten/reference.py
@@ -111,6 +111,7 @@ def run_decoder_reference(
     sin_table: torch.Tensor,
     *,
     mlen: int,
+    max_k_tiles: int = _HW_MAX_K_TILES,
     precision: ReferencePrecision,
     trace: Callable[[int, torch.Tensor], None] | None = None,
 ) -> torch.Tensor:
@@ -128,9 +129,10 @@ def run_decoder_reference(
             cos_table,
             sin_table,
             mlen,
+            max_k_tiles,
             precision,
         )
-        x = _ffn_block_ref(x, layer, mlen, precision)
+        x = _ffn_block_ref(x, layer, mlen, max_k_tiles, precision)
 
         if trace is not None:
             trace(layer_idx, x)
@@ -146,18 +148,19 @@ def _attention_block_ref(
     cos_table: torch.Tensor,
     sin_table: torch.Tensor,
     mlen: int,
+    max_k_tiles: int,
     precision: ReferencePrecision,
 ) -> torch.Tensor:
     quantize = precision.quantize
     residual = x.clone()
     x_normed = _rms_norm_ref(x, layer.eps, precision)
-    q_full = _round(_linear_ref(x_normed, quantize(layer.w_q), mlen, precision), precision)
+    q_full = _round(_linear_ref(x_normed, quantize(layer.w_q), mlen, max_k_tiles, precision), precision)
 
     k_heads = []
     v_heads = []
     for kv_h in range(config.num_kv_heads):
-        k_h = _linear_ref(x_normed, quantize(layer.w_k_heads[kv_h]), mlen, precision)
-        v_h = _linear_ref(x_normed, quantize(layer.w_v_heads[kv_h]), mlen, precision)
+        k_h = _linear_ref(x_normed, quantize(layer.w_k_heads[kv_h]), mlen, max_k_tiles, precision)
+        v_h = _linear_ref(x_normed, quantize(layer.w_v_heads[kv_h]), mlen, max_k_tiles, precision)
         k_h = _rope_ref(k_h, rope_matrix, cos_table, sin_table, precision)
         k_heads.append(_hbm_round_ref(k_h, precision))
         v_heads.append(_hbm_round_ref(v_h, precision))
@@ -171,7 +174,7 @@ def _attention_block_ref(
         o_heads.append(_flash_attn_ref(q_h, k_heads[kv_h], v_heads[kv_h], scale, causal=True))
 
     attn_out = _round(torch.cat(o_heads, dim=1), precision)
-    o_proj = _round(_linear_ref(attn_out, quantize(layer.w_o), mlen, precision), precision)
+    o_proj = _round(_linear_ref(attn_out, quantize(layer.w_o), mlen, max_k_tiles, precision), precision)
     return _residual_add_ref(o_proj, residual, precision)
 
 
@@ -179,15 +182,16 @@ def _ffn_block_ref(
     x: torch.Tensor,
     layer: LayerWeights,
     mlen: int,
+    max_k_tiles: int,
     precision: ReferencePrecision,
 ) -> torch.Tensor:
     quantize = precision.quantize
     residual = x.clone()
     x_normed = _rms_norm_ref(x, layer.eps, precision)
-    up_out = _linear_ref(x_normed, quantize(layer.w_up), mlen, precision)
-    gate_out = _linear_ref(x_normed, quantize(layer.w_gate), mlen, precision)
+    up_out = _linear_ref(x_normed, quantize(layer.w_up), mlen, max_k_tiles, precision)
+    gate_out = _linear_ref(x_normed, quantize(layer.w_gate), mlen, max_k_tiles, precision)
     silu_gate = precision.to_inter(F.silu(_round(up_out, precision)) * _round(gate_out, precision))
-    x = _linear_ref(precision.from_inter(silu_gate), quantize(layer.w_down), mlen, precision)
+    x = _linear_ref(precision.from_inter(silu_gate), quantize(layer.w_down), mlen, max_k_tiles, precision)
     return _residual_add_ref(_round(x, precision), residual, precision)
 
 
@@ -205,6 +209,7 @@ def _linear_ref(
     x: torch.Tensor,
     weight: torch.Tensor,
     mlen: int,
+    max_k_tiles: int,
     precision: ReferencePrecision,
 ) -> torch.Tensor:
     if not precision.use_ksplit:
@@ -213,7 +218,7 @@ def _linear_ref(
         x,
         weight,
         mlen=mlen,
-        max_k_tiles=_HW_MAX_K_TILES,
+        max_k_tiles=max_k_tiles,
         to_inter=precision.to_inter,
         from_inter=precision.from_inter,
     )

--- a/aten/reference.py
+++ b/aten/reference.py
@@ -57,6 +57,59 @@ class ReferencePrecision:
         return tensor.float() if self.bf16_intermediates else tensor
 
 
+@dataclass(frozen=True)
+class ScheduledReferenceConfig:
+    """Physical/native decoder dimensions used by the scheduled PLENA reference."""
+
+    seq_len: int
+    padded_seq_len: int
+    hidden_size: int
+    padded_hidden_size: int
+    inter_dim: int
+    padded_inter_dim: int
+    head_dim: int
+    padded_head_dim: int
+    num_heads: int
+    num_kv_heads: int
+    mlen: int
+    blen: int
+    max_k_tiles: int = _HW_MAX_K_TILES
+    attention_head_packing: bool = False
+    head_slot_dim: int | None = None
+    broadcast_amount: int | None = None
+    total_q_dim: int | None = None
+    batch_size: int = 1
+    rows_per_batch: int | None = None
+
+    @property
+    def head_ratio(self) -> int:
+        return self.num_heads // self.num_kv_heads
+
+    @property
+    def packed_group_width(self) -> int:
+        return self.mlen
+
+    @property
+    def attention_width(self) -> int:
+        if self.attention_head_packing:
+            return self.total_q_dim if self.total_q_dim is not None else self.num_kv_heads * self.mlen
+        return self.num_heads * self.padded_head_dim
+
+    @property
+    def kv_head_width(self) -> int:
+        if self.attention_head_packing:
+            return self.head_slot_dim or self.head_dim
+        return self.padded_head_dim
+
+    @property
+    def physical_rows_per_batch(self) -> int:
+        return self.rows_per_batch if self.rows_per_batch is not None else self.padded_seq_len
+
+    @property
+    def total_physical_rows(self) -> int:
+        return self.batch_size * self.physical_rows_per_batch
+
+
 def quantize_to_mxfp(tensor: torch.Tensor) -> torch.Tensor:
     """Quantize tensor to MXFP8 matching HBM hardware format; return dequantized result."""
     orig_shape = tensor.shape
@@ -140,6 +193,54 @@ def run_decoder_reference(
     return _rms_norm_ref(x, weights[0].eps, precision)
 
 
+def run_native_decoder_scheduled_reference(
+    token_embeds: torch.Tensor,
+    pos_weight: torch.Tensor,
+    weights: list[LayerWeights],
+    config: ScheduledReferenceConfig,
+    rope_matrix: torch.Tensor,
+    cos_table: torch.Tensor,
+    sin_table: torch.Tensor,
+    *,
+    precision: ReferencePrecision,
+    trace: Callable[[int, torch.Tensor], None] | None = None,
+) -> torch.Tensor:
+    """Run the native decoder on the same padded tensors the compiler emits.
+
+    This reference starts from physical padded inputs and weights rather than
+    padding an unpadded CPU/HF result afterward. It mirrors the major hardware
+    boundaries that affect the final output: HBM MXFP load/store, BF16
+    vector/matrix writeback, active-hidden RMS denominators, K-split GEMMs,
+    packed GQA layout, and padded RoPE lanes.
+    """
+    x = _vram_load_ref(token_embeds.clone(), precision)
+    pos = _vram_load_ref(pos_weight, precision)
+    x = _round(x + pos, precision)
+
+    # R_rope is consumed as an HBM matrix by the projection helper, while COS
+    # and SIN are loaded into VRAM batches before vector ops.
+    rope_ref = rope_matrix
+    cos_ref = _vram_load_ref(cos_table, precision)
+    sin_ref = _vram_load_ref(sin_table, precision)
+
+    for layer_idx, layer in enumerate(weights):
+        x = _scheduled_attention_block_ref(
+            x,
+            layer,
+            config,
+            rope_ref,
+            cos_ref,
+            sin_ref,
+            precision,
+        )
+        x = _scheduled_ffn_block_ref(x, layer, config, precision)
+
+        if trace is not None:
+            trace(layer_idx, x)
+
+    return _rms_norm_scheduled_ref(x, config.hidden_size, weights[0].eps, config.mlen, precision)
+
+
 def _attention_block_ref(
     x: torch.Tensor,
     layer: LayerWeights,
@@ -178,6 +279,189 @@ def _attention_block_ref(
     return _residual_add_ref(o_proj, residual, precision)
 
 
+def _scheduled_attention_block_ref(
+    x: torch.Tensor,
+    layer: LayerWeights,
+    config: ScheduledReferenceConfig,
+    rope_matrix: torch.Tensor,
+    cos_table: torch.Tensor,
+    sin_table: torch.Tensor,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    residual = x.clone()
+    x_normed = _rms_norm_scheduled_ref(x, config.hidden_size, layer.eps, config.mlen, precision)
+    q_full = _linear_scheduled_ref(x_normed, layer.w_q, config, precision)
+
+    if config.attention_head_packing:
+        attn_out = _packed_attention_scheduled_ref(
+            q_full,
+            x_normed,
+            layer,
+            config,
+            rope_matrix,
+            cos_table,
+            sin_table,
+            precision,
+        )
+    else:
+        attn_out = _mha_attention_scheduled_ref(
+            q_full,
+            x_normed,
+            layer,
+            config,
+            rope_matrix,
+            cos_table,
+            sin_table,
+            precision,
+        )
+
+    o_proj = _linear_scheduled_ref(attn_out, layer.w_o, config, precision)
+    return _residual_add_ref(o_proj, residual, precision)
+
+
+def _packed_attention_scheduled_ref(
+    q_full: torch.Tensor,
+    x_normed: torch.Tensor,
+    layer: LayerWeights,
+    config: ScheduledReferenceConfig,
+    rope_matrix: torch.Tensor,
+    cos_table: torch.Tensor,
+    sin_table: torch.Tensor,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    if config.head_slot_dim is None or config.broadcast_amount is None:
+        raise ValueError("Scheduled packed attention requires head_slot_dim and broadcast_amount")
+
+    rows = q_full.shape[0]
+    group_width = config.packed_group_width
+    head_slot_dim = config.head_slot_dim
+    ratio = config.head_ratio
+    scale = 1.0 / math.sqrt(config.head_dim)
+    out = torch.zeros((rows, config.attention_width), dtype=q_full.dtype, device=q_full.device)
+
+    rows_per_batch = config.physical_rows_per_batch
+    if rows_per_batch < config.seq_len:
+        raise ValueError(
+            f"rows_per_batch={rows_per_batch} cannot cover seq_len={config.seq_len}"
+        )
+    if rows < config.batch_size * rows_per_batch:
+        raise ValueError(
+            f"q_full rows={rows} cannot cover batch_size*rows_per_batch="
+            f"{config.batch_size * rows_per_batch}"
+        )
+
+    k_heads = []
+    v_heads = []
+    for kv_h in range(config.num_kv_heads):
+        k_h = _linear_scheduled_ref(x_normed, layer.w_k_heads[kv_h], config, precision)
+        v_h = _linear_scheduled_ref(x_normed, layer.w_v_heads[kv_h], config, precision)
+        k_h = _pad_cols_ref(k_h, group_width)
+        v_h = _pad_cols_ref(v_h, group_width)
+        k_h = _rope_scheduled_ref(k_h, rope_matrix, cos_table, sin_table, config, precision)
+        k_heads.append(_hbm_round_ref(k_h, precision))
+        v_heads.append(_hbm_round_ref(v_h, precision))
+
+    for batch_idx in range(config.batch_size):
+        row_start = batch_idx * rows_per_batch
+        row_end = row_start + config.seq_len
+        for kv_h in range(config.num_kv_heads):
+            group_start = kv_h * group_width
+            q_group = q_full[row_start:row_end, group_start:group_start + group_width]
+            q_group = _rope_scheduled_ref(
+                q_group,
+                rope_matrix,
+                cos_table[row_start:row_end],
+                sin_table[row_start:row_end],
+                config,
+                precision,
+            )
+            k_h = k_heads[kv_h][row_start:row_end]
+            v_h = v_heads[kv_h][row_start:row_end]
+
+            for lane in range(ratio):
+                lane_start = lane * head_slot_dim
+                lane_end = lane_start + head_slot_dim
+                q_h = q_group[:, lane_start:lane_end]
+                k_lane = k_h[:, :head_slot_dim]
+                v_lane = v_h[:, :head_slot_dim]
+                o_h = _flash_attn_scheduled_ref(
+                    q_h,
+                    k_lane,
+                    v_lane,
+                    scale,
+                    precision,
+                    causal=True,
+                    matmul_scale=0.25,
+                )
+                out[row_start:row_end, group_start + lane_start:group_start + lane_end] = o_h
+
+    return _round(out, precision)
+
+
+def _mha_attention_scheduled_ref(
+    q_full: torch.Tensor,
+    x_normed: torch.Tensor,
+    layer: LayerWeights,
+    config: ScheduledReferenceConfig,
+    rope_matrix: torch.Tensor,
+    cos_table: torch.Tensor,
+    sin_table: torch.Tensor,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    rows = q_full.shape[0]
+    head_width = config.padded_head_dim
+    scale = 1.0 / math.sqrt(config.head_dim)
+    rows_per_batch = config.physical_rows_per_batch
+    if rows_per_batch < config.seq_len:
+        raise ValueError(
+            f"rows_per_batch={rows_per_batch} cannot cover seq_len={config.seq_len}"
+        )
+    if rows < config.batch_size * rows_per_batch:
+        raise ValueError(
+            f"q_full rows={rows} cannot cover batch_size*rows_per_batch="
+            f"{config.batch_size * rows_per_batch}"
+        )
+
+    k_heads = []
+    v_heads = []
+    for kv_h in range(config.num_kv_heads):
+        k_h = _linear_scheduled_ref(x_normed, layer.w_k_heads[kv_h], config, precision)
+        v_h = _linear_scheduled_ref(x_normed, layer.w_v_heads[kv_h], config, precision)
+        k_h = _pad_cols_ref(k_h, head_width)
+        v_h = _pad_cols_ref(v_h, head_width)
+        k_h = _rope_scheduled_ref(k_h, rope_matrix, cos_table, sin_table, config, precision)
+        k_heads.append(_hbm_round_ref(k_h, precision))
+        v_heads.append(_hbm_round_ref(v_h, precision))
+
+    out = torch.zeros((rows, config.attention_width), dtype=q_full.dtype, device=q_full.device)
+    for batch_idx in range(config.batch_size):
+        row_start = batch_idx * rows_per_batch
+        row_end = row_start + config.seq_len
+        for h in range(config.num_heads):
+            kv_h = h // config.head_ratio
+            start = h * head_width
+            end = start + head_width
+            q_h = q_full[row_start:row_end, start:end]
+            q_h = _rope_scheduled_ref(
+                q_h,
+                rope_matrix,
+                cos_table[row_start:row_end],
+                sin_table[row_start:row_end],
+                config,
+                precision,
+            )
+            out[row_start:row_end, start:end] = _flash_attn_scheduled_ref(
+                q_h,
+                k_heads[kv_h][row_start:row_end],
+                v_heads[kv_h][row_start:row_end],
+                scale,
+                precision,
+                causal=True,
+            )
+
+    return _round(out, precision)
+
+
 def _ffn_block_ref(
     x: torch.Tensor,
     layer: LayerWeights,
@@ -195,14 +479,77 @@ def _ffn_block_ref(
     return _residual_add_ref(_round(x, precision), residual, precision)
 
 
+def _scheduled_ffn_block_ref(
+    x: torch.Tensor,
+    layer: LayerWeights,
+    config: ScheduledReferenceConfig,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    residual = x.clone()
+    x_normed = _rms_norm_scheduled_ref(x, config.hidden_size, layer.eps, config.mlen, precision)
+    up_out = _linear_scheduled_ref(x_normed, layer.w_up, config, precision)
+    gate_out = _linear_scheduled_ref(x_normed, layer.w_gate, config, precision)
+    silu_gate = _silu_gate_scheduled_ref(up_out, gate_out, precision)
+    ffn_out = _linear_scheduled_ref(silu_gate, layer.w_down, config, precision)
+    return _residual_add_ref(ffn_out, residual, precision)
+
+
 def _round(x: torch.Tensor, precision: ReferencePrecision) -> torch.Tensor:
     return precision.from_inter(precision.to_inter(x))
+
+
+def _scalar_round(value: float, precision: ReferencePrecision) -> float:
+    if not precision.bf16_intermediates:
+        return float(value)
+    return float(torch.tensor(float(value), dtype=torch.float32).to(torch.bfloat16).float())
+
+
+def _scalar_preload_ref(value: float, precision: ReferencePrecision) -> float:
+    if not precision.bf16_intermediates:
+        return float(value)
+    fp16_value = torch.tensor(float(value), dtype=torch.float16).float()
+    return _scalar_round(float(fp16_value), precision)
+
+
+def _vram_load_ref(tensor: torch.Tensor, precision: ReferencePrecision) -> torch.Tensor:
+    return _round(precision.quantize(tensor), precision)
 
 
 def _rms_norm_ref(x: torch.Tensor, eps: float, precision: ReferencePrecision) -> torch.Tensor:
     x_inter = precision.to_inter(x)
     rms = torch.rsqrt(precision.from_inter(x_inter).pow(2).mean(-1, keepdim=True) + eps)
     return _round(precision.from_inter(x_inter) * rms, precision)
+
+
+def _rms_norm_scheduled_ref(
+    x: torch.Tensor,
+    active_hidden: int,
+    eps: float,
+    mlen: int,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    if not precision.bf16_intermediates:
+        rms = torch.rsqrt(x.pow(2).sum(-1, keepdim=True) / float(active_hidden) + eps)
+        return x * rms
+
+    x_inter = _round(x, precision)
+    out = torch.empty_like(x_inter.float())
+    eps_scalar = _scalar_preload_ref(eps, precision)
+    reci_hidden = _scalar_preload_ref(1.0 / active_hidden, precision)
+
+    for row in range(x_inter.shape[0]):
+        acc = _scalar_round(0.0, precision)
+        for col in range(0, x_inter.shape[1], mlen):
+            chunk = x_inter[row, col:col + mlen].float()
+            sq = _round(chunk * chunk, precision)
+            acc = _scalar_round(acc + float(sq.sum().item()), precision)
+        mean_sq = _scalar_round(acc * reci_hidden, precision)
+        denom = _scalar_round(math.sqrt(_scalar_round(mean_sq + eps_scalar, precision)), precision)
+        inv = _scalar_round(1.0 / denom, precision)
+        for col in range(0, x_inter.shape[1], mlen):
+            out[row, col:col + mlen] = _round(x_inter[row, col:col + mlen].float() * inv, precision)
+
+    return out
 
 
 def _linear_ref(
@@ -224,6 +571,24 @@ def _linear_ref(
     )
 
 
+def _linear_scheduled_ref(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    config: ScheduledReferenceConfig,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    return _round(
+        _linear_ref(
+            x,
+            precision.quantize(weight),
+            config.mlen,
+            config.max_k_tiles,
+            precision,
+        ),
+        precision,
+    )
+
+
 def _rope_ref(
     x: torch.Tensor,
     rope_matrix: torch.Tensor,
@@ -238,6 +603,23 @@ def _rope_ref(
     )
     x_cos = _round(x_inter * _round(cos_table, precision), precision)
     x_rot_sin = _round(x_rot * _round(sin_table, precision), precision)
+    return _round(x_cos + x_rot_sin, precision)
+
+
+def _rope_scheduled_ref(
+    x: torch.Tensor,
+    rope_matrix: torch.Tensor,
+    cos_table: torch.Tensor,
+    sin_table: torch.Tensor,
+    config: ScheduledReferenceConfig,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    cols = x.shape[1]
+    rows = x.shape[0]
+    x_inter = _round(x, precision)
+    x_rot = _linear_scheduled_ref(x_inter, rope_matrix[:cols, :cols], config, precision)
+    x_cos = _round(x_inter * _round(cos_table[:rows, :cols], precision), precision)
+    x_rot_sin = _round(x_rot * _round(sin_table[:rows, :cols], precision), precision)
     return _round(x_cos + x_rot_sin, precision)
 
 
@@ -262,6 +644,56 @@ def _flash_attn_ref(Q, K, V, scale, causal=False):
         scores.masked_fill_(mask, float("-inf"))
     attn = F.softmax(scores, dim=-1).to(torch.bfloat16).float()
     return (attn @ V).to(torch.bfloat16).float()
+
+
+def _flash_attn_scheduled_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+    precision: ReferencePrecision,
+    *,
+    causal: bool,
+    matmul_scale: float = 1.0,
+) -> torch.Tensor:
+    q = _round(q, precision)
+    k = _round(k, precision)
+    v = _round(v, precision)
+    scores = q @ k.T
+    if matmul_scale != 1.0:
+        scores = scores * matmul_scale
+    scores = _round(scores, precision)
+    if causal:
+        mask = torch.triu(torch.ones(scores.shape[-2], scores.shape[-1], device=scores.device), diagonal=1).bool()
+        scores = scores.masked_fill(mask, float("-inf"))
+    scores = _round(scores * _scalar_preload_ref(scale, precision), precision)
+    attn = _round(torch.softmax(scores, dim=-1), precision)
+    return _round(attn @ v, precision)
+
+
+def _silu_gate_scheduled_ref(
+    up_out: torch.Tensor,
+    gate_out: torch.Tensor,
+    precision: ReferencePrecision,
+) -> torch.Tensor:
+    up = _round(up_out, precision)
+    gate = _round(gate_out, precision)
+    neg = _round(0.0 - up, precision)
+    exp_neg = _round(torch.clamp(neg, -88.0, 88.0).exp(), precision)
+    denom = _round(exp_neg + 1.0, precision)
+    sigmoid = _round(denom.reciprocal(), precision)
+    silu = _round(sigmoid * up, precision)
+    return _round(silu * gate, precision)
+
+
+def _pad_cols_ref(x: torch.Tensor, cols: int) -> torch.Tensor:
+    if x.shape[1] == cols:
+        return x
+    if x.shape[1] > cols:
+        raise ValueError(f"Cannot pad tensor with {x.shape[1]} cols to {cols} cols")
+    out = torch.zeros((x.shape[0], cols), dtype=x.dtype, device=x.device)
+    out[:, :x.shape[1]] = x
+    return out
 
 
 def _ksplit_matmul(A, B, mlen=64, max_k_tiles=_HW_MAX_K_TILES, to_inter=None, from_inter=None):

--- a/aten/tests/test_plena_compiler.py
+++ b/aten/tests/test_plena_compiler.py
@@ -196,6 +196,45 @@ def test_linear_projection_uses_runtime_mram_tile_capacity():
     print("  PASS test_linear_projection_uses_runtime_mram_tile_capacity")
 
 
+def test_vram_layout_tracks_logical_and_physical_shape():
+    """Layouts should keep native logical rows while allocating physical BLEN row storage."""
+    from compiler.aten.plena import PlenaCompiler
+
+    prog = PlenaCompiler(mlen=256, blen=64)
+    x = prog.alloc("X", 4, 256, strict=False, physical_shape=(64, 256))
+    layout = prog.get_vram_layout(x.name)
+
+    assert layout.full_shape == (4, 256)
+    assert layout.physical_shape == (64, 256)
+    block = layout.get_sub_block(0, 0)
+    assert block.valid_shape == (4, 256)
+    assert x.shape == (4, 256)
+    assert x.physical_shape == (64, 256)
+
+    print("  PASS test_vram_layout_tracks_logical_and_physical_shape")
+
+
+def test_partial_row_linear_uses_one_blen_row_group():
+    """M < BLEN on a large-MLEN config should emit one row group, not force MLEN rows."""
+    from compiler.aten.plena import PlenaCompiler
+
+    prog = PlenaCompiler(mlen=256, blen=64)
+    x_input = prog.input("X", shape=(4, 256), physical_shape=(64, 256))
+    w = prog.input("W", shape=(256, 256), physical_shape=(256, 256))
+    x = prog.load_batch(x_input, name="X")
+    y = prog.linear_projection(x, w, name="Y")
+    code = prog.get_code()
+
+    assert y.shape == (4, 256)
+    assert y.physical_shape == (64, 256)
+    assert "M_MM" in code
+    # The projection template receives valid_rows=4 and BLEN=64, so the
+    # middle row-group loop should run once.
+    assert ", 1" in code
+
+    print("  PASS test_partial_row_linear_uses_one_blen_row_group")
+
+
 def test_fix_large_immediates_roundtrip():
     """_fix_large_immediates must preserve exact address values."""
     from compiler.aten.plena_frontend import _fix_large_immediates
@@ -250,6 +289,101 @@ def test_rotate_half_matrix_identity():
     expected = -torch.eye(64)
     assert torch.allclose(RR, expected, atol=1e-6), f"R @ R should be -I, got max diff {(RR - expected).abs().max()}"
     print("  PASS test_rotate_half_matrix_identity")
+
+
+def test_grouped_attention_weight_padding_preserves_head_slots():
+    """Padded Q/O weights must keep native head lanes in padded per-head slots."""
+    from compiler.aten.plena_frontend import _pad_o_weight_grouped, _pad_q_weight_grouped
+
+    w_q = torch.arange(2 * 6, dtype=torch.float32).reshape(2, 6)
+    padded_q = _pad_q_weight_grouped(w_q, num_heads=3, head_dim=2, padded_hidden=4, padded_head_dim=4)
+
+    assert padded_q.shape == (4, 12)
+    assert torch.equal(padded_q[:2, 0:2], w_q[:, 0:2])
+    assert torch.equal(padded_q[:2, 4:6], w_q[:, 2:4])
+    assert torch.equal(padded_q[:2, 8:10], w_q[:, 4:6])
+    assert torch.count_nonzero(padded_q[:2, 2:4]) == 0
+    assert torch.count_nonzero(padded_q[:2, 6:8]) == 0
+    assert torch.count_nonzero(padded_q[:2, 10:12]) == 0
+    assert torch.count_nonzero(padded_q[2:, :]) == 0
+
+    w_o = torch.arange(6 * 2, dtype=torch.float32).reshape(6, 2)
+    padded_o = _pad_o_weight_grouped(w_o, num_heads=3, head_dim=2, padded_head_dim=4, padded_hidden=4)
+
+    assert padded_o.shape == (12, 4)
+    assert torch.equal(padded_o[0:2, :2], w_o[0:2, :])
+    assert torch.equal(padded_o[4:6, :2], w_o[2:4, :])
+    assert torch.equal(padded_o[8:10, :2], w_o[4:6, :])
+    assert torch.count_nonzero(padded_o[2:4, :]) == 0
+    assert torch.count_nonzero(padded_o[6:8, :]) == 0
+    assert torch.count_nonzero(padded_o[10:12, :]) == 0
+    assert torch.count_nonzero(padded_o[:, 2:]) == 0
+
+    print("  PASS test_grouped_attention_weight_padding_preserves_head_slots")
+
+
+def test_kv_grouped_head_packing_preserves_slots():
+    """Packed attention should place Q/O heads in KV-group HLEN slots."""
+    from compiler.aten.plena_frontend import (
+        _pad_o_weight_grouped_by_kv,
+        _pad_q_weight_grouped_by_kv,
+        _pad_rope_inputs_for_head_slots,
+    )
+
+    w_q = torch.arange(2 * 6, dtype=torch.float32).reshape(2, 6)
+    padded_q = _pad_q_weight_grouped_by_kv(
+        w_q,
+        num_heads=3,
+        num_kv_heads=1,
+        head_dim=2,
+        padded_hidden=4,
+        group_width=8,
+        head_slot_dim=2,
+    )
+    assert padded_q.shape == (4, 8)
+    assert torch.equal(padded_q[:2, 0:2], w_q[:, 0:2])
+    assert torch.equal(padded_q[:2, 2:4], w_q[:, 2:4])
+    assert torch.equal(padded_q[:2, 4:6], w_q[:, 4:6])
+    assert torch.count_nonzero(padded_q[:2, 6:8]) == 0
+    assert torch.count_nonzero(padded_q[2:, :]) == 0
+
+    w_o = torch.arange(6 * 2, dtype=torch.float32).reshape(6, 2)
+    padded_o = _pad_o_weight_grouped_by_kv(
+        w_o,
+        num_heads=3,
+        num_kv_heads=1,
+        head_dim=2,
+        group_width=8,
+        head_slot_dim=2,
+        padded_hidden=4,
+    )
+    assert padded_o.shape == (8, 4)
+    assert torch.equal(padded_o[0:2, :2], w_o[0:2, :])
+    assert torch.equal(padded_o[2:4, :2], w_o[2:4, :])
+    assert torch.equal(padded_o[4:6, :2], w_o[4:6, :])
+    assert torch.count_nonzero(padded_o[6:8, :]) == 0
+    assert torch.count_nonzero(padded_o[:, 2:]) == 0
+
+    rope = torch.eye(2)
+    cos = torch.ones(3, 2)
+    sin = torch.full((3, 2), 2.0)
+    packed_rope, packed_cos, packed_sin = _pad_rope_inputs_for_head_slots(
+        rope,
+        cos,
+        sin,
+        padded_seq_len=4,
+        group_width=8,
+        head_slot_dim=2,
+        broadcast_amount=4,
+    )
+    assert packed_rope.shape == (8, 8)
+    assert torch.equal(packed_rope[0:2, 0:2], rope)
+    assert torch.equal(packed_rope[2:4, 2:4], rope)
+    assert torch.equal(packed_cos[:3, 4:6], cos)
+    assert torch.equal(packed_sin[:3, 6:8], sin)
+    assert torch.count_nonzero(packed_cos[3, :]) == 0
+
+    print("  PASS test_kv_grouped_head_packing_preserves_slots")
 
 
 def test_compile_native_hf_decoder_golden_vs_hf():
@@ -332,9 +466,13 @@ if __name__ == "__main__":
         test_mram_allocator_scales_with_runtime_mlen,
         test_compiler_threads_runtime_memory_geometry,
         test_linear_projection_uses_runtime_mram_tile_capacity,
+        test_vram_layout_tracks_logical_and_physical_shape,
+        test_partial_row_linear_uses_one_blen_row_group,
         test_fix_large_immediates_roundtrip,
         test_fix_large_immediates_preserves_relative_adds,
         test_rotate_half_matrix_identity,
+        test_grouped_attention_weight_padding_preserves_head_slots,
+        test_kv_grouped_head_packing_preserves_slots,
         test_compile_native_hf_decoder_golden_vs_hf,
         test_native_compile_assembles,
     ]

--- a/aten/tests/test_plena_compiler.py
+++ b/aten/tests/test_plena_compiler.py
@@ -48,14 +48,16 @@ def test_isa_builder_legalizes_large_absolute_immediates():
     print("  PASS test_isa_builder_legalizes_large_absolute_immediates")
 
 
-def test_isa_builder_preserves_relative_large_immediates():
-    """Typed ISA builder should not split relative S_ADDI_INT instructions."""
+def test_isa_builder_legalizes_relative_large_immediates():
+    """Typed ISA builder should split relative S_ADDI_INT instructions safely."""
     from compiler.aten.isa_builder import IsaBuilder, gp
 
     rendered = IsaBuilder().instr("S_ADDI_INT", gp(5), gp(3), 300000).render()
-    assert "S_ADDI_INT gp5, gp3, 300000" in rendered
+    assert "S_ADDI_INT gp5, gp3, 262143" in rendered
+    assert "S_ADDI_INT gp5, gp5, 37857" in rendered
+    assert "S_ADDI_INT gp5, gp3, 300000" not in rendered
     assert "S_LUI_INT" not in rendered
-    print("  PASS test_isa_builder_preserves_relative_large_immediates")
+    print("  PASS test_isa_builder_legalizes_relative_large_immediates")
 
 
 def test_fpvar_helper_uses_canonical_emit_path():
@@ -95,7 +97,9 @@ def test_vram_fill_zero_all_column_blocks():
     code = prog.get_code()
 
     # 384/64 = 6 column blocks, each needs a V_MUL_VF zeroing loop
-    assert code.count("V_MUL_VF") >= 6, f"Expected >= 6 V_MUL_VF (one per column block), got {code.count('V_MUL_VF')}"
+    assert code.count("V_MUL_VF") >= 6, (
+        f"Expected >= 6 V_MUL_VF (one per column block), got {code.count('V_MUL_VF')}"
+    )
     print("  PASS test_vram_fill_zero_all_column_blocks")
 
 
@@ -110,8 +114,40 @@ def test_vram_add_all_column_blocks():
     code = prog.get_code()
 
     # 6 column blocks = 6 V_ADD_VV loops
-    assert code.count("V_ADD_VV") >= 6, f"Expected >= 6 V_ADD_VV (one per column block), got {code.count('V_ADD_VV')}"
+    assert code.count("V_ADD_VV") >= 6, (
+        f"Expected >= 6 V_ADD_VV (one per column block), got {code.count('V_ADD_VV')}"
+    )
     print("  PASS test_vram_add_all_column_blocks")
+
+
+def test_stage_checkpoint_recorder_emits_stable_vram_copy_metadata():
+    """Debug checkpoints should preserve source tensors at new VRAM addresses."""
+    from compiler.aten.plena import PlenaCompiler
+    from compiler.aten.plena_frontend import StageCheckpointRecorder
+
+    prog = PlenaCompiler(mlen=8, blen=2)
+    x = prog.alloc("X", 8, 8)
+    recorder = StageCheckpointRecorder(enabled=True)
+    checkpoint = recorder.record(
+        prog,
+        layer_idx=0,
+        stage="attn_norm",
+        tensor=x,
+        active_shape=(8, 8),
+        semantic="unit test checkpoint",
+    )
+    metadata = recorder.metadata()
+
+    assert checkpoint is not None
+    assert len(metadata["checkpoints"]) == 1
+    entry = metadata["checkpoints"][0]
+    assert entry["stage"] == "attn_norm"
+    assert entry["layer_idx"] == 0
+    assert entry["source"] == x.name
+    assert entry["vram_addr"] == prog.get_vram_addr(checkpoint.name)
+    assert entry["physical_shape"] == [8, 8]
+    assert "VRAM Matrix Add" in prog.get_code()
+    print("  PASS test_stage_checkpoint_recorder_emits_stable_vram_copy_metadata")
 
 
 def test_alloc_at_correct_address():
@@ -128,7 +164,9 @@ def test_alloc_at_correct_address():
     view = prog.alloc_at("X_cb2_view", 64, 64, view_addr)
 
     actual_addr = prog.get_vram_addr(view.name)
-    assert actual_addr == view_addr, f"alloc_at address mismatch: expected {view_addr}, got {actual_addr}"
+    assert actual_addr == view_addr, (
+        f"alloc_at address mismatch: expected {view_addr}, got {actual_addr}"
+    )
     print("  PASS test_alloc_at_correct_address")
 
 
@@ -248,12 +286,16 @@ def test_fix_large_immediates_roundtrip():
 
         if val < (1 << 18):
             # Should remain as S_ADDI_INT
-            assert f"S_ADDI_INT gp5, gp0, {val}" in fixed, f"Small value {val} was incorrectly converted"
+            assert f"S_ADDI_INT gp5, gp0, {val}" in fixed, (
+                f"Small value {val} was incorrectly converted"
+            )
         else:
             # Should be S_LUI_INT + optional S_ADDI_INT
             upper = val >> 12
             lower = val & 0xFFF
-            assert f"S_LUI_INT gp5, {upper}" in fixed, f"Large value {val}: missing S_LUI_INT gp5, {upper}"
+            assert f"S_LUI_INT gp5, {upper}" in fixed, (
+                f"Large value {val}: missing S_LUI_INT gp5, {upper}"
+            )
             # Verify roundtrip: upper << 12 + lower == val
             reconstructed = (upper << 12) + lower
             assert reconstructed == val, (
@@ -263,21 +305,27 @@ def test_fix_large_immediates_roundtrip():
     print("  PASS test_fix_large_immediates_roundtrip")
 
 
-def test_fix_large_immediates_preserves_relative_adds():
-    """_fix_large_immediates must NOT convert relative S_ADDI_INT (non-gp0 source)."""
+def test_fix_large_immediates_legalizes_relative_adds():
+    """_fix_large_immediates must legalize relative S_ADDI_INT without a scratch register."""
     from compiler.aten.plena_frontend import _fix_large_immediates
 
-    # Relative add: gp5 = gp3 + 300000 — should NOT be converted
+    # Relative add: gp5 = gp3 + 300000. With no liveness information available
+    # in the post-pass, this lowers to bounded ADDI chunks instead of using a
+    # scratch register that could clobber live state.
     asm = "S_ADDI_INT gp5, gp3, 300000\n"
     fixed = _fix_large_immediates(asm)
-    assert "S_ADDI_INT gp5, gp3, 300000" in fixed, "Relative S_ADDI_INT was incorrectly converted"
+    assert "S_ADDI_INT gp5, gp3, 262143" in fixed
+    assert "S_ADDI_INT gp5, gp5, 37857" in fixed
+    assert "S_ADDI_INT gp5, gp3, 300000" not in fixed
 
     # Absolute load: gp5 = gp0 + 300000 — SHOULD be converted
     asm2 = "S_ADDI_INT gp5, gp0, 300000\n"
     fixed2 = _fix_large_immediates(asm2)
-    assert "S_LUI_INT" in fixed2, "Absolute S_ADDI_INT with large value was not converted"
+    assert "S_LUI_INT" in fixed2, (
+        "Absolute S_ADDI_INT with large value was not converted"
+    )
 
-    print("  PASS test_fix_large_immediates_preserves_relative_adds")
+    print("  PASS test_fix_large_immediates_legalizes_relative_adds")
 
 
 def test_rotate_half_matrix_identity():
@@ -287,7 +335,9 @@ def test_rotate_half_matrix_identity():
     R = _make_rotate_half_matrix(64)
     RR = R @ R
     expected = -torch.eye(64)
-    assert torch.allclose(RR, expected, atol=1e-6), f"R @ R should be -I, got max diff {(RR - expected).abs().max()}"
+    assert torch.allclose(RR, expected, atol=1e-6), (
+        f"R @ R should be -I, got max diff {(RR - expected).abs().max()}"
+    )
     print("  PASS test_rotate_half_matrix_identity")
 
 
@@ -386,12 +436,225 @@ def test_kv_grouped_head_packing_preserves_slots():
     print("  PASS test_kv_grouped_head_packing_preserves_slots")
 
 
+def test_packed_kv_weights_keep_compact_logical_width_with_physical_storage():
+    """Packed K/V weights should be logical HLEN while reserving MLEN HBM storage."""
+    from compiler.aten.model_extract import LayerWeights, ModelConfig
+    from compiler.aten.plena import PlenaCompiler
+    from compiler.aten.plena_frontend import (
+        AttentionHeadPacking,
+        _pad_decoder_weights_for_tiles,
+        _tensor_layout_metadata,
+        _weight_physical_shapes_for_layer,
+    )
+
+    model_cfg = ModelConfig(
+        hidden_size=2,
+        inter_dim=4,
+        num_heads=2,
+        num_kv_heads=1,
+        head_dim=2,
+        eps=1e-5,
+        rope_theta=10000.0,
+        vocab_size=None,
+        model_type="unit",
+    )
+    weights = LayerWeights(
+        w_q=torch.ones(2, 4),
+        w_o=torch.ones(4, 2),
+        w_k_heads=[torch.ones(2, 2)],
+        w_v_heads=[torch.ones(2, 2)],
+        w_gate=torch.ones(2, 4),
+        w_up=torch.ones(2, 4),
+        w_down=torch.ones(4, 2),
+        eps=1e-5,
+    )
+    head_packing = AttentionHeadPacking(
+        enabled=True,
+        hlen=4,
+        broadcast_amount=2,
+        head_slot_dim=4,
+        group_width=8,
+        total_q_dim=8,
+    )
+    padded = _pad_decoder_weights_for_tiles(
+        weights,
+        model_cfg,
+        padded_hidden=8,
+        padded_inter=8,
+        padded_head_dim=8,
+        head_packing=head_packing,
+    )
+
+    assert padded.w_k_heads[0].shape == (8, 4)
+    assert padded.w_v_heads[0].shape == (8, 4)
+
+    prog = PlenaCompiler(mlen=8, blen=2)
+    physical_shapes = _weight_physical_shapes_for_layer(
+        0,
+        padded,
+        head_packing=head_packing,
+        padded_head_dim=8,
+    )
+    prog.input("W_k_0_h0", shape=tuple(padded.w_k_heads[0].shape), physical_shape=physical_shapes["W_k_0_h0"])
+    layouts = _tensor_layout_metadata(prog, {"W_k_0_h0": padded.w_k_heads[0]})
+
+    assert layouts["W_k_0_h0"]["source_shape"] == [8, 4]
+    assert layouts["W_k_0_h0"]["storage_shape"] == [8, 8]
+    assert layouts["W_k_0_h0"]["source_row_elements"] == 4
+    assert layouts["W_k_0_h0"]["storage_row_elements"] == 8
+
+    print("  PASS test_packed_kv_weights_keep_compact_logical_width_with_physical_storage")
+
+
+def test_packed_gqa_kv_group_loop_reduces_static_code():
+    """Packed GQA can emit one attention-core body under a KV-head loop."""
+    from compiler.aten.plena import PlenaCompiler
+
+    def instruction_lines(asm: str) -> int:
+        prefixes = ("S_", "C_", "H_", "V_", "M_")
+        return sum(1 for line in asm.splitlines() if line.strip().startswith(prefixes))
+
+    def emit(looped: bool) -> str:
+        prog = PlenaCompiler(mlen=256, blen=64)
+        prog.hlen = 64
+        prog.broadcast_amount = 4
+        q = prog.alloc("Q", 64, 512, strict=False, physical_shape=(256, 512))
+        o = prog.alloc("O", 64, 512, strict=False, physical_shape=(256, 512))
+        scratch = prog.alloc("S_scratch", 256 * (4 + 3), 256, strict=True)
+        mask = prog.alloc("mask", 256, 256, strict=True)
+        kv_pairs = []
+        for kv_h in range(2):
+            k = prog.input(f"K{kv_h}", shape=(64, 64), physical_shape=(256, 256))
+            v = prog.input(f"V{kv_h}", shape=(64, 64), physical_shape=(256, 256))
+            kv_pairs.append((k, v))
+
+        q_base = prog.get_vram_addr(q.name)
+        o_base = prog.get_vram_addr(o.name)
+        scratch_base = prog.get_vram_addr(scratch.name)
+        if looped:
+            prog.flash_attention_packed_groups_looped(
+                q,
+                kv_pairs,
+                group_heads=3,
+                head_slot_dim=64,
+                output_base_address=o_base,
+                scratch_base_address=scratch_base,
+                broadcast_amount=4,
+                causal_mask=mask,
+            )
+        else:
+            for kv_h, (k, v) in enumerate(kv_pairs):
+                q_group = prog.alloc_at(
+                    f"Q_group{kv_h}",
+                    64,
+                    256,
+                    q_base + kv_h * 256 * 256,
+                    physical_shape=(256, 256),
+                )
+                prog.flash_attention_packed_group(
+                    q_group,
+                    k,
+                    v,
+                    group_heads=3,
+                    head_slot_dim=64,
+                    output_base_address=o_base + kv_h * 256 * 256,
+                    scratch_base_address=scratch_base,
+                    broadcast_amount=4,
+                    causal_mask=mask,
+                )
+        return prog.compile()
+
+    baseline = emit(looped=False)
+    looped = emit(looped=True)
+
+    assert baseline.count("Packed GQA QK^T") == 2
+    assert looped.count("Packed GQA attention core loop over KV groups") == 1
+    assert looped.count("Packed GQA QK^T") == 1
+    assert instruction_lines(looped) < instruction_lines(baseline)
+
+    print("  PASS test_packed_gqa_kv_group_loop_reduces_static_code")
+
+
+def test_packed_gqa_fused_accepts_batch_slabs():
+    """Packed GQA should isolate true B>1 slabs instead of attending across B*S rows."""
+    from compiler.aten.plena import PlenaCompiler
+
+    prog = PlenaCompiler(mlen=64, blen=4)
+    prog.hlen = 16
+    prog.broadcast_amount = 4
+
+    q_input = prog.input("Q", shape=(128, 64), physical_shape=(128, 64), prestaged_vram_addr=0)
+    k_input = prog.input("K", shape=(128, 16), physical_shape=(128, 64))
+    v_input = prog.input("V", shape=(128, 16), physical_shape=(128, 64))
+    q = prog.load_batch(q_input, name="Q")
+
+    o = prog.flash_attention(
+        q,
+        k_input,
+        v_input,
+        scale=1.0 / 4.0,
+        hq=4,
+        hkv=1,
+        h_qkv=16,
+        batch_size=2,
+        seq_len=64,
+        kv_seq_len=64,
+    )
+    asm = prog.compile()
+
+    assert o.shape == (128, 64)
+    assert o.physical_shape == (128, 64)
+    assert "VRAM View _gqa_Q_b0" in asm
+    assert "VRAM View _gqa_Q_b1" in asm
+    assert "Load SubMatrix K[0][0]" in asm
+    assert "Load SubMatrix K[1][0]" in asm
+    assert "Compute PV = P @ V[k_idx=0]" in asm
+    assert "Compute PV = P @ V[k_idx=1]" in asm
+
+    print("  PASS test_packed_gqa_fused_accepts_batch_slabs")
+
+
+def test_mha_accepts_batch_slabs():
+    """MHA should isolate true B>1 slabs instead of flattening into one sequence."""
+    from compiler.aten.plena import PlenaCompiler
+
+    prog = PlenaCompiler(mlen=64, blen=4)
+    q_input = prog.input("Q", shape=(128, 64), physical_shape=(128, 64), prestaged_vram_addr=0)
+    k_input = prog.input("K", shape=(128, 64), physical_shape=(128, 64))
+    v_input = prog.input("V", shape=(128, 64), physical_shape=(128, 64))
+    q = prog.load_batch(q_input, name="Q")
+
+    o = prog.flash_attention(
+        q,
+        k_input,
+        v_input,
+        scale=1.0 / 8.0,
+        batch_size=2,
+        seq_len=64,
+        kv_seq_len=64,
+    )
+    asm = prog.compile()
+
+    assert o.shape == (128, 64)
+    assert o.physical_shape == (128, 64)
+    assert "VRAM View _mha_Q_b0" in asm
+    assert "VRAM View _mha_Q_b1" in asm
+    assert "Load SubMatrix Row K[0][:]" in asm
+    assert "Load SubMatrix Row K[1][:]" in asm
+    assert "Compute PV = P @ V[k_idx=0]" in asm
+    assert "Compute PV = P @ V[k_idx=1]" in asm
+
+    print("  PASS test_mha_accepts_batch_slabs")
+
+
 def test_compile_native_hf_decoder_golden_vs_hf():
     """Golden (MXFP8+BF16) should closely match HF float32 at native dims."""
     from compiler.aten.plena_frontend import compile_native_hf_decoder
     from transformers import AutoModelForCausalLM
 
-    model = AutoModelForCausalLM.from_pretrained("AICrossSim/clm-60m", torch_dtype=torch.float32)
+    model = AutoModelForCausalLM.from_pretrained(
+        "AICrossSim/clm-60m", torch_dtype=torch.float32
+    )
     model.eval()
 
     r = compile_native_hf_decoder(model, seq_len=64, num_layers=1)
@@ -400,7 +663,9 @@ def test_compile_native_hf_decoder_golden_vs_hf():
 
     diff = (golden - hf).abs()
     pct = (diff <= 0.2 + 0.2 * hf.abs()).float().mean() * 100
-    cos = torch.nn.functional.cosine_similarity(golden.flatten().unsqueeze(0), hf.flatten().unsqueeze(0))
+    cos = torch.nn.functional.cosine_similarity(
+        golden.flatten().unsqueeze(0), hf.flatten().unsqueeze(0)
+    )
 
     assert pct >= 95.0, f"Golden vs HF allclose {pct:.1f}% < 95%"
     assert cos.item() >= 0.99, f"Golden vs HF cosine {cos.item():.4f} < 0.99"
@@ -415,7 +680,9 @@ def test_native_compile_assembles():
     from compiler.aten.plena_frontend import compile_native_hf_decoder
     from transformers import AutoModelForCausalLM
 
-    model = AutoModelForCausalLM.from_pretrained("AICrossSim/clm-60m", torch_dtype=torch.float32)
+    model = AutoModelForCausalLM.from_pretrained(
+        "AICrossSim/clm-60m", torch_dtype=torch.float32
+    )
     model.eval()
 
     r = compile_native_hf_decoder(model, seq_len=64, num_layers=1)
@@ -457,11 +724,12 @@ if __name__ == "__main__":
     tests = [
         test_isa_builder_renders_typed_instruction,
         test_isa_builder_legalizes_large_absolute_immediates,
-        test_isa_builder_preserves_relative_large_immediates,
+        test_isa_builder_legalizes_relative_large_immediates,
         test_fpvar_helper_uses_canonical_emit_path,
         test_hbm_load_helper_uses_typed_legalization,
         test_vram_fill_zero_all_column_blocks,
         test_vram_add_all_column_blocks,
+        test_stage_checkpoint_recorder_emits_stable_vram_copy_metadata,
         test_alloc_at_correct_address,
         test_mram_allocator_scales_with_runtime_mlen,
         test_compiler_threads_runtime_memory_geometry,
@@ -469,10 +737,14 @@ if __name__ == "__main__":
         test_vram_layout_tracks_logical_and_physical_shape,
         test_partial_row_linear_uses_one_blen_row_group,
         test_fix_large_immediates_roundtrip,
-        test_fix_large_immediates_preserves_relative_adds,
+        test_fix_large_immediates_legalizes_relative_adds,
         test_rotate_half_matrix_identity,
         test_grouped_attention_weight_padding_preserves_head_slots,
         test_kv_grouped_head_packing_preserves_slots,
+        test_packed_kv_weights_keep_compact_logical_width_with_physical_storage,
+        test_packed_gqa_kv_group_loop_reduces_static_code,
+        test_packed_gqa_fused_accepts_batch_slabs,
+        test_mha_accepts_batch_slabs,
         test_compile_native_hf_decoder_golden_vs_hf,
         test_native_compile_assembles,
     ]

--- a/aten/tests/test_plena_compiler.py
+++ b/aten/tests/test_plena_compiler.py
@@ -5,6 +5,7 @@ Run: PYTHONPATH=.:tools:.. python3 aten/tests/test_plena_compiler.py
 
 import sys
 import os
+import re
 
 # Insert PLENA_Simulator root and tools/ so imports resolve correctly regardless
 # of how the test is invoked (direct python3 or via PYTHONPATH=.:tools:..).
@@ -271,6 +272,46 @@ def test_partial_row_linear_uses_one_blen_row_group():
     assert ", 1" in code
 
     print("  PASS test_partial_row_linear_uses_one_blen_row_group")
+
+
+def test_ffn_workspace_uses_allocator_and_avoids_rope_tables():
+    """FFN temps must be allocator-managed, not hardcoded into low VRAM."""
+    from compiler.aten.plena import PlenaCompiler
+
+    def overlaps(a0, a1, b0, b1):
+        return a0 < b1 and b0 < a1
+
+    prog = PlenaCompiler(mlen=256, blen=64, mram_tile_capacity=16)
+    cos_input = prog.input("COS", shape=(64, 256), physical_shape=(64, 256))
+    sin_input = prog.input("SIN", shape=(64, 256), physical_shape=(64, 256))
+    cos = prog.load_batch(cos_input, name="COS")
+    sin = prog.load_batch(sin_input, name="SIN")
+    x_input = prog.input("X", shape=(64, 768), physical_shape=(64, 768))
+    x = prog.load_batch(x_input, name="X")
+    w_gate = prog.input("W_gate", shape=(768, 1536), physical_shape=(768, 1536))
+    w_up = prog.input("W_up", shape=(768, 1536), physical_shape=(768, 1536))
+    w_down = prog.input("W_down", shape=(1536, 768), physical_shape=(1536, 768))
+
+    cos_range = (prog.get_vram_addr(cos.name), prog.get_vram_addr(cos.name) + 64 * 256)
+    sin_range = (prog.get_vram_addr(sin.name), prog.get_vram_addr(sin.name) + 64 * 256)
+    prog.ffn(x, w_gate, w_up, w_down)
+    code = prog.compile()
+
+    match = re.search(r"Allocate VRAM Matrix _ffn_workspace:.* at VRAM\[(\d+)\]", code)
+    assert match is not None, "FFN workspace allocation comment missing"
+    workspace_base = int(match.group(1))
+    workspace_elems = 64 * (2 * 1536 + 1536)
+    workspace_range = (workspace_base, workspace_base + workspace_elems)
+
+    assert not overlaps(*workspace_range, *cos_range), (
+        f"FFN workspace {workspace_range} overlaps COS {cos_range}"
+    )
+    assert not overlaps(*workspace_range, *sin_range), (
+        f"FFN workspace {workspace_range} overlaps SIN {sin_range}"
+    )
+    assert "_ffn_absolute_workspace_padding" not in code
+
+    print("  PASS test_ffn_workspace_uses_allocator_and_avoids_rope_tables")
 
 
 def test_fix_large_immediates_roundtrip():
@@ -736,6 +777,7 @@ if __name__ == "__main__":
         test_linear_projection_uses_runtime_mram_tile_capacity,
         test_vram_layout_tracks_logical_and_physical_shape,
         test_partial_row_linear_uses_one_blen_row_group,
+        test_ffn_workspace_uses_allocator_and_avoids_rope_tables,
         test_fix_large_immediates_roundtrip,
         test_fix_large_immediates_legalizes_relative_adds,
         test_rotate_half_matrix_identity,

--- a/aten/tests/test_plena_compiler.py
+++ b/aten/tests/test_plena_compiler.py
@@ -132,6 +132,70 @@ def test_alloc_at_correct_address():
     print("  PASS test_alloc_at_correct_address")
 
 
+def test_mram_allocator_scales_with_runtime_mlen():
+    """MRAMAllocator capacity/alignment must use runtime mlen, not module MLEN=64."""
+    from compiler.aten.plena.memory import MRAMAllocator
+
+    alloc = MRAMAllocator(mlen=256, tile_capacity=4)
+    tile_elems = 256 * 256
+
+    assert alloc.alignment == tile_elems
+    assert alloc.total_size == 4 * tile_elems
+    assert alloc.tile_elems == tile_elems
+    assert alloc.tile_capacity == 4
+
+    addrs = [alloc.allocate(f"tile_{i}", tile_elems) for i in range(4)]
+    assert addrs == [0, tile_elems, 2 * tile_elems, 3 * tile_elems]
+
+    try:
+        alloc.allocate("overflow", tile_elems)
+    except MemoryError:
+        pass
+    else:
+        raise AssertionError("MRAMAllocator accepted a fifth tile despite tile_capacity=4")
+
+    print("  PASS test_mram_allocator_scales_with_runtime_mlen")
+
+
+def test_compiler_threads_runtime_memory_geometry():
+    """PlenaCompiler must pass runtime mlen/capacity into VRAM and MRAM allocators."""
+    from compiler.aten.plena import PlenaCompiler
+
+    prog = PlenaCompiler(mlen=256, blen=64, mram_tile_capacity=3)
+    tile_elems = 256 * 256
+
+    assert prog.mram_tile_capacity == 3
+    assert prog.mram_tile_elems == tile_elems
+    assert prog.mram_capacity_elems == 3 * tile_elems
+    assert prog.mram_allocator.alignment == tile_elems
+    assert prog.mram_allocator.total_size == 3 * tile_elems
+    assert prog.vram_allocator.alignment == 256
+
+    print("  PASS test_compiler_threads_runtime_memory_geometry")
+
+
+def test_linear_projection_uses_runtime_mram_tile_capacity():
+    """K-split should follow prog.mram_tile_capacity instead of a module constant."""
+    from compiler.aten.plena import PlenaCompiler
+
+    prog = PlenaCompiler(mlen=128, blen=4, mram_tile_capacity=2)
+    x_input = prog.input("X", shape=(128, 384), prestaged_vram_addr=0)
+    x = prog.load_batch(x_input, name="X")
+    w = prog.input("W", shape=(384, 128))
+
+    prog.linear_projection(x, w, name="Y")
+    code = prog.compile()
+
+    # K=384 at mlen=128 is 3 K-tiles. With runtime capacity 2 this must split
+    # into two projection chunks and accumulate the second partial sum.
+    assert prog.mram_allocator.total_size == 2 * 128 * 128
+    assert "V_ADD_VV" in code
+    assert "linear_out_temp" not in code
+    assert "Y_temp" in code
+
+    print("  PASS test_linear_projection_uses_runtime_mram_tile_capacity")
+
+
 def test_fix_large_immediates_roundtrip():
     """_fix_large_immediates must preserve exact address values."""
     from compiler.aten.plena_frontend import _fix_large_immediates
@@ -265,6 +329,9 @@ if __name__ == "__main__":
         test_vram_fill_zero_all_column_blocks,
         test_vram_add_all_column_blocks,
         test_alloc_at_correct_address,
+        test_mram_allocator_scales_with_runtime_mlen,
+        test_compiler_threads_runtime_memory_geometry,
+        test_linear_projection_uses_runtime_mram_tile_capacity,
         test_fix_large_immediates_roundtrip,
         test_fix_large_immediates_preserves_relative_adds,
         test_rotate_half_matrix_identity,

--- a/aten/vram_stage_compare.py
+++ b/aten/vram_stage_compare.py
@@ -115,9 +115,9 @@ def _linear_hw(A: torch.Tensor, B: torch.Tensor, mlen: int, max_k_tiles: int) ->
 def _rope_hw(x: torch.Tensor, rope: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
     rows, cols = x.shape
     rope_slice = rope[:cols, :cols]
-    cos_slice = cos[:rows, :cols]
-    sin_slice = sin[:rows, :cols]
     x_inter = _round_hw(x)
+    cos_slice = _pad_expected_to_actual(cos[:rows, :cols], x_inter)
+    sin_slice = _pad_expected_to_actual(sin[:rows, :cols], x_inter)
     x_rot = _round_hw(torch.matmul(x_inter, _round_hw(rope_slice)))
     x_cos = _round_hw(x_inter * _round_hw(cos_slice))
     x_rot_sin = _round_hw(x_rot * _round_hw(sin_slice))

--- a/aten/vram_stage_compare.py
+++ b/aten/vram_stage_compare.py
@@ -1,53 +1,73 @@
-"""VRAM-in-the-loop stage comparison for SmolVLM2 / clm-60m.
+"""VRAM-in-the-loop stage comparison for native decoder compiles.
 
-Instead of comparing the final output against a golden chain (which drifts),
-this reads the emulator's ACTUAL VRAM values at each stage boundary and uses
-them as input to compute the expected NEXT stage output. Each stage is then
-compared independently.
-
-Usage:
-    from compiler.aten.vram_stage_compare import compare_stages
-    results = compare_stages(
-        vram_path="transactional_emulator/vram_dump.bin",
-        build_dir="/tmp/smolvlm2_1layer_f32regs",
-        hidden=576, inter=1536, num_heads=9, num_kv_heads=3,
-        layer_idx=0,
-    )
+When a build contains ``stage_checkpoints.json``, this checker validates the
+preserved VRAM stage boundaries directly. For older builds it falls back to the
+legacy final-layer FFN check that starts from the emulator's residual scratch.
 """
 
+from __future__ import annotations
+
+import argparse
+import json
 import re
 import struct
+import sys
+from pathlib import Path
+
 import numpy as np
 import torch
 import torch.nn.functional as F
-from pathlib import Path
-from compiler.aten.plena_frontend import quantize_to_mxfp, _ksplit_matmul
+
+_COMPILER_ROOT = Path(__file__).resolve().parents[1]
+_SIM_ROOT = _COMPILER_ROOT.parent
+for _path in (_SIM_ROOT, _SIM_ROOT / "tools", _COMPILER_ROOT):
+    _path_str = str(_path)
+    if _path_str not in sys.path:
+        sys.path.insert(0, _path_str)
+
+from compiler.aten.plena_frontend import _ksplit_matmul, quantize_to_mxfp
 
 
 _HW_MAX_K_TILES = 4
 
 
-def _read_bf16_matrix(vram_path, addr, rows, cols, mlen=64):
-    """Read a (rows, cols) matrix from VRAM dump in column-tile layout."""
+def _read_bf16_matrix(vram_path, addr: int, rows: int, cols: int, mlen: int = 64) -> torch.Tensor:
+    """Read a VRAM matrix stored in column-tile layout as float32."""
+    if rows <= 0 or cols <= 0:
+        raise ValueError(f"rows and cols must be positive, got rows={rows}, cols={cols}")
+    if cols % mlen != 0:
+        raise ValueError(f"cols ({cols}) must be a multiple of mlen ({mlen})")
+
     out = np.zeros((rows, cols), dtype=np.float32)
     with open(vram_path, "rb") as f:
         for tile in range(cols // mlen):
-            for r in range(rows):
-                f.seek((addr + tile * rows * mlen + r * mlen) * 2)
+            for row in range(rows):
+                f.seek((addr + tile * rows * mlen + row * mlen) * 2)
                 raw = f.read(mlen * 2)
-                for c in range(mlen):
-                    u16 = int(raw[c * 2]) | (int(raw[c * 2 + 1]) << 8)
-                    u32 = u16 << 16
-                    out[r, tile * mlen + c] = struct.unpack("f", struct.pack("I", u32))[0]
+                if len(raw) != mlen * 2:
+                    raise EOFError(
+                        f"Could not read {mlen * 2} bytes at VRAM element offset "
+                        f"{addr + tile * rows * mlen + row * mlen}"
+                    )
+                for col in range(mlen):
+                    u16 = raw[col * 2] | (raw[col * 2 + 1] << 8)
+                    out[row, tile * mlen + col] = struct.unpack("f", struct.pack("I", u16 << 16))[0]
     return torch.tensor(out)
 
 
-def _allclose_pct(a, b, atol=0.2, rtol=0.2):
+def _allclose_pct(a: torch.Tensor, b: torch.Tensor, atol: float = 0.2, rtol: float = 0.2) -> float:
     return torch.isclose(a.bfloat16(), b.bfloat16(), atol=atol, rtol=rtol).float().mean().item() * 100
 
 
-def _mse(a, b):
+def _mse(a: torch.Tensor, b: torch.Tensor) -> float:
     return ((a.float() - b.float()) ** 2).mean().item()
+
+
+def _load_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with path.open() as f:
+        return json.load(f)
 
 
 def _infer_final_layer_idx(build: Path) -> int:
@@ -62,11 +82,314 @@ def _infer_final_layer_idx(build: Path) -> int:
 
 
 def _read_alloc_addr(asm: str, name: str) -> int | None:
-    match = re.search(
-        rf"Allocate VRAM Matrix {re.escape(name)}: .*?VRAM\[(\d+)\]",
-        asm,
-    )
+    match = re.search(rf"Allocate VRAM Matrix {re.escape(name)}: .*?VRAM\[(\d+)\]", asm)
     return int(match.group(1)) if match else None
+
+
+def _load_weight(build: Path, name: str) -> torch.Tensor:
+    return quantize_to_mxfp(torch.load(build / name, map_location="cpu", weights_only=True))
+
+
+def _load_tensor(build: Path, name: str, *, quantized: bool = False) -> torch.Tensor:
+    tensor = torch.load(build / name, map_location="cpu", weights_only=True).float()
+    return quantize_to_mxfp(tensor) if quantized else tensor
+
+
+def _round_hw(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.to(torch.bfloat16).float()
+
+
+def _linear_hw(A: torch.Tensor, B: torch.Tensor, mlen: int, max_k_tiles: int) -> torch.Tensor:
+    return _round_hw(
+        _ksplit_matmul(
+            A,
+            B,
+            mlen,
+            max_k_tiles,
+            to_inter=lambda x: x.to(torch.bfloat16),
+            from_inter=lambda x: x.float(),
+        )
+    )
+
+
+def _rope_hw(x: torch.Tensor, rope: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    rows, cols = x.shape
+    rope_slice = rope[:cols, :cols]
+    cos_slice = cos[:rows, :cols]
+    sin_slice = sin[:rows, :cols]
+    x_inter = _round_hw(x)
+    x_rot = _round_hw(torch.matmul(x_inter, _round_hw(rope_slice)))
+    x_cos = _round_hw(x_inter * _round_hw(cos_slice))
+    x_rot_sin = _round_hw(x_rot * _round_hw(sin_slice))
+    return _round_hw(x_cos + x_rot_sin)
+
+
+def _rms_norm_padded(x: torch.Tensor, active_hidden: int, eps: float) -> torch.Tensor:
+    """RMS norm for padded physical hidden storage.
+
+    Native compiler output can store hidden columns padded to MLEN, while FPRAM
+    still stores 1/native_hidden. Padded columns are expected to be zero, so the
+    scalar denominator must remain the active hidden width.
+    """
+    x_bf = x.to(torch.bfloat16)
+    rms = torch.rsqrt(x_bf.float().pow(2).sum(-1, keepdim=True) / float(active_hidden) + eps)
+    return (x_bf.float() * rms).to(torch.bfloat16).float()
+
+
+def _compare_region(
+    expected: torch.Tensor,
+    actual: torch.Tensor,
+    active_rows: int,
+    active_cols: int,
+) -> dict[str, float]:
+    active_expected = expected[:active_rows, :active_cols]
+    active_actual = actual[:active_rows, :active_cols]
+    return {
+        "full_allclose": _allclose_pct(expected, actual),
+        "active_allclose": _allclose_pct(active_expected, active_actual),
+        "full_mse": _mse(expected, actual),
+        "active_mse": _mse(active_expected, active_actual),
+    }
+
+
+def _pad_expected_to_actual(expected: torch.Tensor, actual: torch.Tensor) -> torch.Tensor:
+    if expected.shape == actual.shape:
+        return expected
+    if expected.shape[0] > actual.shape[0] or expected.shape[1] > actual.shape[1]:
+        raise ValueError(f"Expected shape {tuple(expected.shape)} exceeds actual shape {tuple(actual.shape)}")
+    padded = torch.zeros_like(actual)
+    padded[: expected.shape[0], : expected.shape[1]] = expected
+    return padded
+
+
+def _load_stage_checkpoint_metadata(build: Path) -> dict:
+    metadata = _load_json(build / "stage_checkpoints.json")
+    if not metadata:
+        return {}
+    if isinstance(metadata, list):
+        return {"schema_version": 0, "checkpoints": metadata}
+    return metadata
+
+
+def _checkpoint_lookup(metadata: dict) -> dict[tuple[int | None, str], dict]:
+    lookup = {}
+    for entry in metadata.get("checkpoints", []):
+        lookup[(entry.get("layer_idx"), entry["stage"])] = entry
+    return lookup
+
+
+def _read_checkpoint(vram_path, entry: dict, mlen: int) -> torch.Tensor:
+    physical_rows, physical_cols = entry["physical_shape"]
+    return _read_bf16_matrix(vram_path, int(entry["vram_addr"]), physical_rows, physical_cols, mlen=mlen)
+
+
+def _stage_result(stage: str, expected: torch.Tensor, actual: torch.Tensor, entry: dict) -> dict[str, float | str]:
+    expected = _pad_expected_to_actual(expected, actual)
+    active_rows, active_cols = entry["active_shape"]
+    result = _compare_region(expected, actual, int(active_rows), int(active_cols))
+    return {
+        "stage": stage,
+        "active_allclose": result["active_allclose"],
+        "full_allclose": result["full_allclose"],
+        "active_mse": result["active_mse"],
+        "full_mse": result["full_mse"],
+        "semantic": entry.get("semantic", ""),
+    }
+
+
+def _append_stage_result(
+    stage_results: list[dict],
+    lookup: dict[tuple[int | None, str], dict],
+    vram_path,
+    mlen: int,
+    layer_idx: int | None,
+    stage: str,
+    expected: torch.Tensor,
+) -> torch.Tensor | None:
+    entry = lookup.get((layer_idx, stage))
+    if entry is None:
+        return None
+    actual = _read_checkpoint(vram_path, entry, mlen)
+    stage_results.append(_stage_result(stage, expected, actual, entry))
+    return actual
+
+
+def _compare_checkpointed_stages(
+    vram_path,
+    build: Path,
+    info: dict,
+    params: dict,
+    metadata: dict,
+    *,
+    hidden: int,
+    inter: int,
+    seq_len: int,
+    mlen: int,
+    eps: float,
+    verbose: bool,
+    layer_idx: int | None,
+) -> dict:
+    del params
+
+    lookup = _checkpoint_lookup(metadata)
+    if layer_idx is None:
+        layer_indices = sorted(
+            {
+                int(entry["layer_idx"])
+                for entry in metadata.get("checkpoints", [])
+                if entry.get("layer_idx") is not None
+            }
+        )
+    else:
+        layer_indices = [layer_idx]
+    layer_indices = [idx for idx in layer_indices if (idx, "attn_input") in lookup or (idx, "ffn_input") in lookup]
+    if not layer_indices:
+        raise ValueError(f"No layer checkpoints found in {build / 'stage_checkpoints.json'}")
+
+    padded_hidden = int(info.get("padded_hidden_size", hidden))
+    padded_inter = int(info.get("padded_inter_dim", inter))
+    padded_seq_len = int(info.get("padded_seq_len", seq_len))
+    max_k_tiles = int(info.get("mram_tile_capacity", _HW_MAX_K_TILES))
+    num_kv_heads = int(info.get("num_kv_heads", 1))
+
+    rope = _load_tensor(build, "R_rope.pt", quantized=True)
+    cos = _load_tensor(build, "COS.pt", quantized=True)
+    sin = _load_tensor(build, "SIN.pt", quantized=True)
+
+    stage_results = []
+    results = {
+        "mode": "checkpointed",
+        "layers": layer_indices,
+        "seq_len": seq_len,
+        "hidden": hidden,
+        "inter": inter,
+        "mlen": mlen,
+        "padded_seq_len": padded_seq_len,
+        "padded_hidden": padded_hidden,
+        "padded_inter": padded_inter,
+        "stage_results": stage_results,
+    }
+
+    for idx in layer_indices:
+        if verbose:
+            print(f"  Validating checkpointed layer {idx}")
+        W_q = _load_weight(build, f"W_q_{idx}.pt")
+        W_o = _load_weight(build, f"W_o_{idx}.pt")
+        W_gate = _load_weight(build, f"W_gate_{idx}.pt")
+        W_up = _load_weight(build, f"W_up_{idx}.pt")
+        W_down = _load_weight(build, f"W_down_{idx}.pt")
+
+        attn_input_entry = lookup.get((idx, "attn_input"))
+        attn_norm_entry = lookup.get((idx, "attn_norm"))
+        if attn_input_entry is not None and attn_norm_entry is not None:
+            attn_input = _read_checkpoint(vram_path, attn_input_entry, mlen)
+            attn_norm_expected = _rms_norm_padded(attn_input, hidden, eps)
+            attn_norm = _append_stage_result(
+                stage_results,
+                lookup,
+                vram_path,
+                mlen,
+                idx,
+                "attn_norm",
+                attn_norm_expected,
+            )
+            if attn_norm is not None:
+                q_expected = _linear_hw(attn_norm, W_q, mlen, max_k_tiles)
+                _append_stage_result(stage_results, lookup, vram_path, mlen, idx, "q_full", q_expected)
+
+                for kv_h in range(num_kv_heads):
+                    W_k = _load_weight(build, f"W_k_{idx}_h{kv_h}.pt")
+                    W_v = _load_weight(build, f"W_v_{idx}_h{kv_h}.pt")
+                    k_expected = _linear_hw(attn_norm, W_k, mlen, max_k_tiles)
+                    v_expected = _linear_hw(attn_norm, W_v, mlen, max_k_tiles)
+                    _append_stage_result(stage_results, lookup, vram_path, mlen, idx, f"k_proj_h{kv_h}", k_expected)
+                    _append_stage_result(stage_results, lookup, vram_path, mlen, idx, f"v_proj_h{kv_h}", v_expected)
+                    k_rope_expected = _rope_hw(k_expected, rope, cos, sin)
+                    _append_stage_result(stage_results, lookup, vram_path, mlen, idx, f"k_rope_h{kv_h}", k_rope_expected)
+
+        o_full_entry = lookup.get((idx, "o_full"))
+        o_proj_entry = lookup.get((idx, "o_proj"))
+        if o_full_entry is not None and o_proj_entry is not None:
+            o_full = _read_checkpoint(vram_path, o_full_entry, mlen)
+            o_proj_expected = _linear_hw(o_full, W_o, mlen, max_k_tiles)
+            o_proj = _append_stage_result(stage_results, lookup, vram_path, mlen, idx, "o_proj", o_proj_expected)
+
+            attn_input_entry = lookup.get((idx, "attn_input"))
+            if o_proj is not None and attn_input_entry is not None:
+                attn_input = _read_checkpoint(vram_path, attn_input_entry, mlen)
+                attn_input = _pad_expected_to_actual(attn_input, o_proj)
+                attn_resid_expected = _round_hw(o_proj + attn_input)
+                _append_stage_result(
+                    stage_results,
+                    lookup,
+                    vram_path,
+                    mlen,
+                    idx,
+                    "attn_residual",
+                    attn_resid_expected,
+                )
+
+        ffn_input_entry = lookup.get((idx, "ffn_input"))
+        ffn_norm_entry = lookup.get((idx, "ffn_norm"))
+        if ffn_input_entry is not None and ffn_norm_entry is not None:
+            ffn_input = _read_checkpoint(vram_path, ffn_input_entry, mlen)
+            ffn_norm_expected = _rms_norm_padded(ffn_input, hidden, eps)
+            ffn_norm = _append_stage_result(
+                stage_results,
+                lookup,
+                vram_path,
+                mlen,
+                idx,
+                "ffn_norm",
+                ffn_norm_expected,
+            )
+            if ffn_norm is not None:
+                up_out = _linear_hw(ffn_norm, W_up, mlen, max_k_tiles)
+                gate_out = _linear_hw(ffn_norm, W_gate, mlen, max_k_tiles)
+                silu_gate = _round_hw(F.silu(up_out) * gate_out)
+                ffn_out_expected = _linear_hw(silu_gate, W_down, mlen, max_k_tiles)
+                ffn_out = _append_stage_result(stage_results, lookup, vram_path, mlen, idx, "ffn_out", ffn_out_expected)
+                if ffn_out is not None:
+                    ffn_input = _pad_expected_to_actual(ffn_input, ffn_out)
+                    ffn_resid_expected = _round_hw(ffn_out + ffn_input)
+                    ffn_resid = _append_stage_result(
+                        stage_results,
+                        lookup,
+                        vram_path,
+                        mlen,
+                        idx,
+                        "ffn_residual",
+                        ffn_resid_expected,
+                    )
+                    if ffn_resid is not None and (idx, "final_norm") in lookup:
+                        final_expected = _rms_norm_padded(ffn_resid, hidden, eps)
+                        _append_stage_result(
+                            stage_results,
+                            lookup,
+                            vram_path,
+                            mlen,
+                            idx,
+                            "final_norm",
+                            final_expected,
+                        )
+
+    if not stage_results:
+        raise ValueError("Checkpoint metadata was present, but no comparable stages were found")
+
+    min_active = min(float(row["active_allclose"]) for row in stage_results)
+    results["min_active_allclose"] = min_active
+    results["passed"] = min_active >= 99.0
+
+    if verbose:
+        print("  Stage results:")
+        for row in stage_results:
+            print(
+                f"    {row['stage']:<16} {row['active_allclose']:6.1f}% active "
+                f"{row['full_allclose']:6.1f}% full  mse={row['active_mse']:.4e}"
+            )
+        print(f"  ==> {'PASS' if results['passed'] else 'DIVERGENCE'}: checkpointed stage chain")
+
+    return results
 
 
 def compare_stages(
@@ -82,134 +405,184 @@ def compare_stages(
     eps=1e-5,
     verbose=True,
     layer_idx=None,
+    padded_hidden=None,
+    padded_inter=None,
+    padded_seq_len=None,
 ):
-    """Compare each pipeline stage using emulator's own VRAM intermediates.
+    """Compare the final layer's FFN segment from emulator VRAM intermediates.
 
-    Args:
-        vram_path: path to the emulator's vram_dump.bin
-        build_dir: path to the build directory with weight .pt files
-        hidden, inter, num_heads, num_kv_heads: model dimensions
-        layer_idx: decoder layer to validate. Defaults to the last layer found
-                   in build_dir, which is the layer that feeds the final output.
-
-    Returns:
-        dict of stage results with allclose percentages
+    ``hidden``/``inter``/``seq_len`` are active dimensions. The optional
+    ``padded_*`` dimensions describe storage. If ``compile_info.json`` is
+    present, it overrides these arguments.
     """
+    del num_heads, num_kv_heads, head_dim
+
     build = Path(build_dir)
-    _to_inter = lambda x: x.to(torch.bfloat16)
-    _from_inter = lambda x: x.float()
+    params = _load_json(build / "comparison_params.json")
+    info = _load_json(build / "compile_info.json")
+    if not params:
+        raise FileNotFoundError(f"Missing comparison_params.json in {build}")
+
+    checkpoint_metadata = _load_stage_checkpoint_metadata(build)
+    if not info and checkpoint_metadata.get("compile_info"):
+        info = checkpoint_metadata["compile_info"]
+
+    hidden = int(info.get("hidden_size", hidden))
+    inter = int(info.get("inter_dim", inter))
+    seq_len = int(info.get("seq_len", seq_len))
+    mlen = int(info.get("mlen", mlen))
+    padded_hidden = int(info.get("padded_hidden_size", padded_hidden or hidden))
+    padded_inter = int(info.get("padded_inter_dim", padded_inter or inter))
+    padded_seq_len = int(info.get("padded_seq_len", padded_seq_len or params.get("physical_rows", seq_len)))
+
+    if checkpoint_metadata.get("checkpoints"):
+        return _compare_checkpointed_stages(
+            vram_path,
+            build,
+            info,
+            params,
+            checkpoint_metadata,
+            hidden=hidden,
+            inter=inter,
+            seq_len=seq_len,
+            mlen=mlen,
+            eps=eps,
+            verbose=verbose,
+            layer_idx=layer_idx,
+        )
 
     if layer_idx is None:
         layer_idx = _infer_final_layer_idx(build)
 
-    # Read final output address from comparison_params
-    import json
+    final_addr = int(params["start_row_idx"]) * mlen
+    results = {
+        "layer_idx": layer_idx,
+        "seq_len": seq_len,
+        "hidden": hidden,
+        "inter": inter,
+        "mlen": mlen,
+        "padded_seq_len": padded_seq_len,
+        "padded_hidden": padded_hidden,
+        "padded_inter": padded_inter,
+    }
 
-    params = json.load(open(build / "comparison_params.json"))
-    final_addr = params["start_row_idx"] * mlen
+    to_inter = lambda x: x.to(torch.bfloat16)
+    from_inter = lambda x: x.float()
 
-    results = {"layer_idx": layer_idx}
+    W_o = _load_weight(build, f"W_o_{layer_idx}.pt")
+    W_gate = _load_weight(build, f"W_gate_{layer_idx}.pt")
+    W_up = _load_weight(build, f"W_up_{layer_idx}.pt")
+    W_down = _load_weight(build, f"W_down_{layer_idx}.pt")
 
-    # --- Load weights ---
-    W_o = quantize_to_mxfp(torch.load(build / f"W_o_{layer_idx}.pt", weights_only=True))
-    W_gate = quantize_to_mxfp(torch.load(build / f"W_gate_{layer_idx}.pt", weights_only=True))
-    W_up = quantize_to_mxfp(torch.load(build / f"W_up_{layer_idx}.pt", weights_only=True))
-    W_down = quantize_to_mxfp(torch.load(build / f"W_down_{layer_idx}.pt", weights_only=True))
-
-    # --- Stage 1: O_full (attention output) ---
-    # Find O_full address from ISA comments
-    o_full_addr = final_addr - 2 * seq_len * hidden
     asm_path = build / "generated_asm_code.asm"
+    scratch_addr = None
+    o_full_addr = final_addr - 2 * padded_seq_len * padded_hidden
     if asm_path.exists():
-        with open(asm_path) as f:
-            asm = f.read()
+        asm = asm_path.read_text()
         parsed_o_full_addr = _read_alloc_addr(asm, f"O_full_{layer_idx}")
         if parsed_o_full_addr is not None:
             o_full_addr = parsed_o_full_addr
         scratch_addr = _read_alloc_addr(asm, "residual_scratch")
-    else:
-        scratch_addr = None
+
+    if scratch_addr is None:
+        raise ValueError("Could not find residual_scratch allocation in generated ASM")
 
     if verbose:
         print(f"  Validating layer {layer_idx}")
+        print(
+            f"  active shape=({seq_len}, {hidden}), "
+            f"storage shape=({padded_seq_len}, {padded_hidden}), mlen={mlen}"
+        )
 
-    O_full = _read_bf16_matrix(vram_path, o_full_addr, seq_len, hidden)
+    O_full = _read_bf16_matrix(vram_path, o_full_addr, padded_seq_len, padded_hidden, mlen=mlen)
+    O_proj_expected = _ksplit_matmul(O_full, W_o, mlen, _HW_MAX_K_TILES, to_inter, from_inter)
+    O_proj_expected = from_inter(to_inter(O_proj_expected))
 
-    # --- Stage 2: O_proj = O_full @ W_o ---
-    O_proj_expected = _ksplit_matmul(O_full, W_o, mlen, _HW_MAX_K_TILES, _to_inter, _from_inter)
-    O_proj_expected = _from_inter(_to_inter(O_proj_expected))
+    scratch_vram = _read_bf16_matrix(vram_path, scratch_addr, padded_seq_len, padded_hidden, mlen=mlen)
 
-    # --- Stage 3: O_proj + X_residual ---
-    # scratch = O_proj + X_residual (saved before FFN norm)
-    if scratch_addr is not None:
-        scratch_vram = _read_bf16_matrix(vram_path, scratch_addr, seq_len, hidden)
-        # X_residual = scratch - O_proj
-        X_residual = _from_inter(_to_inter(scratch_vram - O_proj_expected))
-        O_proj_resid = _from_inter(_to_inter(O_proj_expected + X_residual))
+    # The residual itself is not preserved after the FFN prologue. Recovering it
+    # from scratch makes this a sanity check for shape/address math, not a
+    # proof of O-projection correctness.
+    x_residual = from_inter(to_inter(scratch_vram - O_proj_expected))
+    o_proj_resid = from_inter(to_inter(O_proj_expected + x_residual))
+    resid_result = _compare_region(o_proj_resid, scratch_vram, seq_len, hidden)
+    results["O_proj+resid"] = resid_result["active_allclose"]
+    results["O_proj+resid_full"] = resid_result["full_allclose"]
+    results["O_proj+resid_mse"] = resid_result["active_mse"]
 
-        allclose_resid = _allclose_pct(O_proj_resid, scratch_vram, atol=0.01, rtol=0.01)
-        results["O_proj+resid"] = allclose_resid
-        if verbose:
-            print(f"  O_proj+resid:  {allclose_resid:.1f}% (atol=0.01)")
+    X_pre_ffn = scratch_vram.clone()
+    X_normed = _rms_norm_padded(X_pre_ffn, hidden, eps)
 
-    # --- Stage 4: RMS norm → FFN → residual → final norm ---
-    # Use emulator's scratch (O_proj+resid) as input
-    if scratch_addr is not None:
-        X_pre_ffn = scratch_vram.clone()
+    up_out = to_inter(_ksplit_matmul(X_normed, W_up, mlen, _HW_MAX_K_TILES, to_inter, from_inter))
+    gate_out = to_inter(_ksplit_matmul(X_normed, W_gate, mlen, _HW_MAX_K_TILES, to_inter, from_inter))
+    silu_gate = to_inter(F.silu(from_inter(up_out)) * from_inter(gate_out))
+    ffn_out = _ksplit_matmul(from_inter(silu_gate), W_down, mlen, _HW_MAX_K_TILES, to_inter, from_inter)
+    ffn_out = from_inter(to_inter(ffn_out))
 
-        # RMS norm
-        X_bf = _to_inter(X_pre_ffn)
-        rms = torch.rsqrt(_from_inter(X_bf).pow(2).mean(-1, keepdim=True) + eps)
-        X_normed = _from_inter(_to_inter(_from_inter(X_bf) * rms))
+    post_ffn = from_inter(to_inter(ffn_out + X_pre_ffn))
+    expected_final = _rms_norm_padded(post_ffn, hidden, eps)
 
-        # FFN
-        up_out = _to_inter(torch.matmul(_from_inter(_to_inter(X_normed)), W_up.float()))
-        gate_out = _to_inter(torch.matmul(_from_inter(_to_inter(X_normed)), W_gate.float()))
-        silu_gate = _to_inter(F.silu(_from_inter(up_out)) * _from_inter(gate_out))
-        ffn_out = _from_inter(_to_inter(torch.matmul(_from_inter(silu_gate), W_down.float())))
+    final_vram = _read_bf16_matrix(vram_path, final_addr, padded_seq_len, padded_hidden, mlen=mlen)
+    final_result = _compare_region(expected_final, final_vram, seq_len, hidden)
+    results["norm+FFN+norm"] = final_result["active_allclose"]
+    results["norm+FFN+norm_full"] = final_result["full_allclose"]
+    results["final_mse"] = final_result["active_mse"]
+    results["final_mse_full"] = final_result["full_mse"]
 
-        # FFN residual
-        post_ffn = _from_inter(_to_inter(ffn_out + X_pre_ffn))
-
-        # Final norm
-        X_bf2 = _to_inter(post_ffn)
-        rms2 = torch.rsqrt(_from_inter(X_bf2).pow(2).mean(-1, keepdim=True) + eps)
-        expected_final = _from_inter(_to_inter(_from_inter(X_bf2) * rms2))
-
-        # Compare with VRAM final output
-        final_vram = _read_bf16_matrix(vram_path, final_addr, seq_len, hidden)
-
-        allclose_final = _allclose_pct(expected_final, final_vram)
-        mse_final = _mse(expected_final, final_vram)
-        results["norm+FFN+norm"] = allclose_final
-        results["final_mse"] = mse_final
-
-        if verbose:
-            print(f"  norm+FFN+norm: {allclose_final:.1f}% allclose (atol=0.2)")
-            print(f"                 MSE={mse_final:.4e}")
-            if allclose_final >= 99.0:
-                print("  ==> PASS: emulator's FFN chain matches golden from its own intermediate")
-            else:
-                print("  ==> DIVERGENCE in FFN chain")
+    if verbose:
+        print(
+            f"  O_proj+resid:  {resid_result['active_allclose']:.1f}% active "
+            f"({resid_result['full_allclose']:.1f}% full; residual reconstructed)"
+        )
+        print(f"  norm+FFN+norm: {final_result['active_allclose']:.1f}% active allclose (atol=0.2)")
+        print(f"                 {final_result['full_allclose']:.1f}% full allclose")
+        print(
+            f"                 active MSE={final_result['active_mse']:.4e}, "
+            f"full MSE={final_result['full_mse']:.4e}"
+        )
+        if final_result["active_allclose"] >= 99.0:
+            print("  ==> PASS: emulator's FFN chain matches golden from its own intermediate")
+        else:
+            print("  ==> DIVERGENCE in FFN chain")
 
     return results
 
 
-if __name__ == "__main__":
-    import sys
-
-    vram = sys.argv[1] if len(sys.argv) > 1 else "transactional_emulator/vram_dump.bin"
-    build = sys.argv[2] if len(sys.argv) > 2 else "/tmp/smolvlm2_1layer_f32regs"
-    layer_idx = int(sys.argv[3]) if len(sys.argv) > 3 else None
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("vram", nargs="?", default="transactional_emulator/vram_dump.bin")
+    parser.add_argument("build", nargs="?", default="/tmp/smolvlm2_1layer_f32regs")
+    parser.add_argument("layer_idx", nargs="?", type=int, default=None)
+    parser.add_argument("--hidden", type=int, default=576)
+    parser.add_argument("--inter", type=int, default=1536)
+    parser.add_argument("--num-heads", type=int, default=9)
+    parser.add_argument("--num-kv-heads", type=int, default=3)
+    parser.add_argument("--seq-len", type=int, default=64)
+    parser.add_argument("--mlen", type=int, default=64)
+    parser.add_argument("--head-dim", type=int, default=64)
+    parser.add_argument("--eps", type=float, default=1e-5)
+    args = parser.parse_args()
 
     print("=== VRAM Stage Comparison ===")
     results = compare_stages(
-        vram_path=vram,
-        build_dir=build,
-        hidden=576,
-        inter=1536,
-        num_heads=9,
-        num_kv_heads=3,
-        layer_idx=layer_idx,
+        vram_path=args.vram,
+        build_dir=args.build,
+        hidden=args.hidden,
+        inter=args.inter,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        seq_len=args.seq_len,
+        mlen=args.mlen,
+        head_dim=args.head_dim,
+        eps=args.eps,
+        layer_idx=args.layer_idx,
     )
-    print(f"\nOverall: {'PASS' if results.get('norm+FFN+norm', 0) >= 99.0 else 'FAIL'}")
+    report_path = Path(args.build) / "vram_stage_compare.json"
+    report_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n")
+    print(f"\nReport: {report_path}")
+    passed = bool(results.get("passed", results.get("norm+FFN+norm", 0) >= 99.0))
+    print(f"\nOverall: {'PASS' if passed else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/operation.svh
+++ b/doc/operation.svh
@@ -171,10 +171,7 @@ typedef enum logic [instruction_pkg::OPCODE_WIDTH - 1:0] {
 
     // Extensions
     V_SHIFT_V              = 6'h31,
-    C_BREAK                = 6'h32,
-    V_PS_V                 = 6'h33,
-    V_SHFT_V               = 6'h34,
-    C_HADAMARD_TRANSFORM   = 6'h35
+    C_BREAK                = 6'h32
 } CUSTOM_ISA_OPCODE;
 
 

--- a/doc/operation.svh
+++ b/doc/operation.svh
@@ -170,10 +170,11 @@ typedef enum logic [instruction_pkg::OPCODE_WIDTH - 1:0] {
     C_LOOP_END             = 6'h30,
 
     // Extensions
-    V_PS_V                 = 6'h31,
-    V_SHFT_V               = 6'h32,
-    C_HADAMARD_TRANSFORM   = 6'h33,
-    C_BREAK                = 6'h34
+    V_SHIFT_V              = 6'h31,
+    C_BREAK                = 6'h32,
+    V_PS_V                 = 6'h33,
+    V_SHFT_V               = 6'h34,
+    C_HADAMARD_TRANSFORM   = 6'h35
 } CUSTOM_ISA_OPCODE;
 
 

--- a/utils/load_config.py
+++ b/utils/load_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

This branch adds native model compilation support for SmolVLM2 and LLaDA, multi-batch attention codegen, support for varying hardware configurations (mlen/vlen/blen), and HBM tile alignment infrastructure.

### Multi-batch attention + configurable hardware dimensions
- `flash_attention` MHA and GQA paths accept `batch_size > 1` — splits Q/K/V into independent batches with correct VRAM stride and physical row validation
- Tested at mlen=64/128/256 with vlen=64/128/256 and blen=4/16/64 across all model architectures
- `compile_native_hf_decoder` accepts `batch_size`, `mlen`, `blen`, `hlen`, `broadcast_amount`, `mram_tile_capacity` as explicit parameters — no longer tied to global TOML defaults

### Native SmolVLM2 support
- Vision encoder compilation via `compile_native_hf_vision_encoder` — patch embedding (im2col), SigLIP transformer layers (LayerNorm, MHA, GELU MLP), post-LN, vision-to-text connector
- Vision model extraction helpers in `model_extract.py` — `VisionConfig`, `VisionLayerWeights`, `VisionPatchWeights`, `VisionConnectorWeights`, bias extraction
- End-to-end VLM pipeline: vision encoder → connector → text decoder at native dimensions

### Rolled attention + looped KV-group codegen
- Looped KV-group attention via `flash_attention_packed_groups_looped` — reduces ISA size by emitting hardware loops instead of unrolling per KV group
- `V_SHIFT_V` instruction support for element-wise vector shifting in online softmax

### HBM tile alignment + address export
- `_allocate_hbm` pads to `mlen*mlen` at mlen>=256 for Rust emulator's `continous_write_delayed` alignment requirement
- Free-block recycling respects tile alignment to prevent reuse of misaligned regions
- Both `compile_native_hf_decoder` and `compile_native_hf_vision_encoder` export `hbm_addrs` dict so test harnesses can pad HBM binaries to match ISA-expected offsets

### LLaDA bidirectional attention
- Skip causal mask generation for masked diffusion models (`model_type == "llada"`) — bidirectional attention uses the full sequence without causal masking

### Parameterize MRAM tile capacity
- `mram_tile_capacity` parameter exposed through `PlenaCompiler` and `compile_native_hf_decoder` — allows runtime tuning of how many tiles fit in MRAM for K-split accumulation

### FFN overflow fix (Gregor)
- Resolve immediate overflow in `asm_templates/ffn_asm.py` for large hidden dims — `_load_large_int` used consistently for `hidden_size * intermediate_size` immediates

### Cleanup
- Remove unused opcodes (V_PS_V, V_SHFT_V, C_HADAMARD_TRANSFORM) from `operation.svh` — only V_SHIFT_V (0x31) and C_BREAK (0x32) remain, matching Rust emulator

## Tested

Across 5 decoder models (SmolLM2-135M, SmolVLM2-256M-text, CLM-60M, LLaDA-8B-Instruct, LLaDA-8B-Base):

- Sliced decoder at mlen=64, blen=16, batch=1,2, layers 1/5/10: 100% allclose (CLM/LLaDA), 100% at 1L for all models
- Sliced decoder at mlen=256, blen=64 with Q/O projection + GQA (hq=3): 100% (CLM/LLaDA)
- Native SmolVLM2 vision encoder 12L at mlen=256: 100% allclose
- Native SmolVLM2 vlm-e2e 12v+1t at mlen=256: 99.75% allclose
- Native SmolVLM2 text decoder 1L/5L/10L/30L at mlen=256: 99.05%/96.74%/94.43%/93.79%
- LLaDA-8B at mlen=128: 100% allclose