### PR TITLE
fix(attention): normalize P in the rolled online-softmax emitter

### DIFF
--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -112,15 +112,24 @@ class IsaAttentionMixin:
         lines.append(f"V_SUB_VF gp{gp_s}, gp{gp_s}, f{fp_m_old}, {mask_en}, 0")
         lines.append(f"V_EXP_V gp{gp_s}, gp{gp_s}, {mask_en}, 0")
 
-        lines.append(f"S_LD_FP f{fp_l_old}, gp{gp_l_addr}, 0")
+        if inline_normalize:
+            # Single-block fast path (parity with _online_softmax_asm_unrolled).
+            lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
+            lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
+            lines.append(f"S_RECI_FP f{fp_sum_p}, f{fp_sum_p}, 0")
+            for _ in range(4):  # retire multi-cycle S_RECI_FP before V_MUL_VF reads it
+                lines.append("S_ADDI_INT gp0, gp0, 0")
+            lines.append(f"V_MUL_VF gp{gp_s}, gp{gp_s}, f{fp_sum_p}, {mask_en}")
+        else:
+            lines.append(f"S_LD_FP f{fp_l_old}, gp{gp_l_addr}, 0")
 
-        lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
-        lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
+            lines.append(f"S_ADD_FP f{fp_sum_p}, f0, f0")
+            lines.append(f"V_RED_SUM f{fp_sum_p}, gp{gp_s}, {mask_en}, 0")
 
-        lines.append(f"S_MUL_FP f{fp_l_old}, f{fp_l_old}, f{fp_m_res}")
-        lines.append(f"S_ADD_FP f{fp_l_old}, f{fp_l_old}, f{fp_sum_p}")
+            lines.append(f"S_MUL_FP f{fp_l_old}, f{fp_l_old}, f{fp_m_res}")
+            lines.append(f"S_ADD_FP f{fp_l_old}, f{fp_l_old}, f{fp_sum_p}")
 
-        lines.append(f"S_ST_FP f{fp_l_old}, gp{gp_l_addr}, 0")
+            lines.append(f"S_ST_FP f{fp_l_old}, gp{gp_l_addr}, 0")
 
         lines.append(f"S_ADDI_INT gp{gp_s}, gp{gp_s}, {mlen}")
         lines.append(f"S_ADDI_INT gp{gp_m_addr}, gp{gp_m_addr}, 1")


### PR DESCRIPTION
## Problem
The rolled online-softmax emitter `_online_softmax_asm` accepted an `inline_normalize` flag but never used it — it always emitted the running-`l` FP-SRAM accumulation path and never divided P by its row sum. Its unrolled twin `_online_softmax_asm_unrolled` got the `inline_normalize` fast-path in #63/#64; the rolled emitter was left behind.

The decomposed attention used by the llama/GQA path (`linear_projection` QK^T + P@V with inline-normalize softmax) relies on inline normalization and does **no** final O/l rescale. So with the rolled emitter (`ATEN_OPS_UNROLL=0` / `unroll_loops=False`), P stayed **unnormalized** → P@V, O, O-proj and residual were all wrong (rolled llama attn ~16%).

## Fix
Add the `if inline_normalize:` branch to `_online_softmax_asm`, mirroring the unrolled twin (`V_RED_SUM` → `S_RECI_FP` → retire NOPs → `V_MUL_VF`). The `else` (running-`l`) path is byte-identical to before.

**Zero-regression:** production runs unrolled (`unroll_attention=True` early-returns to the unrolled emitter, never touching this code), and rolled+inline was broken so nothing passing depended on it.

## Result
Rolled llama attn **16.21% → 92.38%** (and → 100% together with the RTL `fp_max` negative-max fix in PLENA_RTL). One file, +17/-6.