### PR TITLE
feat(attention): ATen-compiler GQA support (M_BTMM tiling, inline-normalize softmax, P@V fixes)

### DIFF
--- a/asm_templates/ffn_asm.py
+++ b/asm_templates/ffn_asm.py
@@ -556,8 +556,15 @@ def _emit_ffn_projection_chunk(
                 )
             lines.append(f"S_ADDI_INT gp{w_actual_register}, gp0, 0 \n")
         else:
+            # Sub-column tile within an MLEN block. The WEIGHT-read pointer must
+            # advance by blen*mlen (row-aligned) so each sub-column reads a DISTINCT
+            # MRAM row: the RTL matrix SRAM read is row-granular (raddr >> log2(MLEN)
+            # drops the low log2(MLEN) bits), so a plain +blen would collapse tiles
+            # 1..(mlen/blen-1) onto tile 0's row. The OUTPUT-write pointer stays at
+            # +blen (the low bits select the 4-wide column lane of the VLEN row).
+            # This matches the working projection_asm (_emit_projection_chunk).
             lines.append(
-                f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen} \n"
+                f"S_ADDI_INT gp{w_actual_register}, gp0, {(weight_row % (mlen // blen)) * blen * mlen} \n"
             )
             lines.append(
                 f"S_ADDI_INT gp{intermediate_register}, gp{result_base_register}, {(weight_row % (mlen // blen)) * blen} \n"

--- a/aten/ops/plena/softmax_ops.py
+++ b/aten/ops/plena/softmax_ops.py
@@ -1,47 +1,60 @@
 """
 PLENA backend implementation for softmax operator.
 
-This encapsulates the online softmax algorithm that was previously
-written inline in fpvar_softmax_test.py (Tilelang-style).
-
 ATen-style: the function receives a PlenaCompiler context and TensorVar
 arguments, orchestrates PlenaCompiler calls, and returns the result TensorVar.
 """
 
 from __future__ import annotations
 
+from compiler.aten.isa_builder import IsaBuilder, fp, gp
+
 
 def softmax_plena(prog, input_var, scale: float = 1.0):
     """
-    PLENA backend: online softmax (numerically stable, row-wise).
+    PLENA backend: single-pass, per-row, register-direct row-wise softmax.
 
-    Algorithm (matches fpvar_softmax_test.py):
-        Initialize: m_old[row] = -inf, l_old[row] = 0
-        for row in range(mlen):
-            m_old_saved = m_old[row]
-            S[row] *= scale
-            row_max = max(S[row])
-            m_old[row] = max(m_old[row], row_max)  # m_curr
-            m_res[row] = exp(m_old_saved - m_curr)
-            S[row] -= m_curr
-            P[row] = exp(S[row])
-            sum_p = sum(P[row])
-            l_old[row] = l_old[row] * m_res[row] + sum_p
-        P[row] /= l_old[row]  # final normalization
+    The input is one (mlen, mlen) block whose rows each fit in a single vector
+    tile (mlen == VLEN), so the whole softmax can be computed in one pass over
+    the row without the streaming running-max / running-sum machinery that the
+    flash-attention path (``_online_softmax_asm``) needs for multi-tile
+    sequences.
+
+    This mirrors the hand-written softmax_asm template EXACTLY: it emits, per
+    row, the 6-op sequence with the reduction results (max, sum) held in FP
+    REGISTERS and fed DIRECTLY to their immediate vector consumers -- no
+    ``S_ST_FP`` / ``S_LD_FP`` round-trip through FP SRAM:
+
+        V_RED_MAX f2, row, 0          ; row max -> FP register f2
+        V_SUB_VF  row, row, f2, 0, 0  ; x - max   (f2 used directly)
+        V_EXP_V   row, row, 0         ; exp(x - max)
+        S_ADD_FP  f3, f0, f0          ; clear sum accumulator
+        V_RED_SUM f3, row             ; row sum -> FP register f3
+        S_RECI_FP f3, f3, 0           ; 1 / sum   (in register)
+        V_MUL_VF  row, row, f3, 0     ; normalize (f3 used directly)
+
+    Batching the reductions and round-tripping max/sum through FP SRAM (the
+    ``tile_row_max`` / ``tile_row_sum`` helpers) trips a reduction-result
+    capture hazard on back-to-back reductions (the stored sum comes out ~half
+    on alternate rows -> result ~2x golden). Keeping the reduction result in a
+    register and consuming it immediately avoids that hazard entirely.
+
+    No scalar running-max (no ``S_MAX_FP``, which is a silent no-op in RTL) and
+    no correction-factor bookkeeping.
 
     Args:
         prog:      PlenaCompiler instance (compilation context)
         input_var: BatchVar or VRAMMatrixVar — the input matrix in VRAM
                    Shape: (mlen, mlen)
-        scale:     Multiplicative scale applied before softmax (default 1.0)
+        scale:     Multiplicative scale applied before softmax (default 1.0).
+                   When != 1.0 it is read from FP SRAM slot 1.
 
     Returns:
-        The same input_var (in-place modification) after softmax is applied.
-        The result is stored in S (VRAM), which is also returned.
+        The output VRAM matrix ``S`` (the softmax result is written in place
+        into S, tile (0, 0), across all mlen rows).
 
     Note:
-        fp_preload layout expected: [0]=0.0, [1]=scale, [2]=-inf
-        The caller must set fp_preload = [0.0, scale, float('-inf'), ...]
+        fp_preload layout expected: [0]=0.0, [1]=scale.
     """
     mlen = prog.mlen
 
@@ -52,23 +65,37 @@ def softmax_plena(prog, input_var, scale: float = 1.0):
     # simulator, matching the previous implementation's S += input behavior.
     prog.vram_add(S, input_var)
 
-    # Reuse the flash-attention online-softmax state layout instead of
-    # allocating separate FPVars for m_old/m_res/l_old/inv_l.  At MLEN=256 the
-    # old FPVar-heavy lowering needed 1028 slots plus reserved constants and
-    # overflowed the 1024-slot FPRAM.  The shared layout uses exactly 3*MLEN
-    # slots at _ONLINE_SOFTMAX_FPSRAM_BASE and scalar FP registers for temps.
-    fp_sram_start = prog._ONLINE_SOFTMAX_FPSRAM_BASE
-    prog.emit(prog._reset_fpsram_asm(fp_sram_start, mlen, 2))  # m_old = -inf
-    prog.emit(prog._reset_fpsram_asm(fp_sram_start + 2 * mlen, mlen, 0))  # l_old = 0
-    prog.emit(
-        prog._online_softmax_asm(
-            mlen=mlen,
-            s_address=prog.get_vram_addr(S.name),
-            m_start_address=fp_sram_start,
-            scale=scale,
-            rows=mlen,
-        )
-    )
-    prog.final_scale_o(0, S, rows=mlen)
+    s_addr = prog.get_vram_addr(S.name)
+
+    # f2 = row max, f3 = row sum; each reduction result stays in its register and
+    # feeds the next vector op directly (no S_ST_FP/S_LD_FP round-trip).
+    fp_max = 2
+    fp_sum = 3
+
+    (gp_row,) = prog._reg.allocate_gp(1)
+    try:
+        asm = IsaBuilder().comment("=== Single-pass per-row softmax on S (register-direct) ===")
+        for row in range(mlen):
+            row_addr = s_addr + row * mlen
+            asm.comment(f"row {row}: softmax over VRAM[{row_addr}:{row_addr + mlen}]")
+            asm.instr("S_ADDI_INT", gp(gp_row), gp(0), row_addr)
+
+            # Optional pre-scale: row *= scale (FP SRAM slot 1 holds scale).
+            if scale != 1.0:
+                asm.instr("S_LD_FP", fp(fp_max), gp(0), 1)
+                asm.instr("V_MUL_VF", gp(gp_row), gp(gp_row), fp(fp_max), 0)
+
+            # max -> sub -> exp -> (clear acc) sum -> reci -> mul, register-direct
+            asm.instr("V_RED_MAX", fp(fp_max), gp(gp_row), 0)
+            asm.instr("V_SUB_VF", gp(gp_row), gp(gp_row), fp(fp_max), 0, 0)
+            asm.instr("V_EXP_V", gp(gp_row), gp(gp_row), 0)
+            asm.instr("S_ADD_FP", fp(fp_sum), fp(0), fp(0))
+            asm.instr("V_RED_SUM", fp(fp_sum), gp(gp_row))
+            asm.instr("S_RECI_FP", fp(fp_sum), fp(fp_sum), 0)
+            asm.instr("V_MUL_VF", gp(gp_row), gp(gp_row), fp(fp_sum), 0)
+
+        prog.emit(asm)
+    finally:
+        prog._reg.free_gp([gp_row])
 
     return S

--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -20,6 +20,7 @@ class IsaAttentionMixin:
         scale: float = 1.0,
         rows: int | None = None,
         valid_cols: int | None = None,
+        inline_normalize: bool = False,
     ) -> str:
         """
         Online Softmax Computation.
@@ -43,6 +44,7 @@ class IsaAttentionMixin:
                 m_start_address=m_start_address,
                 scale=scale,
                 valid_cols=valid_cols,
+                inline_normalize=inline_normalize,
             )
 
         gp_regs = self.register_allocator.allocate_gp(5)
@@ -136,6 +138,7 @@ class IsaAttentionMixin:
         m_start_address: int,
         scale: float = 1.0,
         valid_cols: int | None = None,
+        inline_normalize: bool = False,
     ) -> str:
         """Legacy Python-unrolled online softmax emission, kept for A/B comparisons."""
         gp_regs = self.register_allocator.allocate_gp(5)
@@ -194,15 +197,27 @@ class IsaAttentionMixin:
             lines.append(f"V_SUB_VF gp{gp_s}, gp{gp_s}, f{fp_m_old}, {mask_en}, 0")
             lines.append(f"V_EXP_V gp{gp_s}, gp{gp_s}, {mask_en}, 0")
 
-            lines.append(f"S_LD_FP f{fp_l_old}, gp{gp_l_addr}, {row}")
+            if inline_normalize:
+                # Single-block fast path: normalise P register-direct (no FP-SRAM l
+                # round-trip, whose per-row store is racy in the unrolled kernel and
+                # PC-pins when looped). softmax(S)=exp(S-m)/sum(exp(S-m)); for one KV
+                # block this also gives correct attention O since (P/l)@V == (P@V)/l.
+                lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
+                lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
+                lines.append(f"S_RECI_FP f{fp_sum_p}, f{fp_sum_p}, 0")
+                for _ in range(4):  # retire multi-cycle S_RECI_FP before V_MUL_VF reads it
+                    lines.append("S_ADDI_INT gp0, gp0, 0")
+                lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_sum_p}, {mask_en}")
+            else:
+                lines.append(f"S_LD_FP f{fp_l_old}, gp{gp_l_addr}, {row}")
 
-            lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
-            lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
+                lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
+                lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
 
-            lines.append(f"S_MUL_FP f{fp_l_old}, f{fp_l_old}, f{fp_m_res}")
-            lines.append(f"S_ADD_FP f{fp_l_old}, f{fp_l_old}, f{fp_sum_p}")
+                lines.append(f"S_MUL_FP f{fp_l_old}, f{fp_l_old}, f{fp_m_res}")
+                lines.append(f"S_ADD_FP f{fp_l_old}, f{fp_l_old}, f{fp_sum_p}")
 
-            lines.append(f"S_ST_FP f{fp_l_old}, gp{gp_l_addr}, {row}")
+                lines.append(f"S_ST_FP f{fp_l_old}, gp{gp_l_addr}, {row}")
 
             lines.append(f"S_ADDI_INT gp{gp_s}, gp{gp_s}, {mlen}")
 
@@ -738,6 +753,7 @@ class IsaAttentionMixin:
         scale: float,
         rows: int | None = None,
         valid_cols: int | None = None,
+        inline_normalize: bool = False,
     ) -> str:
         """
         Run Online Softmax on one S block.
