### PR TITLE
Fix FFN down-projection HBM prefetch advance for multi-K-tile

### DIFF
--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from ._imm import addi_large_int_str as _addi_large_int
 from ._imm import load_large_int_str as _load_large_int
 from ._k_split import k_chunks as _k_chunks
@@ -381,7 +383,7 @@ def _emit_ffn_projection_unrolled(
     chunks = _k_chunks(num_k_tiles, max_k_tiles)
     # Total output region size (elements) for the VRAM accumulator pass.
     output_elements = out_size * batch * seq_len
-    per_vlen_adds = output_elements // vlen
+    per_vlen_adds = math.ceil(output_elements / vlen)
 
     for chunk_idx, (k_start, k_count) in enumerate(chunks):
         lines.append(
@@ -1328,7 +1330,12 @@ def _ffn_asm_with_loops(
         generated_code += (
             f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
         )
-        generated_code += _load_large_int(a_actual_register, mlen * hidden_size)
+        generated_code += _addi_large_int(
+            a_actual_register,
+            a_actual_register,
+            mlen * hidden_size,
+            w_temp_register,
+        )
 
     # Reset for compute phase
     generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
@@ -1689,7 +1696,12 @@ def _ffn_asm_fused_up_gate(
             generated_code += f"; Prefetch DOWN weight tile {prefetch_idx}\n"
             generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-            generated_code += _load_large_int(a_actual_register, mlen * hidden_size)
+            generated_code += _addi_large_int(
+                a_actual_register,
+                a_actual_register,
+                mlen * hidden_size,
+                w_temp_register,
+            )
 
     # Downsize linear (first block already prefetched)
     generated_code += (
@@ -1767,7 +1779,12 @@ def _ffn_asm_fused_up_gate(
         for weight_col in range(num_down_weight_tiles):
             generated_code += f"H_PREFETCH_M gp{w_actual_register}, gp{a_actual_register}, a{down_weight_hbm_offset_reg}, 1, 0\n"
             generated_code += f"S_ADDI_INT gp{w_actual_register}, gp{w_actual_register}, {mlen * mlen}\n"
-            generated_code += _load_large_int(a_actual_register, mlen * hidden_size)
+            generated_code += _addi_large_int(
+                a_actual_register,
+                a_actual_register,
+                mlen * hidden_size,
+                w_temp_register,
+            )
 
         generated_code += f"S_ADDI_INT gp{w_actual_register}, gp0, 0\n"
         generated_code += (


### PR DESCRIPTION
## Summary

The down-projection weight prefetch in `_ffn_asm_with_loops` and `_ffn_asm_fused_up_gate` used `_load_large_int(a_actual, mlen*hidden_size)` to advance the HBM offset register between K-tile prefetches. This overwrote the register instead of adding to it, causing several silent miscomputations:

- At `K_tiles >= 3` the prefetch for K-tiles 2..N-1 all read from `HBM[base + mlen*hidden_size]` instead of advancing by that stride each iteration.
- At `K_tiles == 2` combined with multi-outer-iter (`out_size > mlen`), K-tile 1 of outer iters > 0 read from the wrong absolute address because the per-outer-iter base offset got dropped.

The up-projection in the same function already used `_addi_large_int` correctly; the down path now matches at all three call sites.

Also: `_emit_ffn_projection_unrolled`'s K-split V_ADD_VV accumulator loop count is now `math.ceil(output_elements / vlen)` instead of integer division so the tail vector when `output_elements` is not a multiple of `vlen` is no longer dropped.

## Test plan

Verified with the ATen FFN testbench in PLENA_Simulator (PR AICrossSim/PLENA_Simulator#60). Matrix spans single-tile, multi-K-tile, multi-outer-iter, and BLEN 4–64:

| mlen | blen | hidden | inter | up K×out | down K×out | Before | After |
|------|------|--------|-------|----------|------------|--------|-------|
| 64  | 8  | 128 | 256  | 2×4 | 4×2 | FAIL | PASS |
| 64  | 16 | 128 | 256  | 2×4 | 4×2 | FAIL | PASS |
| 64  | 32 | 128 | 256  | 2×4 | 4×2 | FAIL | PASS |
| 64  | 64 | 192 | 384  | 3×6 | 6×3 | FAIL | PASS |
| 64  | 4  | 192 | 64   | 3×1 | 1×3 | PASS | PASS |
| 64  | 4  | 64  | 192  | 1×3 | 3×1 | FAIL | PASS |
| 64  | 4  | 256 | 256  | 4×4 | 4×4 | FAIL | PASS |
| 64  | 4  | 64  | 128  | 1×2 | 2×1 | PASS | PASS |
| 128 | 8  | 128 | 256  | 1×2 | 2×1 | PASS | PASS |
| 128 | 32 | 256 | 256  | 2×2 | 2×2 | FAIL | PASS |
| 128 | 64 | 256 | 512  | 2×4 | 4×2 | FAIL | PASS |
| 128 | 16 | 384 | 384  | 3×3 | 3×3 | FAIL | PASS |
| 128 | 16 | 128 | 512  | 1×4 | 4×1 | FAIL | PASS |
| 128 | 16 | 512 | 128  | 4×1 | 1×4 | FAIL | PASS |
| 256 | 64 | 256 | 512  | 1×2 | 2×1 | FAIL | PASS¹ |
| 256 | 64 | 512 | 512  | 2×2 | 2×2 | FAIL | PASS¹ |

¹ MLEN=256 additionally required the HBM tile-align fix on the simulator side (PR AICrossSim/PLENA_Simulator#60); with both, FFN passes at MLEN=256.

- [x] Up-projection codegen path unchanged (was already correct)
- [x] FFN multi-K-tile multi-outer-iter passes at MLEN=64 and MLEN=128
- [x] FFN passes at MLEN=256 (with the companion simulator HBM tile-align fix)
- [x] Full ATen sweep (linear, rms_norm, layer_norm, softmax, embedding_add, rope, flash_attn_gqa, flash_attn_mha, ffn) passes at MLEN=64 and MLEN=128