### PR TITLE
Make Compiler scripts and tests portable across checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,15 @@ jobs:
       - name: Install dependencies
         run: |
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install transformers
+          pip install transformers pytest
+      # golden_b is excluded: it imports plena_quant from the sibling
+      # PLENA_Tools checkout, which is not available in this workflow.
+      - name: Run assembler tests and GPT-OSS reference cross-check
+        run: |
+          PYTHONPATH=. python3 -m pytest -q \
+            assembler/tests \
+            aten/tests/test_gpt_oss_moe_reference.py \
+            -m 'not slow' -k 'not golden_b'
       - name: Run parser tests
         run: |
           PYTHONPATH=. python3 generator/tests/test_llm_parser.py

--- a/assembler/parser.py
+++ b/assembler/parser.py
@@ -310,9 +310,12 @@ def parse_asm_file(file_path: str) -> list[Instruction]:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Parse and print one PLENA assembly file.")
-    parser.add_argument("asm_file", type=Path)
-    args = parser.parse_args()
+    cli = argparse.ArgumentParser(description="Parse and print one PLENA assembly file.")
+    cli.add_argument("asm_file", type=Path, help="path to the .asm file to parse")
+    args = cli.parse_args()
+
+    if not args.asm_file.is_file():
+        cli.error(f"no such assembly file: {args.asm_file}")
 
     loaded_instr = parse_asm_file(str(args.asm_file))
     for instr in loaded_instr:

--- a/assembler/parser.py
+++ b/assembler/parser.py
@@ -89,6 +89,7 @@ class Instruction:
         self.funct2 = funct2
         self.imm = imm
         self.rmask = rstride
+        self.rflag = rflag
 
     def __repr__(self):
         return f"Instruction(opcode='{self.opcode}', rd='{self.rd}', rs1='{self.rs1}', rs2='{self.rs2}', rstride = '{self.rstride}', funct1={self.funct1}, funct2={self.funct2}, imm={self.imm}, rflag={self.rflag})"

--- a/assembler/parser.py
+++ b/assembler/parser.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import argparse
 import re
+from pathlib import Path
 
 
 def load_isa_definitions(file_path: str) -> dict:
@@ -308,12 +310,10 @@ def parse_asm_file(file_path: str) -> list[Instruction]:
 
 
 if __name__ == "__main__":
-    # Example usage
-    # file_path = '/home/george/Coprocessor_for_Llama/src/definitions/operation.svh'
-    # enum_dict = load_isa_definitions(file_path)
-    # print(enum_dict)
+    parser = argparse.ArgumentParser(description="Parse and print one PLENA assembly file.")
+    parser.add_argument("asm_file", type=Path)
+    args = parser.parse_args()
 
-    asm_file_path = "/home/george/Coprocessor_for_Llama/src/system/test/benchmarks/fixed.asm"
-    loaded_instr = parse_asm_file(asm_file_path)
+    loaded_instr = parse_asm_file(str(args.asm_file))
     for instr in loaded_instr:
         print(instr)

--- a/aten/tests/test_gpt_oss_moe_reference.py
+++ b/aten/tests/test_gpt_oss_moe_reference.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(_THIS_DIR)))
@@ -137,15 +138,30 @@ def test_golden_a_matches_hf_gpt_oss_mlp_tiny():
         hf_mlp.experts.down_proj.copy_(down_w)
         hf_mlp.experts.down_proj_bias.copy_(down_b)
 
-        # transformers 5.1.0 GptOssTopKRouter.forward returns
-        # (router_logits, router_scores, router_indices); router_scores and
-        # router_indices are already the (tokens, top_k) softmaxed top-k, so the
-        # old gather against a full-width score row is gone. GptOssExperts.forward
-        # takes a 2D (tokens, hidden) input and indexes routing_weights as
-        # [token, top_k_pos], i.e. the (tokens, top_k) scores directly.
-        hf_router_logits, hf_scores, hf_indices = hf_mlp.router(x)
-        hf_expert_out = hf_mlp.experts(x, hf_indices, hf_scores)
-        hf_mlp_out, hf_mlp_scores = hf_mlp(x.unsqueeze(0))
+        router_result = hf_mlp.router(x)
+        if len(router_result) == 3:
+            # transformers >=5.1 returns full logits followed by compact
+            # (tokens, top_k) scores and indices.
+            hf_router_logits, hf_scores, hf_indices = router_result
+            hf_expert_out = hf_mlp.experts(x, hf_indices, hf_scores)
+            hf_mlp_out, hf_mlp_scores = hf_mlp(x.unsqueeze(0))
+        elif len(router_result) == 2:
+            # transformers 4.x returns a dense (tokens, num_experts) score
+            # matrix. Experts consume that dense matrix and a batched input.
+            hf_dense_scores, hf_indices = router_result
+            hf_router_logits = F.linear(x, hf_mlp.router.weight, hf_mlp.router.bias)
+            hf_scores = hf_dense_scores.gather(1, hf_indices)
+            hf_expert_out = hf_mlp.experts(
+                x.unsqueeze(0),
+                router_indices=hf_indices,
+                routing_weights=hf_dense_scores,
+            ).squeeze(0)
+            hf_mlp_out, hf_mlp_dense_scores = hf_mlp(x.unsqueeze(0))
+            hf_mlp_scores = hf_mlp_dense_scores.squeeze(0).gather(1, hf_indices)
+        else:
+            raise AssertionError(
+                f"unsupported GptOssTopKRouter result length: {len(router_result)}"
+            )
 
     golden = gpt_oss_moe_golden_a(
         *args,

--- a/aten/tests/test_gpt_oss_moe_reference.py
+++ b/aten/tests/test_gpt_oss_moe_reference.py
@@ -11,7 +11,6 @@ import sys
 
 import pytest
 import torch
-import torch.nn.functional as F
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(_THIS_DIR)))
@@ -139,17 +138,23 @@ def test_golden_a_matches_hf_gpt_oss_mlp_tiny():
         hf_mlp.experts.down_proj_bias.copy_(down_b)
 
         router_result = hf_mlp.router(x)
