### PR TITLE
fix: complete row-granular matrix-SRAM ABI across FFN and attention

### DIFF
--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -379,10 +379,10 @@ class IsaAttentionMixin:
             lines.append(f"S_ADDI_INT gp{gp_p}, gp{gp_p}, {blen * mlen}")
             lines.append(f"S_ADDI_INT gp{gp_pv}, gp{gp_pv}, {blen * mlen}")
             lines.append(f"C_LOOP_END gp{gp_p_loop}")
-            # EXPERIMENT (row-granular ABI): the V weight is the M_MM matrix operand;
-            # its column sub-tile must advance by blen*mlen (row-aligned) so each
-            # reads a distinct MRAM row. The PV OUTPUT column (gp_pv_col_base) stays
-            # +blen (VRAM output is packed).
+            # The V weight is the M_MM matrix operand; its column sub-tile must
+            # advance by BLEN*MLEN (row-aligned) so each reads a distinct MRAM row
+            # under the row-granular matrix SRAM read. The PV output column
+            # (gp_pv_col_base) stays +BLEN because the VRAM output is packed.
             lines.append(f"S_ADDI_INT gp{gp_v}, gp{gp_v}, {blen * mlen}")
             lines.append(f"S_ADDI_INT gp{gp_pv_col_base}, gp{gp_pv_col_base}, {blen}")
             lines.append(f"C_LOOP_END gp{gp_v_loop}")

--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -379,7 +379,11 @@ class IsaAttentionMixin:
             lines.append(f"S_ADDI_INT gp{gp_p}, gp{gp_p}, {blen * mlen}")
             lines.append(f"S_ADDI_INT gp{gp_pv}, gp{gp_pv}, {blen * mlen}")
             lines.append(f"C_LOOP_END gp{gp_p_loop}")
-            lines.append(f"S_ADDI_INT gp{gp_v}, gp{gp_v}, {blen}")
+            # EXPERIMENT (row-granular ABI): the V weight is the M_MM matrix operand;
+            # its column sub-tile must advance by blen*mlen (row-aligned) so each
+            # reads a distinct MRAM row. The PV OUTPUT column (gp_pv_col_base) stays
+            # +blen (VRAM output is packed).
+            lines.append(f"S_ADDI_INT gp{gp_v}, gp{gp_v}, {blen * mlen}")
             lines.append(f"S_ADDI_INT gp{gp_pv_col_base}, gp{gp_pv_col_base}, {blen}")
             lines.append(f"C_LOOP_END gp{gp_v_loop}")
 

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -545,13 +545,15 @@ class ProgramAttentionMixin:
     ) -> None:
         """Emit packed QK^T with M_BTMM/M_BMM_WO into head-major S tiles.
 
-        The per-head systolic (M_BTMM) produces one BLEN(query) x BLEN(kv) tile per
-        head per op. The full per-head S is tiled BLEN x BLEN: outer loop over
-        query-row tiles (qt), inner over kv-column tiles (kt). Each M_BTMM reads
-          rs1 = K MRAM base + kt*BLEN*MLEN  (the kv-tile's block rows, transposed)
-          rs2 = Q VRAM base + qt*BLEN*MLEN  (the query-row tile)
-        and M_BMM_WO writes to s_base + qt*BLEN*MLEN + kt*BLEN; the DFC per-head drain
-        then scatters the ROW_BLOCK_NUM heads head-major (base + head*MLEN*MLEN).
+        M_BTMM is a whole-tile, all-(broadcast)-heads systolic op: one M_BTMM reads
+        the full [MLEN, MLEN] K tile (transposed) against the [MLEN, MLEN] Q tile and
+        computes the entire S = Q @ K^T for the head group. It reads
+          rs1 = K MRAM base + k_head_offset  (head offset < MLEN)
+          rs2 = Q VRAM base
+        and M_BMM_WO drains the ROW_BLOCK_NUM heads head-major (base + head*MLEN*MLEN).
+        Packed GQA requires seq_len <= MLEN, so K and V fit in one tile and no kv/query
+        sub-tiling is needed; padding of partial rows/cols is applied by the caller's
+        valid-column score mask.
         """
         self._ensure_hbm_sub_matrix_registered(K)
         k_layout = self.get_hbm_layout(K.name)
@@ -571,20 +573,16 @@ class ProgramAttentionMixin:
             ),
         )
 
-        mlen, blen = self.mlen, self.blen
+        mlen = self.mlen
         q_base = self.get_vram_addr(Q_group.name) + q_idx * mlen * mlen
