### PR TITLE
fix(im2col): enable the V_SHIFT_V im2col path for non-64-aligned columns (native-dim vision)

### DIFF
--- a/asm_templates/im2col_asm.py
+++ b/asm_templates/im2col_asm.py
@@ -125,13 +125,12 @@ def im2col_asm(
     if W_padded is None:
         W_padded = W
 
-    # Validate HBM alignment: every pixel column offset must be 64-aligned.
-    for ow in range(OW):
-        pixel_col = ow * stride
-        assert pixel_col % 64 == 0, (
-            f"im2col_asm: ow={ow}, pixel_col={pixel_col} is not 64-aligned. "
-            f"Use im2col_asm_no_shift for stride={stride} with non-64-aligned columns."
-        )
+    # HBM alignment: each H_PREFETCH_V load starts at the exact pixel_col, so the K
+    # patch elements land at [0:K] of the loaded vector and the mask+right-shift below
+    # places them. The emulator's HBM gather walks the byte range one 64-byte block at a
+    # time, clamping each read to a block boundary (dma::transfer_mx_from_hbm), so a
+    # non-64-aligned pixel_col (e.g. stride-16 patch embedding) is loaded correctly
+    # without any realignment. (The old 64-aligned-only assertion predated that gather.)
 
     # Compute save f_regs for precious fp_sram slots (mirrors im2col_asm_no_shift).
     # Mask construction zeroes fp_sram[0..VLEN-1] then writes mask values, corrupting


### PR DESCRIPTION
The `V_SHIFT_V` im2col path (`asm_templates/im2col_asm.py`, opt-in via `CONV_USE_SHIFT=1`) already loads each patch at its exact `pixel_col`, so the K patch elements land at `[0:K]` of the loaded vector and are placed with a mask + right-shift. The only thing blocking it for SmolVLM2/SigLIP patch embedding (stride=16 → non-64-aligned pixel columns) was a stale compiler-side assertion requiring every `ow*stride` to be 64-aligned. That assertion predated the emulator's byte-block HBM gather (`dma::transfer_mx_from_hbm`, #62), which now walks each load one 64-byte block at a time and clamps each read to a block boundary — so a non-64-aligned `H_PREFETCH_V` start is loaded correctly with no realignment needed. Removing the assertion is the entire fix; there is no emulator change.

Verified on SmolVLM2 vision (1 layer, both im2col modes) across all native dims — `allclose` 100% PASS in every cell, and the shift path is both smaller and lower modeled latency:

| config | mode | ISA lines | sim_lat | allclose |
|--------|------|----------:|--------:|:--------:|
| 16/16/4 | no-shift (default) | 2,369,505 | 54.855ms | PASS |
| 16/16/4 | shift | 2,092,822 (−12%) | 54.138ms (−1.3%) | PASS |
| 32/32/4 | no-shift | 599,202 | 39.826ms | PASS |
| 32/32/4 | shift | 335,688 (−44%) | 39.120ms (−1.8%) | PASS |
| 64/64/16 | no-shift | 321,664 | 3.812ms | PASS |
| 64/64/16 | shift | 84,047 (−74%) | 3.165ms (−17%) | PASS |
| 256/256/64 | no-shift | 317,805 | 5.649ms | PASS |
| 256/256/64 | shift | 79,804 (−75%) | 4.996ms (−12%) | PASS |

The reduction is largest where the patch-embed im2col is a big share of the program (64/256: −74/−75% lines, −12/−17% sim_lat) and smaller at mlen=16 (−12% lines) where attention/projection dominate the 2.4M-line program — but it is a win on both axes everywhere. Still opt-in: the default stays `im2col_asm_no_shift`; `CONV_USE_SHIFT=1` selects the shift path. This branch is rebased on `main` (post #56), so the mlen=16 row compiles via the O(n²) ISA-emit fix.
