### PR TITLE
fix(hbm): row-align tensor allocation to match the stager at every MLEN

### DIFF
--- a/aten/plena/isa_compiler.py
+++ b/aten/plena/isa_compiler.py
@@ -199,9 +199,9 @@ class IsaCompiler(
 
             if tensor_info.hbm_addr < 0 or tensor_info.hbm_addr != hbm_addr:
                 tensor_info.hbm_addr = hbm_addr
-                # HBM stores the MXFP-expanded size (logical size × real_data_ratio).
+                # HBM stores element + scale rows, each row-aligned (see hbm_tensor_size).
                 size = batch_size * hidden_size
-                tensor_info.hbm_size = int(size * self.real_data_ratio)
+                tensor_info.hbm_size = self.hbm_tensor_size(size)
         finally:
             self.register_allocator.free_gp(gp_regs)
             if need_free_addr:

--- a/aten/plena/memory_state.py
+++ b/aten/plena/memory_state.py
@@ -24,6 +24,10 @@ class MemoryStateMixin:
         blen: int = BLEN,
         unroll_loops: bool = False,
         mram_tile_capacity: int = 4,
+        hbm_row_width: int = 256,
+        hbm_element_width: int = 8,
+        hbm_block_size: int = 8,
+        hbm_scale_width: int = 8,
     ):
         if mlen <= 0:
             raise ValueError(f"mlen must be > 0, got {mlen}")
@@ -36,6 +40,13 @@ class MemoryStateMixin:
         self.mram_tile_capacity = mram_tile_capacity
         self.mram_tile_elems = mlen * mlen
         self.mram_capacity_elems = self.mram_tile_capacity * self.mram_tile_elems
+
+        # HBM row-aligned layout params (MXINT8/256b defaults). Must match the stager
+        # (create_mem_for_sim / calculate_instr_storage_offset_from_shapes).
+        self.hbm_row_width = hbm_row_width
+        self.hbm_element_width = hbm_element_width
+        self.hbm_block_size = hbm_block_size
+        self.hbm_scale_width = hbm_scale_width
 
         # Layout tables
         self.hbm_matrices: dict[str, MatrixBlockLayout] = {}
@@ -203,6 +214,23 @@ class MemoryStateMixin:
         self.fpram_matrices.pop(name, None)
         return info
 
+    def hbm_tensor_size(self, num_elements: int) -> int:
+        """Row-aligned HBM byte footprint of one tensor: element rows + scale rows,
+        each padded up to hbm_row_width, matching the stager (create_mem_for_sim /
+        plena_utils.calculate_instr_storage_offset_from_shapes). Replaces the packed
+        `int(size * real_data_ratio)` estimate, which ignored per-tensor row padding
+        and mislaid every following tensor whenever a region was not naturally
+        row-aligned (weights/K/V read zeros; common at small MLEN)."""
+        row_bits = self.hbm_row_width
+        ew, bs, sw = self.hbm_element_width, self.hbm_block_size, self.hbm_scale_width
+        bytes_per_row = row_bits // 8
+        elements_per_row = (row_bits // (ew * bs)) * bs
+        element_rows = -(-num_elements // elements_per_row) if elements_per_row > 0 else 0
+        num_scales = num_elements // bs
+        scales_per_row = row_bits // sw if sw > 0 else 1
+        scale_rows = -(-num_scales // scales_per_row) if scales_per_row > 0 else 0
+        return (element_rows + scale_rows) * bytes_per_row
+
     def register_matrix(
         self,
         name: str,
@@ -213,6 +241,7 @@ class MemoryStateMixin:
         strict: bool = True,
     ) -> MatrixBlockLayout:
         """Register an HBM matrix and derive its mlen block layout."""
+        del real_data_ratio  # HBM size is now row-aligned (see hbm_tensor_size)
         rows, cols = shape
         physical_rows, physical_cols = physical_shape or shape
 
@@ -223,7 +252,7 @@ class MemoryStateMixin:
                 raise ValueError(f"Matrix physical cols ({physical_cols}) must be multiple of mlen ({self.mlen})")
 
         size = physical_rows * physical_cols
-        hbm_size = int(size * real_data_ratio)
+        hbm_size = self.hbm_tensor_size(size)
 
         layout = MatrixBlockLayout(
             name=name,

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -37,7 +37,7 @@ class ProgramTensorMixin:
         """
         h, w = physical_shape or shape
         size = h * w
-        hbm_size = int(size * self.real_data_ratio)
+        hbm_size = self.hbm_tensor_size(size)
 
         if hbm_addr is None:
             hbm_addr = self._allocate_hbm(hbm_size)
@@ -147,11 +147,11 @@ class ProgramTensorMixin:
         if hbm_addr is None:
             h, w = tensor_var.physical_shape
             size = h * w
-            hbm_size = int(size * self.real_data_ratio)
+            hbm_size = self.hbm_tensor_size(size)
             hbm_addr = self._allocate_hbm(hbm_size)
         else:
             h, w = tensor_var.physical_shape
-            hbm_size = int(h * w * self.real_data_ratio)
+            hbm_size = self.hbm_tensor_size(h * w)
 
         super().store_to_hbm(
             tensor_name=tensor_var.name,  # internal name for symbol table lookup


### PR DESCRIPTION
Fixes the ATen compiler's HBM allocator so tensor bases match the memory stager at every MLEN.

## Root cause
The allocator sized each tensor with a **packed** estimate `int(size * real_data_ratio)`. But the stager (`create_mem_for_sim` / `plena_utils.calculate_instr_storage_offset_from_shapes`) places every tensor's **element rows** and **scale rows** on *separate* `hbm_row_width`(256b)-aligned rows. When a region isn't naturally row-aligned (common at small MLEN), the packed base under-counts and every *following* tensor (weights / K / V) lands 2-3 rows too low → the readers fetch zeros.

This is the compiler-side counterpart of the workload-codegen fix in #54: previously only `gqa.py` was patched (by passing explicit `hbm_addr=`, working *around* the allocator). Now the allocator itself is correct, so any ATen-compiled model is right at MLEN=8, not just gqa.

## Fix
Add `MemoryStateMixin.hbm_tensor_size(num_elements)` = `(element_rows + scale_rows) * bytes_per_row`, each rounded up to `hbm_row_width` — the same layout the stager uses — and call it at all five allocation sites (`register_matrix`, `program_tensors` InputVar + `store_to_hbm`, `isa_compiler` store). Precision params default to MXINT8/256b (matching `real_data_ratio = 1.125`).

**Byte-identical** to the old packed value for row-aligned shapes (all MLEN≥16 tiles, and any tile that's a multiple of the row size), so the working MLEN=16/64 emulator/sim paths are unchanged.

## Verified
- gqa @ **MLEN=8**: PASSED (100%) via plain auto-allocation, with the `gqa.py` `hbm_addr` workaround removed.
- gqa @ **MLEN=16**: PASSED (100%), unchanged (fix is a no-op there).

Follow-up in the main repo: bump the submodule pointer and drop the now-redundant `gqa.py` explicit-`hbm_addr` workaround.