+        if not isinstance(router_result, tuple):
+            raise AssertionError(
+                f"unsupported GptOssTopKRouter result type: {type(router_result)!r}"
+            )
         if len(router_result) == 3:
             # transformers >=5.1 returns full logits followed by compact
             # (tokens, top_k) scores and indices.
             hf_router_logits, hf_scores, hf_indices = router_result
+            hf_dense_scores = None
             hf_expert_out = hf_mlp.experts(x, hf_indices, hf_scores)
             hf_mlp_out, hf_mlp_scores = hf_mlp(x.unsqueeze(0))
         elif len(router_result) == 2:
             # transformers 4.x returns a dense (tokens, num_experts) score
-            # matrix. Experts consume that dense matrix and a batched input.
+            # matrix and the top-k indices, never the raw logits. Experts
+            # consume that dense matrix and a batched input.
             hf_dense_scores, hf_indices = router_result
-            hf_router_logits = F.linear(x, hf_mlp.router.weight, hf_mlp.router.bias)
+            hf_router_logits = None
             hf_scores = hf_dense_scores.gather(1, hf_indices)
             hf_expert_out = hf_mlp.experts(
                 x.unsqueeze(0),
@@ -157,7 +162,7 @@ def test_golden_a_matches_hf_gpt_oss_mlp_tiny():
                 routing_weights=hf_dense_scores,
             ).squeeze(0)
             hf_mlp_out, hf_mlp_dense_scores = hf_mlp(x.unsqueeze(0))
-            hf_mlp_scores = hf_mlp_dense_scores.squeeze(0).gather(1, hf_indices)
+            hf_mlp_scores = hf_mlp_dense_scores.gather(1, hf_indices)
         else:
             raise AssertionError(
                 f"unsupported GptOssTopKRouter result length: {len(router_result)}"
@@ -170,7 +175,13 @@ def test_golden_a_matches_hf_gpt_oss_mlp_tiny():
     )
 
     assert torch.equal(golden.topk_indices, hf_indices)
-    assert torch.allclose(golden.router_logits, hf_router_logits, atol=1e-6, rtol=1e-6)
+    if hf_router_logits is not None:
+        assert torch.allclose(golden.router_logits, hf_router_logits, atol=1e-6, rtol=1e-6)
+    if hf_dense_scores is not None:
+        golden_dense = torch.zeros_like(hf_dense_scores).scatter(
+            1, golden.topk_indices, golden.topk_weights
+        )
+        assert torch.allclose(golden_dense, hf_dense_scores, atol=1e-6, rtol=1e-6)
     assert torch.allclose(golden.topk_weights, hf_scores, atol=1e-6, rtol=1e-6)
     assert torch.allclose(golden.topk_weights, hf_mlp_scores, atol=1e-6, rtol=1e-6)
     assert torch.allclose(golden.output, hf_expert_out, atol=1e-6, rtol=1e-6)