-        n_q_tiles = max(1, (min(mlen, q_rows or mlen) + blen - 1) // blen)
-        n_kv_tiles = max(1, (min(mlen, kv_cols or mlen) + blen - 1) // blen)
 
-        # EXPERIMENT (row-granular ABI): the emulator's M_BTMM is a whole-tile,
-        # all-(broadcast)-heads operator with NO kv-column sub-tile dimension -- it
-        # reads the full [MLEN,MLEN] K tile and produces the entire S=Q@K^T for the
-        # head group in one op, drained head-major by M_BMM_WO. So emit ONE M_BTMM
-        # over the whole MLEN KV (matrix operand = head offset < MLEN) instead of
-        # kv-tiling with kt*BLEN*MLEN offsets that the whole-tile decode cannot map
-        # (they land as out-of-range row starts). The full-tile compute covers all
-        # n_q_tiles*n_kv_tiles blocks at once.
-        _ = (n_q_tiles, n_kv_tiles)
+        # The compiler M_BTMM is a whole-tile, all-(broadcast)-heads operator: it
+        # reads the full [MLEN, MLEN] K tile and produces the entire S = Q @ K^T for
+        # the head group in one op, drained head-major by M_BMM_WO. Emit a single
+        # M_BTMM over the whole MLEN KV (matrix operand = head offset < MLEN); it
+        # covers every query/kv sub-tile at once. Padding of partial q_rows/kv_cols
+        # is handled by the caller's valid-column score mask, not by tiling here.
+        # (Packed GQA requires seq_len <= MLEN, so K and V fit in one tile.)
         gp_q, gp_s = self.register_allocator.allocate_gp(2)
         lines = ["; === Packed GQA QK^T using compiler M_BTMM (whole-tile) ==="]
         lines += [

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -576,23 +576,24 @@ class ProgramAttentionMixin:
         n_q_tiles = max(1, (min(mlen, q_rows or mlen) + blen - 1) // blen)
         n_kv_tiles = max(1, (min(mlen, kv_cols or mlen) + blen - 1) // blen)
 
-        gp_q, gp_s, gp_k = self.register_allocator.allocate_gp(3)
-        lines = ["; === Packed GQA QK^T using compiler M_BTMM "
-                 f"({n_q_tiles} query-tile x {n_kv_tiles} kv-tile) ==="]
-        for qt in range(n_q_tiles):
-            for kt in range(n_kv_tiles):
-                k_off = k_head_offset + kt * blen * mlen
-                # kt==0 reads K from MRAM base 0 (gp0); kt>0 offsets by kt*BLEN*MLEN
-                # (the kv-tile's block rows, read transposed).
-                k_reg = "gp0" if k_off == 0 else f"gp{gp_k}"
-                lines += ([] if k_off == 0 else load_large_int(gp_k, k_off))
-                lines += [
-                    *load_large_int(gp_q, q_base + qt * blen * mlen),
-                    f"M_BTMM 0, {k_reg}, gp{gp_q}",
-                    *load_large_int(gp_s, s_base_address + qt * blen * mlen + kt * blen),
-                    f"M_BMM_WO gp{gp_s}, 0",
-                ]
-        self.register_allocator.free_gp([gp_q, gp_s, gp_k])
+        # EXPERIMENT (row-granular ABI): the emulator's M_BTMM is a whole-tile,
+        # all-(broadcast)-heads operator with NO kv-column sub-tile dimension -- it
+        # reads the full [MLEN,MLEN] K tile and produces the entire S=Q@K^T for the
+        # head group in one op, drained head-major by M_BMM_WO. So emit ONE M_BTMM
+        # over the whole MLEN KV (matrix operand = head offset < MLEN) instead of
+        # kv-tiling with kt*BLEN*MLEN offsets that the whole-tile decode cannot map
+        # (they land as out-of-range row starts). The full-tile compute covers all
+        # n_q_tiles*n_kv_tiles blocks at once.
+        _ = (n_q_tiles, n_kv_tiles)
+        gp_q, gp_s = self.register_allocator.allocate_gp(2)
+        lines = ["; === Packed GQA QK^T using compiler M_BTMM (whole-tile) ==="]
+        lines += [
+            *load_large_int(gp_q, q_base),
+            f"M_BTMM {k_head_offset}, gp0, gp{gp_q}",
+            *load_large_int(gp_s, s_base_address),
+            f"M_BMM_WO gp{gp_s}, 0",
+        ]
+        self.register_allocator.free_gp([gp_q, gp_s])
         self.emit("\n".join(lines) + "\n")
 
     def _emit_packed_qkt_to_s_dynamic(

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -415,14 +415,13 @@ class ProgramTensorMixin:
                 f"FFN activation rows ({batch_size}) must be a positive multiple of BLEN ({blen})."
             )
         activation_base_address = self.get_vram_addr(input_var.name)
-        max_k_tiles = max(hidden_size // mlen, inter_dim // mlen)
-        # EXPERIMENT (row-granular ABI stopgap): the C_LOOP FFN path
-        # (_ffn_asm_with_loops) advances the M_MM weight pointer by `blen`
-        # (element-granular), which the row-granular matrix SRAM read collapses
-        # onto column-block 0. Force the unrolled path (_ffn_asm_unrolled ->
-        # _emit_ffn_projection_chunk), which advances the weight by `blen*mlen`.
+        # Always emit the unrolled FFN projection path. The matrix SRAM read is
+        # row-granular (raddr >> log2(MLEN)), so a matrix-operand column sub-tile
+        # must advance by BLEN*MLEN to land on a distinct MRAM row. The C_LOOP
+        # variant (_ffn_asm_with_loops) advances the M_MM weight pointer by BLEN,
+        # which collapses every sub-tile onto column-block 0; the unrolled path
+        # (_emit_ffn_projection_chunk) uses the correct BLEN*MLEN stride.
         use_loop_instructions = False
-        _ = max_k_tiles  # retained for the (currently disabled) loop-path heuristic
         workspace_elems = batch_size * (2 * inter_dim + max(hidden_size, inter_dim))
         workspace_rows = (workspace_elems + mlen - 1) // mlen
         workspace = self.alloc(

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -416,7 +416,13 @@ class ProgramTensorMixin:
             )
         activation_base_address = self.get_vram_addr(input_var.name)
         max_k_tiles = max(hidden_size // mlen, inter_dim // mlen)
-        use_loop_instructions = max_k_tiles <= self.mram_tile_capacity
+        # EXPERIMENT (row-granular ABI stopgap): the C_LOOP FFN path
+        # (_ffn_asm_with_loops) advances the M_MM weight pointer by `blen`
+        # (element-granular), which the row-granular matrix SRAM read collapses
+        # onto column-block 0. Force the unrolled path (_ffn_asm_unrolled ->
+        # _emit_ffn_projection_chunk), which advances the weight by `blen*mlen`.
+        use_loop_instructions = False
+        _ = max_k_tiles  # retained for the (currently disabled) loop-path heuristic
         workspace_elems = batch_size * (2 * inter_dim + max(hidden_size, inter_dim))
         workspace_rows = (workspace_elems + mlen - 1) // mlen
         workspace = self.alloc(


### PR DESCRIPTION
## Problem

The matrix SRAM (MRAM) read is **row-granular** in hardware — `raddr >> log2(MLEN)` drops the low `log2(MLEN)` bits and selects a full MLEN-wide row. So a matrix (weight) operand's column sub-tile must advance by **`blen*mlen`** (row-aligned), not `blen`. A bare `+blen` right-shifts to the same MRAM row as column-block 0 → the output columns replicate (`[a,b,c,d]×4`).

The projection kernels (`vram_sub_projection*`, `projection_asm`, `_emit_ffn_projection_chunk`) were converted to this convention, but **three matrix-operand emitters were left element-granular**. Against a row-granular emulator `M_MM`/`M_BTMM` decode this panics:
- `just test-aten-ffn` → `assert mat_offset % mlen == 0` fails (FFN M_MM offset `k*blen`).
- `just test-aten-flash-attention` → `narrow(start=512)` out of range (QK^T `kt*blen*mlen` into a whole-tile BTMM), then the P@V M_MM.

## Fixes

| Area | File | Change |
|---|---|---|
| FFN | `program_tensors.py` | Force `use_loop_instructions=False` → the row-granular unrolled path. The C_LOOP path advanced the M_MM weight pointer by `+blen`. |
| Attention P@V | `isa_attention.py` `_pv_multiply_asm` | V weight (M_MM operand) column advances `blen → blen*mlen`; PV output column stays `+blen` (packed). |
| Attention QK^T | `program_attention.py` `_emit_packed_qkt_to_s` | Emit ONE whole-tile `M_BTMM` per head-group instead of kv-tiling with `kt*blen*mlen` offsets the whole-tile decode can't map. |

The emulator counterpart (`MatrixMachine::mm` row-granular decode) is in PLENA_Simulator PR #91.

## Validation (transactional emulator, MLEN≤64)

- **aten-quick — all 12 cells pass**: softmax, linear, rms-norm, layer-norm, ffn, flash-attention, embedding-add, rope (incl. mlen16/blen4 and mlen64/blen16/batch2).
- **routed-moe — all 6 recipes pass** (topk, clamp, activation, gate-up, expert, combine).
- **gpt_oss `real_layer0` passes end-to-end** (emu vs Golden-B < 2%).
- Compiler unit tests: **30 pass** (2 failures are unrelated `AICrossSim/clm-60m` model-download/permission errors).

## Caveats / follow-ups

- **QK^T whole-tile is validated for `seq_len ≤ MLEN`** (single KV tile). Longer sequences (multi-tile KV) need higher-level tiling — harden before enabling.
- **FFN fix is a stopgap** (always unrolls → larger code for big models). The proper fix decouples the weight-col stride (`blen*mlen`) from the packed output-col stride (`blen`) so the C_LOOP path stays available.
- **packed-skinny** (`vram_sub_projection_packed_skinny*`, routed-MoE opt-in) is inherently incompatible with row-granular reads and should be gated off under this ABI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)