### PR TITLE
fix(ffn): guard non-positive activation-row loop count

### DIFF
--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -393,6 +393,12 @@ class ProgramTensorMixin:
         _, inter_dim = w_up.physical_shape
         mlen = self.mlen
         blen = self.blen
+        # rows//blen drives the inner activation-column loop; a non-multiple
+        # (esp. rows < blen) emits C_LOOP_START 0 and the emulator panics.
+        if batch_size <= 0 or batch_size % blen != 0:
+            raise ValueError(
+                f"FFN activation rows ({batch_size}) must be a positive multiple of BLEN ({blen})."
+            )
         activation_base_address = self.get_vram_addr(input_var.name)
         max_k_tiles = max(hidden_size // mlen, inter_dim // mlen)
         use_loop_instructions = max_k_tiles <= self.mram_tile_capacity


### PR DESCRIPTION
## Summary

Defensive compile-time guard in the FFN op. `ops.ffn` with activation `rows` that aren't a positive multiple of `BLEN` emitted `C_LOOP_START gp, 0` (inner activation-column loop count `rows // blen = 0`), which tripped the Rust emulator assert `imm > 0` (`main.rs`) → panic, exit 101.

This raises a clear `ValueError` at compile time instead of the opaque deep-Rust panic, for any caller.

## Companion

Paired with the PLENA_Simulator PR that pads the sliced-FFN activation rows up to a `BLEN` multiple — the actual fix for the reported SmolLM2 128×256 (sliced) FFN crash at the 64/64/16 preset with `batch_size=4`.

## Test

- `ops.ffn` invoked with `rows=4` (not a `BLEN` multiple) → clean `ValueError` at compile time (was a Rust panic / exit 101).