@@ -745,6 +761,8 @@ class IsaAttentionMixin:
           Output:  P (mlen × mlen) in-place in VRAM
           Updates: m_old, m_res, l in FP SRAM
           ``scale`` is the QK^T scaling factor (typically 1/sqrt(d)).
+          ``inline_normalize`` (single-block only): normalise P by its row-sum
+          register-direct here and skip the FP-SRAM l/final-scale path.
         """
         s_info = self[s_block_matrix]
         s_address = s_info.vram_addr
@@ -760,6 +778,7 @@ class IsaAttentionMixin:
             scale=scale,
             rows=rows,
             valid_cols=valid_cols,
+            inline_normalize=inline_normalize,
         )
 
         return self._emit(isa_code)

--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -306,11 +306,20 @@ class IsaAttentionMixin:
             v_block_hbm_offset = v_hbm_offset + v_col_block * mlen
             lines.append(f"S_ADDI_INT gp{gp_v}, gp0, 0")
             lines.extend(load_large_int(gp_hbm, v_block_hbm_offset))
-            lines.append(f"H_PREFETCH_M gp{gp_v}, gp{gp_hbm}, a{v_hbm_offset_reg}, 1, 1")
+            # funct1=0 => PREFETCH_M_H (High Precision, m_controller_precision_select=0),
+            # matching how V is staged in HBM (same High-Precision MXINT format as the K/W
+            # weights, which load via _H). funct1=1 (_L / Low Precision) mis-decodes the
+            # High-staged V into garbage (~constant mantissas) -> rank-1 P@V collapse.
+            lines.append(f"H_PREFETCH_M gp{gp_v}, gp{gp_hbm}, a{v_hbm_offset_reg}, 1, 0")
 
             pv_col_block_base = pv_address + v_col_block * pv_physical_rows * mlen
             lines.extend(load_large_int(gp_pv_col_base, pv_col_block_base))
-            lines.append(f"C_LOOP_START gp{gp_v_loop}, {tiles_per_mlen}")
+            # Only cover the output columns this block actually has. head_dim < mlen
+            # (e.g. GQA head_slot_dim=4) would otherwise over-iterate V's zero-pad
+            # columns, writing garbage into PV cols head_dim..mlen (spilled by the pack).
+            block_cols = min(head_dim - v_col_block * mlen, mlen)
+            v_col_tiles = max(1, math.ceil(block_cols / blen))
+            lines.append(f"C_LOOP_START gp{gp_v_loop}, {v_col_tiles}")
             lines.extend(load_large_int(gp_p, p_address))
             lines.append(f"S_ADDI_INT gp{gp_pv}, gp{gp_pv_col_base}, 0")
             lines.append(f"C_LOOP_START gp{gp_p_loop}, {p_row_groups}")
@@ -364,9 +373,17 @@ class IsaAttentionMixin:
             v_block_hbm_offset = v_hbm_offset + v_col_block * mlen
             lines.append(f"S_ADDI_INT gp{gp_v}, gp0, 0")
             lines.extend(load_large_int(gp_hbm, v_block_hbm_offset))
-            lines.append(f"H_PREFETCH_M gp{gp_v}, gp{gp_hbm}, a{v_hbm_offset_reg}, 1, 1")
+            # funct1=0 => PREFETCH_M_H (High Precision), matching V's HBM staging; _L
+            # (Low Precision) mis-decodes it to garbage. See _pv_multiply_asm above.
+            lines.append(f"H_PREFETCH_M gp{gp_v}, gp{gp_hbm}, a{v_hbm_offset_reg}, 1, 0")
 
-            for v_col in range(mlen // blen):
+            # Only emit output-column tiles that this block actually covers. When
+            # head_dim < mlen (e.g. GQA head_slot_dim=4), mlen//blen would over-iterate
+            # over V's zero-padded columns, writing GARBAGE into PV cols head_dim..mlen
+            # that the pack (V_SHFT_V + V_ADD_VV over all lanes) then spills across heads.
+            block_cols = min(head_dim - v_col_block * mlen, mlen)
+            v_col_tiles = max(1, math.ceil(block_cols / blen))
+            for v_col in range(v_col_tiles):
                 lines.append(f"; V column {v_col_block * mlen + v_col * blen}")
                 v_msram_offset = v_col * blen
                 lines.append(f"S_ADDI_INT gp{gp_v}, gp0, {v_msram_offset}")
@@ -835,6 +852,34 @@ class IsaAttentionMixin:
         self.register_allocator.free_gp(gp_regs)
         self.register_allocator.free_addr(addr_regs)
 
+        return self._emit(isa_code)
+
+    def warm_v_prefetch(self, v_sub_matrix: str, k_idx: int) -> str:
+        """Prefetch V[k_idx] into MSRAM ONCE (High precision) before the per-head P@V
+        loop so it has fully landed by head 0's first tile. Paired with the RTL
+        cold-start re-prime at the M_BTMM->M_MM boundary: the re-prime re-warms the
+        weight-read pipe, but its ~20-cycle spin can outrun head 0's own (late) per-head
+        prefetch, leaving row 0 reading stale K. Landing V here (during head 0's softmax)
+        guarantees the spin reads V for row 0 too."""
+        v_layout = self.get_hbm_layout(v_sub_matrix)
+        physical_head_dim = (v_layout.physical_shape or v_layout.full_shape)[1]
+        v_hbm_offset = k_idx * self.mlen * physical_head_dim
+        addr_regs = self.register_allocator.allocate_addr(1)
+        v_hbm_reg = addr_regs[0]
+        gp_regs = self.register_allocator.allocate_gp(2)
+
+        from compiler.asm_templates import preload_addr_reg_asm
+
+        isa_code = "; === Warm V into MSRAM once (head-0 row-0 stale-K guard) ===\n"
+        isa_code += preload_addr_reg_asm(
+            addr_reg_to_set=[v_hbm_reg], available_registers=gp_regs, addr_reg_val=[v_layout.hbm_base_addr]
+        )
+        isa_code += f"S_ADDI_INT gp{gp_regs[0]}, gp0, 0\n"
+        isa_code += "\n".join(load_large_int(gp_regs[1], v_hbm_offset)) + "\n"
+        isa_code += f"H_PREFETCH_M gp{gp_regs[0]}, gp{gp_regs[1]}, a{v_hbm_reg}, 1, 0\n"
+
+        self.register_allocator.free_gp(gp_regs)
+        self.register_allocator.free_addr(addr_regs)
         return self._emit(isa_code)
 
     def scale_o_row(

--- a/aten/plena/isa_matrix.py
+++ b/aten/plena/isa_matrix.py
@@ -294,7 +294,12 @@ class IsaMatrixMixin:
             result_vram_addr=result_vram_addr,
             full_batch=full_batch,
             num_hidden_blocks=num_hidden_blocks,
-            mat_col_stride=self.blen,
+            # Row-aligned column stride: the matrix SRAM read is row-granular
+            # (raddr >> log2(MLEN)), so successive BLEN-column output sub-tiles
+            # must be a full MLEN row apart, else they collapse onto the same
+            # MRAM rows and the output columns replicate ([a,b,c,d]x4). blen
+            # alone is sub-row and only works on an element-granular model.
+            mat_col_stride=self.blen * self.mlen,
             transposed=False,
             gp_regs=gp_regs,
             caller_name="vram_sub_projection_asm",

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -461,8 +461,19 @@ class ProgramAttentionMixin:
         k_idx: int,
         s_base_address: int,
         k_head_offset: int = 0,
+        q_rows: int | None = None,
+        kv_cols: int | None = None,
     ) -> None:
-        """Emit packed QK^T with M_BTMM/M_BMM_WO into head-major S tiles."""
+        """Emit packed QK^T with M_BTMM/M_BMM_WO into head-major S tiles.
+
+        The per-head systolic (M_BTMM) produces one BLEN(query) x BLEN(kv) tile per
+        head per op. The full per-head S is tiled BLEN x BLEN: outer loop over
+        query-row tiles (qt), inner over kv-column tiles (kt). Each M_BTMM reads
+          rs1 = K MRAM base + kt*BLEN*MLEN  (the kv-tile's block rows, transposed)
+          rs2 = Q VRAM base + qt*BLEN*MLEN  (the query-row tile)
+        and M_BMM_WO writes to s_base + qt*BLEN*MLEN + kt*BLEN; the DFC per-head drain
+        then scatters the ROW_BLOCK_NUM heads head-major (base + head*MLEN*MLEN).
+        """
         self._ensure_hbm_sub_matrix_registered(K)
         k_layout = self.get_hbm_layout(K.name)
         self._emit_hbm_matrix_load(
@@ -478,16 +489,28 @@ class ProgramAttentionMixin:
             ),
         )
 
-        q_base = self.get_vram_addr(Q_group.name) + q_idx * self.mlen * self.mlen
-        gp_q, gp_s = self.register_allocator.allocate_gp(2)
-        lines = [
-            "; === Packed GQA QK^T using compiler M_BTMM ===",
-            *load_large_int(gp_q, q_base),
-            f"M_BTMM {k_head_offset}, gp0, gp{gp_q}",
-            *load_large_int(gp_s, s_base_address),
-            f"M_BMM_WO gp{gp_s}, 0",
-        ]
-        self.register_allocator.free_gp([gp_q, gp_s])
+        mlen, blen = self.mlen, self.blen
+        q_base = self.get_vram_addr(Q_group.name) + q_idx * mlen * mlen
+        n_q_tiles = max(1, (min(mlen, q_rows or mlen) + blen - 1) // blen)
+        n_kv_tiles = max(1, (min(mlen, kv_cols or mlen) + blen - 1) // blen)
+
+        gp_q, gp_s, gp_k = self.register_allocator.allocate_gp(3)
+        lines = ["; === Packed GQA QK^T using compiler M_BTMM "
+                 f"({n_q_tiles} query-tile x {n_kv_tiles} kv-tile) ==="]
+        for qt in range(n_q_tiles):
+            for kt in range(n_kv_tiles):
+                k_off = k_head_offset + kt * blen * mlen
+                # kt==0 reads K from MRAM base 0 (gp0); kt>0 offsets by kt*BLEN*MLEN
+                # (the kv-tile's block rows, read transposed).
+                k_reg = "gp0" if k_off == 0 else f"gp{gp_k}"
+                lines += ([] if k_off == 0 else load_large_int(gp_k, k_off))
+                lines += [
+                    *load_large_int(gp_q, q_base + qt * blen * mlen),
+                    f"M_BTMM 0, {k_reg}, gp{gp_q}",
+                    *load_large_int(gp_s, s_base_address + qt * blen * mlen + kt * blen),
+                    f"M_BMM_WO gp{gp_s}, 0",
+                ]
+        self.register_allocator.free_gp([gp_q, gp_s, gp_k])
         self.emit("\n".join(lines) + "\n")
 
     def _emit_packed_qkt_to_s_dynamic(
@@ -559,13 +582,27 @@ class ProgramAttentionMixin:
             *load_large_int(gp_dst, output_base_address),
             *load_large_int(gp_scratch, scratch_address),
             *load_large_int(gp_shift, shift),
-            f"C_LOOP_START gp{gp_loop}, {rows}",
-            f"V_SHIFT_V gp{gp_scratch}, gp{gp_src}, gp{gp_shift}",
-            f"V_ADD_VV gp{gp_dst}, gp{gp_dst}, gp{gp_scratch}, 0",
-            f"S_ADDI_INT gp{gp_src}, gp{gp_src}, {self.mlen}",
-            f"S_ADDI_INT gp{gp_dst}, gp{gp_dst}, {self.mlen}",
-            f"C_LOOP_END gp{gp_loop}",
         ]
+        if getattr(self, "unroll_attention", False):
+            # Straight-line pack (no C_LOOP). The last head's pack C_LOOP_END sits
+            # right before the program's C_BREAK, and the decoder's early_loop_end_stall
+            # lookahead pins pc_reg there (C_BREAK never decodes -> hang). Unrolling
+            # removes every pack loop, so no C_LOOP_END precedes the trailing C_BREAK.
+            for i in range(rows):
+                lines.append(f"V_SHIFT_V gp{gp_scratch}, gp{gp_src}, gp{gp_shift}")
+                lines.append(f"V_ADD_VV gp{gp_dst}, gp{gp_dst}, gp{gp_scratch}, 0")
+                if i < rows - 1:
+                    lines.append(f"S_ADDI_INT gp{gp_src}, gp{gp_src}, {self.mlen}")
+                    lines.append(f"S_ADDI_INT gp{gp_dst}, gp{gp_dst}, {self.mlen}")
+        else:
+            lines += [
+                f"C_LOOP_START gp{gp_loop}, {rows}",
+                f"V_SHIFT_V gp{gp_scratch}, gp{gp_src}, gp{gp_shift}",
+                f"V_ADD_VV gp{gp_dst}, gp{gp_dst}, gp{gp_scratch}, 0",
+                f"S_ADDI_INT gp{gp_src}, gp{gp_src}, {self.mlen}",
+                f"S_ADDI_INT gp{gp_dst}, gp{gp_dst}, {self.mlen}",
+                f"C_LOOP_END gp{gp_loop}",
+            ]
         self.register_allocator.free_gp([gp_src, gp_dst, gp_scratch, gp_shift, gp_loop])
         self.emit("\n".join(lines) + "\n")
 
@@ -643,9 +680,10 @@ class ProgramAttentionMixin:
         self._ensure_vram_matrix_layout(Q_group.name)
 
         rows = min(mlen, seq_len)
-        # M_BTMM applies the emulator's fixed bmm_scale (0.25). Compensate in
-        # online softmax so the effective QK scale remains caller-provided.
-        softmax_scale = scale / 0.25
+        # RTL M_BTMM applies NO bmm_scale (unlike the emulator's fixed 0.25), so the
+        # QK^T scores reach the softmax unscaled -> apply the caller's scale directly.
+        # (scale/0.25 would make the softmax 4x too sharp -> peaked P -> inflated P@V.)
+        softmax_scale = scale
 
         s_views = [
             self.alloc_at(
@@ -676,6 +714,8 @@ class ProgramAttentionMixin:
             q_idx=0,
             k_idx=k_idx,
             s_base_address=scratch_base_address,
+            q_rows=rows,
+            kv_cols=(valid_cols if valid_cols is not None else seq_len),
         )
 
         active_cols = valid_cols or seq_len
@@ -704,11 +744,15 @@ class ProgramAttentionMixin:
                 if valid_col_mask is not None or isinstance(causal_mask, VRAMMatrixVar)
                 else active_cols
             )
-            self.online_softmax_block(s_head, softmax_scale, rows=rows, valid_cols=softmax_valid_cols)
+            # Single KV block (fused packed path): normalise P register-direct in the
+            # softmax block, so pv = softmax(S)@V = O directly. This avoids the FP-SRAM
+            # l/m_res round-trip used by scale_o_row/final_scale_o, whose per-row store
+            # is racy on this RTL (drops -> O saturates to FP12 max; see online_softmax.py).
+            # o_head was zeroed by init_online_softmax, so vram_add copies pv into O.
+            self.online_softmax_block(s_head, softmax_scale, rows=rows,
+                                      valid_cols=softmax_valid_cols, inline_normalize=True)
             self.compute_pv(s_head, V, k_idx, pv, head_slot_dim, rows=rows)
-            self.scale_o_row(o_head, 0, rows=rows)
             self.vram_add(o_head, pv, num_rows=rows)
-            self.final_scale_o(0, o_head, rows=rows)
             output_head = output_head_base + head
             output_col_block = (output_head * head_slot_dim) // mlen
             output_lane = (output_head * head_slot_dim) % mlen // head_slot_dim
@@ -974,6 +1018,7 @@ class ProgramAttentionMixin:
         scale: float,
         rows: int | None = None,
         valid_cols: int | None = None,
+        inline_normalize: bool = False,
     ):
         """Perform Online Softmax on S block"""
         super().online_softmax_block(
@@ -981,6 +1026,7 @@ class ProgramAttentionMixin:
             scale=scale,
             rows=rows,
             valid_cols=valid_cols,
+            inline_normalize=inline_normalize,
         )
 
     def compute_pv(

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -724,6 +724,9 @@ class ProgramAttentionMixin:
             if self._needs_explicit_valid_col_mask(active_cols)
             else None
         )
+        # Warm V into MSRAM once so head 0's cold-start-reprimed first tile reads V
+        # (not the QK^T's stale K) on row 0 too — it lands during head 0's softmax.
+        self.warm_v_prefetch(V.name, k_idx)
         for head, s_head in enumerate(s_views):
             o_head = self.alloc(
                 f"_packed_O_head{head}",


### PR DESCRIPTION
## Summary

ATen-compiler support for grouped-query attention and the full Llama decoder layer: per-head batched transposed matmul (`M_BTMM`) QK^T tiling, inline-normalize online softmax, and the projection / weight-read fixes that let the GQA and Llama-layer workloads pass end-to-end on RTL.

Paired with the consuming RTL PR **AICrossSim/PLENA_RTL#49**, which pins this branch via submodule.

## Changes

- **feat(gqa)**: per-head `M_BTMM` QK^T tiling + inline-normalize online softmax (register-direct row normalization, no FP-SRAM `l` round-trip).
- **fix(gqa)**: correct P@V — V precision (prefetch high), V-column tiling, warm prefetch.
- **fix(softmax)**: single-pass register-direct row softmax.
- **fix(ffn)** / **fix(matrix)**: row-align the weight-read pointer / non-transposed weight-column stride.

## Results (via the RTL consumer)

gqa (ATen) 100%, full Llama decoder layer (ATen) 93.65%; no regressions on linear / softmax / rms / rope / ffn / mha.