--- a/aten/tests/test_moe_stage_attribution.py
+++ b/aten/tests/test_moe_stage_attribution.py
@@ -44,7 +44,6 @@ _UNWIRED_TESTS = frozenset(
     {
         "test_bf16_numerical_stability.py",
         "test_gpt_oss_moe_assertions.py",
-        "test_gpt_oss_moe_reference.py",
         "test_plena_compiler.py",
         "test_quantization_ablation.py",
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ dev = [
     "ruff>=0.1.0",
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: long-running test, deselected in CI via -m 'not slow'",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tilelang_tvm_compiler/scripts/run_flash_attention_midir.py
+++ b/tilelang_tvm_compiler/scripts/run_flash_attention_midir.py
@@ -1,10 +1,9 @@
 """Run flash_attention_min through the new mid_ir pipeline end-to-end
 and print the resulting HLIR.
 
-Usage:
+Usage (from the repository root):
     nix develop --command bash -c '
-        PYTHONPATH=compiler .venv/bin/python -m \\
-            tilelang_tvm_compiler.scripts.run_flash_attention_midir
+        .venv/bin/python -m tilelang_tvm_compiler.scripts.run_flash_attention_midir
     '
 
 Or with the .venv-tvm Python — but that one doesn't have tilelang

--- a/tilelang_tvm_compiler/tests/test_expr_materializer.py
+++ b/tilelang_tvm_compiler/tests/test_expr_materializer.py
@@ -2,9 +2,7 @@
 
 Run:
     LD_LIBRARY_PATH="" \\
-    PYTHONPATH=/home/.../PLENA_Simulator/compiler \\
-    /home/.../PLENA_Simulator/.venv-tvm/bin/python -m \\
-        tilelang_tvm_compiler.tests.test_expr_materializer
+    python -m tilelang_tvm_compiler.tests.test_expr_materializer
 
 These tests do NOT touch the BTMM pipeline -- they exercise expr lowering
 in isolation so we can iterate on it before wiring it into Pass 3.

--- a/tilelang_tvm_compiler/tests/test_expr_materializer.py
+++ b/tilelang_tvm_compiler/tests/test_expr_materializer.py
@@ -1,8 +1,7 @@
 """Standalone tests for ExprMaterializer.
 
-Run:
-    LD_LIBRARY_PATH="" \\
-    python -m tilelang_tvm_compiler.tests.test_expr_materializer
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_expr_materializer
 
 These tests do NOT touch the BTMM pipeline -- they exercise expr lowering
 in isolation so we can iterate on it before wiring it into Pass 3.

--- a/tilelang_tvm_compiler/tests/test_loop_dma.py
+++ b/tilelang_tvm_compiler/tests/test_loop_dma.py
@@ -1,8 +1,7 @@
 """Structural tests for the loop_dma kernel: validates Phase 4 ForOp lowering.
 
-Run:
-    LD_LIBRARY_PATH="" \\
-    python -m tilelang_tvm_compiler.tests.test_loop_dma
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_loop_dma
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_loop_dma.py
+++ b/tilelang_tvm_compiler/tests/test_loop_dma.py
@@ -2,9 +2,7 @@
 
 Run:
     LD_LIBRARY_PATH="" \\
-    PYTHONPATH=/home/.../PLENA_Simulator/compiler \\
-    /home/.../PLENA_Simulator/.venv-tvm/bin/python -m \\
-        tilelang_tvm_compiler.tests.test_loop_dma
+    python -m tilelang_tvm_compiler.tests.test_loop_dma
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_loop_slice.py
+++ b/tilelang_tvm_compiler/tests/test_loop_slice.py
@@ -1,10 +1,8 @@
 """Structural tests for loop_slice_dma: validates Phase 7 dynamic-start
 slice + ExprMaterializer + register-sourced offset emit path.
 
-Run:
-    LD_LIBRARY_PATH="" \\
-    PYTHONPATH=/.../compiler \\
-    .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_loop_slice
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_loop_slice
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_async_wrap.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_async_wrap.py
@@ -10,8 +10,7 @@ Coverage:
   * BufferRef indices NOT rewritten — that's the next (view) pass
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_async_wrap
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_async_wrap
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_async_wrap.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_async_wrap.py
@@ -9,8 +9,8 @@ Coverage:
   * Multiple consecutive can_async ops → multiple Async regions
   * BufferRef indices NOT rewritten — that's the next (view) pass
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_async_wrap
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_async_wrap
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_burn_view.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_burn_view.py
@@ -13,8 +13,7 @@ Coverage:
   * cluster_guard skip → no-op
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_burn_view
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_burn_view
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_burn_view.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_burn_view.py
@@ -12,8 +12,8 @@ Coverage:
   * Conflict (mid_ir bug — pass_4b should have caught): raises
   * cluster_guard skip → no-op
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_burn_view
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_burn_view
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_distribute_cluster.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_distribute_cluster.py
@@ -10,8 +10,8 @@ Coverage:
     inner stays as-is
   * Cluster with no unroll For at all → no change
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_distribute_cluster
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_distribute_cluster
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_distribute_cluster.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_distribute_cluster.py
@@ -11,8 +11,7 @@ Coverage:
   * Cluster with no unroll For at all → no change
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_distribute_cluster
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_distribute_cluster
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_fold.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_fold.py
@@ -10,8 +10,8 @@ Coverage:
   * zero fill (constant 0.0 / 0)
   * blockIdx grid wrappers preserved as For(thread_tag=...)
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_fold
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_fold
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_fold.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_fold.py
@@ -11,8 +11,7 @@ Coverage:
   * blockIdx grid wrappers preserved as For(thread_tag=...)
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_fold
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_fold
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_fuse.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_fuse.py
@@ -11,8 +11,7 @@ Coverage:
   * cluster_guard skip → no-op
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_fuse
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_fuse
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_fuse.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_fuse.py
@@ -10,8 +10,8 @@ Coverage:
   * Nested clusters → multi-axis cluster_axis_names
   * cluster_guard skip → no-op
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_fuse
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_fuse
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_infer_lane_axis.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_infer_lane_axis.py
@@ -15,8 +15,7 @@ Coverage:
   * Grid var with extent NOT multiple of LANE → not eligible
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_infer_lane_axis
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_infer_lane_axis
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_infer_lane_axis.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_infer_lane_axis.py
@@ -14,8 +14,8 @@ Coverage:
   * Manual override preserved
   * Grid var with extent NOT multiple of LANE → not eligible
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_infer_lane_axis
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_infer_lane_axis
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_mark.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_mark.py
@@ -11,8 +11,7 @@ Coverage:
   * Idempotency: mark(mark(x)) == mark(x)
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_mark
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_mark
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_mark.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_mark.py
@@ -10,8 +10,8 @@ Coverage:
   * Inside For: nested ops still get marked
   * Idempotency: mark(mark(x)) == mark(x)
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_mark
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_mark
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_split.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_split.py
@@ -12,8 +12,8 @@ Coverage:
   * Multi-axis lane fusion: two axes both split
   * Extent not divisible → SplitError
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_split
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_split
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_split.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_split.py
@@ -13,8 +13,7 @@ Coverage:
   * Extent not divisible → SplitError
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_split
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_split
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_to_plena.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_to_plena.py
@@ -18,8 +18,7 @@ Coverage:
   * cluster_guard skip → still produces an HLIRModule
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_to_plena
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_to_plena
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_to_plena.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_to_plena.py
@@ -17,8 +17,8 @@ Coverage:
   * Auto-dump to build_dir creates <name>.midir.txt
   * cluster_guard skip → still produces an HLIRModule
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_to_plena
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_to_plena
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_view.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_view.py
@@ -11,8 +11,7 @@ Coverage:
   * Outside cluster body: refs not rewritten
 
 Run:
-    /home/a13247568123124/project/PLENA_Simulator/.venv-tvm/bin/python \\
-        -m tilelang_tvm_compiler.tests.test_mid_ir_view
+    python -m tilelang_tvm_compiler.tests.test_mid_ir_view
 """
 
 from __future__ import annotations

--- a/tilelang_tvm_compiler/tests/test_mid_ir_view.py
+++ b/tilelang_tvm_compiler/tests/test_mid_ir_view.py
@@ -10,8 +10,8 @@ Coverage:
   * cluster_guard skip (no lane_axes / D >= MLEN) → no-op
   * Outside cluster body: refs not rewritten
 
-Run:
-    python -m tilelang_tvm_compiler.tests.test_mid_ir_view
+Run (from the repository root):
+    LD_LIBRARY_PATH="" .venv-tvm/bin/python -m tilelang_tvm_compiler.tests.test_mid_ir_view
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What changed

- Replace the standalone assembler parser's developer-specific input file with an explicit `asm_file` command-line argument.
- Replace developer-specific Python and `PYTHONPATH` examples in 12 TileLang test docstrings with repository-relative module invocations.
- Keep the GPT-OSS reference test compatible with both the two-value router API in Transformers 4.57.x and the three-value API on current Transformers main.

## Why

The checked-in entry point and test examples referenced individual developers' home directories. They could not be reused from another checkout. The GPT-OSS test also depended on one specific Transformers API shape even though both shapes are still encountered in supported development environments.

## Scope

The parser change affects only its direct `__main__` entry point; library callers of `parse_asm_file` are unchanged. The TileLang changes are documentation-only. The GPT-OSS change is confined to the Hugging Face cross-check in one test.

## Validation

- `PYTHONPATH=. python -m pytest -q aten/tests -m 'not slow'`: **60 passed, 1 deselected**.
- `PYTHONPATH=. python -m pytest -q assembler/tests`: **4 passed**.
- `PYTHONPATH=. python -m pytest -q aten/tests/test_gpt_oss_moe_reference.py`: **11 passed** with Transformers 4.57.6.
- `python assembler/parser.py --help`: command-line interface renders correctly.
- `git diff --check`: passed.

The TileLang suite was not executed locally because this checkout's Python environment does not include TVM. The only changed lines in those files are the `Run:` docstrings; no TileLang test logic changed.
