### PR TITLE
fix(projection_asm): correct single-pass matmul emission

### DIFF
--- a/asm_templates/projection_asm.py
+++ b/asm_templates/projection_asm.py
@@ -198,7 +198,9 @@ def projection_asm(
                     )
                 lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 ")
             else:
-                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} ")
+                # weight rows are 1 output-feature each in matrix SRAM (row-granular), so the
+                # within-group offset must be in rows: (wr % (mlen//blen)) * blen * mlen.
+                lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen * mlen} ")
                 lines.append(
                     f"S_ADDI_INT gp{intermediate_register}, gp{result_reg}, {(weight_row % (mlen // blen)) * blen} "
                 )
@@ -210,13 +212,10 @@ def projection_asm(
                     lines.append(f"M_MM 0, gp{w_temp_register}, gp{act_reg} ")
                     lines.append(f"S_ADDI_INT gp{w_temp_register}, gp{w_temp_register}, {mlen * mlen} ")
                     lines.append(f"S_ADDI_INT gp{act_reg}, gp{act_reg}, {mlen * batch} ")
-                    break
                 lines.append(f"M_MM_WO gp{intermediate_register}, gp0, 0 ")
                 lines.append(f"S_ADDI_INT gp{intermediate_register}, gp{intermediate_register}, {blen * mlen} ")
-                break
             if (weight_row + 1) % (mlen // blen) == 0 and weight_row != out_features // blen - 1:
                 lines.append(f"S_ADDI_INT gp{result_reg}, gp{result_reg}, {mlen * batch} ")
-            break
     else:
         # K-split path
         chunks = _proj_k_chunks(num_k_tiles, MAX_K_TILES)


### PR DESCRIPTION
Two correctness fixes in the single-pass (`num_k_tiles <= MAX_K_TILES`) projection path. Required by PLENA_RTL `kev/linear` (PR AICrossSim/PLENA_RTL#44) to bring the `linear` workload to a passing state.

- **Remove three stray `break`s** that truncated the K-loop to a single tile, so the matmul only computed 1 of N K-tiles.
- **Row-align the within-group weight-row offset**: matrix SRAM is row-granular (one output feature per row), so the offset must be in rows — `(wr % (mlen//blen)) * blen * mlen`, not `* blen` (element units, which got dropped by the SRAM's row-granular address translation and made the BLEN output features of a group alias to the same weights).

## Testing
Verified end-to-end via PLENA_RTL `just rtl-sim linear` → PASSED (95.31%).