### PR TITLE
MoE: required `stage` argument, a lint that runs, and two attribution fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,24 @@ jobs:
           fi
           echo "All Python files parse OK"
 
+  # Deliberately not `needs: syntax-check`: this reads sources with `ast` and
+  # finishes in seconds, so there is no reason to queue it behind anything.
+  moe-stage-guard:
+    name: MoE stage-attribution guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # No torch and no checkpoint: the guard only parses source. pyyaml is
+      # needed solely because collecting anything under `aten/tests/` imports
+      # `aten/__init__.py`, which pulls in the op registry.
+      - name: Install dependencies
+        run: pip install pytest pyyaml
+      - name: Run the stage-attribution guard
+        run: PYTHONPATH=. python3 -m pytest aten/tests/test_moe_stage_attribution.py -v
+
   unit-tests:
     name: Generator unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
 on:
+  # Stacked branches target a parent branch rather than main, so the
+  # pull_request trigger below never fires for them. Manual dispatch is what
+  # lets a stacked PR's guards be run before it retargets main.
+  workflow_dispatch:
   pull_request:
     branches: [main]
   push:

--- a/assembler/assembly_to_binary.py
+++ b/assembler/assembly_to_binary.py
@@ -39,9 +39,7 @@ _IMM_RS1_RD_OPS = frozenset(
 )
 _IMM_RD_OPS = frozenset({"S_LUI_INT", "M_MV_WO", "M_BMM_WO", "M_BMV_WO"})
 _RS1_RD_OPS = frozenset({"S_MV_FP", "S_RECI_FP", "S_EXP_FP", "S_SQRT_FP", "V_EXP_V", "V_RED_SUM"})
-_RD_ONLY_OPS = frozenset(
-    {"C_SET_SCALE_REG", "C_SET_STRIDE_REG", "C_SET_V_MASK_REG", "C_SET_TOPK_REG", "C_LOOP_END"}
-)
+_RD_ONLY_OPS = frozenset({"C_SET_SCALE_REG", "C_SET_STRIDE_REG", "C_SET_V_MASK_REG", "C_SET_TOPK_REG", "C_LOOP_END"})
 _FUNCT_RSTRIDE_OPS = frozenset({"H_PREFETCH_M", "H_PREFETCH_V", "H_STORE_V", "V_SUB_VF"})
 _RS2_RS1_RD_OPS = frozenset(
     {

--- a/assembler/assembly_to_binary.py
+++ b/assembler/assembly_to_binary.py
@@ -39,7 +39,9 @@ _IMM_RS1_RD_OPS = frozenset(
 )
 _IMM_RD_OPS = frozenset({"S_LUI_INT", "M_MV_WO", "M_BMM_WO", "M_BMV_WO"})
 _RS1_RD_OPS = frozenset({"S_MV_FP", "S_RECI_FP", "S_EXP_FP", "S_SQRT_FP", "V_EXP_V", "V_RED_SUM"})
-_RD_ONLY_OPS = frozenset({"C_SET_SCALE_REG", "C_SET_STRIDE_REG", "C_SET_V_MASK_REG", "C_LOOP_END"})
+_RD_ONLY_OPS = frozenset(
+    {"C_SET_SCALE_REG", "C_SET_STRIDE_REG", "C_SET_V_MASK_REG", "C_SET_TOPK_REG", "C_LOOP_END"}
+)
 _FUNCT_RSTRIDE_OPS = frozenset({"H_PREFETCH_M", "H_PREFETCH_V", "H_STORE_V", "V_SUB_VF"})
 _RS2_RS1_RD_OPS = frozenset(
     {

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from compiler.aten.plena.isa_compiler import IsaCompiler
 from compiler.aten.plena.program_attention import ProgramAttentionMixin
 from compiler.aten.plena.program_fp_tile_ops import ProgramFPTileOpsMixin
+from compiler.aten.plena.program_moe_shared import ProgramMoeSharedMixin
 from compiler.aten.plena.program_routed_moe import ProgramRoutedMoeMixin
 from compiler.aten.plena.program_matrix_ops import ProgramMatrixOpsMixin
 from compiler.aten.plena.program_tensors import ProgramTensorMixin
@@ -58,6 +59,9 @@ class PlenaCompiler(
     ProgramFPTileOpsMixin,
     ProgramMatrixOpsMixin,
     ProgramRoutedMoeMixin,
+    # After ProgramRoutedMoeMixin: the shared-expert emitters call into the routed
+    # substrate (moe_expert_activation_v0, moe_materialize_route_weights_*).
+    ProgramMoeSharedMixin,
     ProgramAttentionMixin,
     IsaCompiler,
 ):

--- a/aten/plena/program_moe_shared.py
+++ b/aten/plena/program_moe_shared.py
@@ -39,11 +39,8 @@ profile cannot answer what fraction of MoE time is architecturally dense.
 (token, expert) pair at a time in a BLEN-row slot, re-fetching expert weights per
 pair -- ``moe_gather_token_rows_from_hbm_v0`` calls this "intentionally wasteful
 but keeps the first L2 correctness path exact". The shared path has no such
-constraint and runs as a plain batched projection over all rows. A shared-vs-routed
-cycle ratio measured today therefore reflects *the routed lowering's per-pair
-overhead* at least as much as it reflects the architecture. It is a valid
-measurement of this compiler's output; it is not a statement about MoE hardware in
-general.
+constraint. :data:`SHARED_VS_ROUTED_NOTE` states the consequence, and is the
+canonical wording that travels with the measurement into the profile JSON.
 """
 
 from __future__ import annotations
@@ -58,6 +55,26 @@ from compiler.aten.plena.program_routed_moe import (
     moe_stage_marker,
 )
 from compiler.aten.plena.vars import FPVar, VRAMMatrixVar
+
+#: The caveat that has to travel with any shared-vs-routed ratio.
+#:
+#: Canonical here, and carried into the emulator's stage-profile JSON, where
+#: consumers actually read it. `SHARED_VS_ROUTED_NOTE` in
+#: `transactional_emulator/src/stage_profile.rs` holds the same text, and a test
+#: there parses this constant and asserts the two are byte-identical.
+#:
+#: Two failure modes, not one. A caveat that lives only in compiler source is a
+#: caveat nobody applies, since the JSON is what gets read. A caveat restated by
+#: hand in two repositories is one that quietly stops matching. Declaring it once
+#: and checking the copy is what avoids both.
+SHARED_VS_ROUTED_NOTE = (
+    "The routed lowering processes one (token, expert) pair per BLEN-row slot "
+    "and re-fetches expert weights per pair, while the shared expert runs as a "
+    "plain batched projection over all rows. A shared-vs-routed cycle ratio "
+    "therefore reflects the routed lowering's per-pair overhead at least as "
+    "much as it reflects the architecture. It is a valid measurement of this "
+    "compiler's output; it is not a statement about MoE hardware in general."
+)
 
 
 def fused_shared_intermediate(moe_intermediate_size: int, n_shared_experts: int) -> int:

--- a/aten/plena/program_moe_shared.py
+++ b/aten/plena/program_moe_shared.py
@@ -1,0 +1,340 @@
+"""Shared-expert MoE program-builder helpers.
+
+A *shared* expert is an FFN every token passes through, running alongside the
+routed experts and summed into the same output:
+
+    y = shared(x) + sum_k route_weight_k * routed_expert_k(x)
+
+Architectures that use one:
+
+===================================  =========  ======================  =========
+model                                n_shared   shared intermediate     gate
+===================================  =========  ======================  =========
+DeepSeek-V2 / V3, Kimi K2            1-2        moe_inter * n_shared    none
+Qwen2-MoE (A2.7B / A14B)             1          independent             sigmoid
+Llama-4 Scout / Maverick             1          == routed               none
+GLM-4.5, Qwen3-Next                  1          independent             none
+GPT-OSS, Qwen3-MoE, Mixtral          0          --                      --
+===================================  =========  ======================  =========
+
+``n_shared`` is deliberately not a parameter here. DeepSeek stores its shared
+experts pre-concatenated and builds a *single* MLP of width
+``moe_intermediate_size * n_shared_experts`` -- so the count is a checkpoint
+loading concern, not an emission one. :func:`fused_shared_intermediate` makes that
+conversion explicit rather than leaving callers to rediscover it.
+
+Cost shape, and why it is worth measuring separately
+----------------------------------------------------
+The shared expert is dense over every token, so its cost is
+``rows * (2*hidden*inter_s + inter_s*hidden)`` regardless of routing, while the
+routed branch scales with ``rows * top_k``. Its weights are also *hot* -- every
+token needs them -- so unlike routed weights they do not have to be re-fetched
+per (token, expert) pair.
+
+That last difference is why these emitters bill to their own stages
+(``shared_expert_*``) rather than reusing the routed ones: without the split, the
+profile cannot answer what fraction of MoE time is architecturally dense.
+
+**Read the resulting split with care.** The routed path here processes one
+(token, expert) pair at a time in a BLEN-row slot, re-fetching expert weights per
+pair -- ``moe_gather_token_rows_from_hbm_v0`` calls this "intentionally wasteful
+but keeps the first L2 correctness path exact". The shared path has no such
+constraint and runs as a plain batched projection over all rows. A shared-vs-routed
+cycle ratio measured today therefore reflects *the routed lowering's per-pair
+overhead* at least as much as it reflects the architecture. It is a valid
+measurement of this compiler's output; it is not a statement about MoE hardware in
+general.
+"""
+
+from __future__ import annotations
+
+import math
+
+from compiler.aten.isa_builder import IsaBuilder, fp, gp
+from compiler.aten.plena.program_routed_moe import (
+    ExpertBiases,
+    ExpertWeights,
+    GptOssFPConstants,
+    moe_stage_marker,
+)
+from compiler.aten.plena.vars import FPVar, VRAMMatrixVar
+
+
+def fused_shared_intermediate(moe_intermediate_size: int, n_shared_experts: int) -> int:
+    """Width of the single MLP that stands in for ``n_shared_experts`` shared experts.
+
+    DeepSeek-V2/V3 do not run their shared experts separately; ``DeepseekV2MoE``
+    instantiates one ``DeepseekV2MLP`` of width
+    ``moe_intermediate_size * n_shared_experts`` whose weights are the shared
+    experts concatenated along the intermediate axis. Because SwiGLU is applied
+    elementwise along that axis and the down projection sums over it, the fused
+    MLP is exactly equal to the sum of the individual shared experts -- no
+    approximation.
+    """
+    if n_shared_experts < 1:
+        raise ValueError(f"n_shared_experts must be >= 1, got {n_shared_experts}")
+    if moe_intermediate_size < 1:
+        raise ValueError(f"moe_intermediate_size must be >= 1, got {moe_intermediate_size}")
+    return moe_intermediate_size * n_shared_experts
+
+
+class ProgramMoeSharedMixin:
+    """Shared-expert emit helpers layered on the routed-MoE substrate."""
+
+    def moe_shared_gate_v0(
+        self,
+        x: VRAMMatrixVar,
+        gate_weight_row: VRAMMatrixVar,
+        *,
+        rows: int,
+        hidden: int,
+        constants: GptOssFPConstants,
+        gate_fp_scratch: FPVar | None = None,
+        zero_row: FPVar | None = None,
+        policy_name: str = "qwen2_moe",
+        name: str = "moe_shared_gate",
+    ) -> VRAMMatrixVar:
+        """Emit Qwen2-MoE's ``sigmoid(x @ w_gate)`` shared-expert gate.
+
+        ``gate_weight_row`` holds the ``[hidden, 1]`` gate projection stored as a
+        single BF16 VRAM row of length ``hidden``, so the per-token projection is a
+        dot product rather than a matmul. Going through the matrix path would mean
+        padding a one-column weight out to MLEN and discarding 63/64 of the result.
+
+        Returns a ``[rows, hidden]`` VRAM matrix holding each token's scalar gate
+        broadcast across the hidden axis, ready to multiply the shared expert
+        output. That is the same shape and mechanism the routed branch uses for
+        route weights, so the two are combined identically downstream.
+
+        The sigmoid is evaluated in the scalar FP unit
+        (``S_SUB_FP`` / ``S_EXP_FP`` / ``S_ADD_FP`` / ``S_RECI_FP``) on one value
+        per token, not as a vector pass over a broadcast row -- there is exactly one
+        gate scalar per token, and the vector form would compute MLEN copies of it.
+        """
+        if hidden % self.mlen != 0:
+            raise ValueError(f"{name}: hidden={hidden} must be divisible by MLEN={self.mlen}")
+        if rows > x.physical_shape[0]:
+            raise ValueError(f"{name}: rows={rows} exceeds x physical rows={x.physical_shape[0]}")
+        if hidden > x.shape[1]:
+            raise ValueError(f"{name}: hidden={hidden} exceeds x width={x.shape[1]}")
+        if gate_weight_row.shape[1] < hidden:
+            raise ValueError(
+                f"{name}: gate_weight_row width={gate_weight_row.shape[1]} is narrower than hidden={hidden}"
+            )
+        _zero, _limit_pos, _limit_neg, one, _neg = constants
+
+        scratch = self.alloc(
+            f"{name}_dot_scratch",
+            rows=1,
+            cols=self.mlen,
+            strict=False,
+            physical_shape=(1, self.mlen),
+        )
+        gate_scalars = gate_fp_scratch or self.fp_var(f"{name}_scalars", size=rows)
+        if gate_scalars.size < rows:
+            raise ValueError(f"{name}: gate scratch size={gate_scalars.size} is smaller than rows={rows}")
+
+        k_blocks = hidden // self.mlen
+        x_step = x.physical_shape[0] * self.mlen
+        w_step = gate_weight_row.physical_shape[0] * self.mlen
+
+        gp_x, gp_w, gp_scratch, gp_out, gp_loop = self._reg.allocate_gp(5)
+        fp_acc, fp_one, fp_tmp = self.allocate_fp_reg(3)
+        try:
+            asm = IsaBuilder().comment(
+                moe_stage_marker(
+                    "shared_expert_gate",
+                    f"[{policy_name}] {name}: rows={rows}, hidden={hidden}",
+                )
+            )
+            asm.instr("S_ADDI_INT", gp(gp_scratch), gp(0), self.get_vram_addr(scratch.name))
+            # 1.0 is loop-invariant; hoist the load out of the token loop.
+            asm.instr("S_ADDI_INT", gp(gp_out), gp(0), one.address)
+            asm.instr("S_LD_FP", fp(fp_one), gp(gp_out), 0)
+
+            for token_idx in range(rows):
+                asm.comment(f"shared gate token {token_idx}")
+                asm.instr("S_ADD_FP", fp(fp_acc), fp(0), fp(0))
+                asm.instr("S_ADDI_INT", gp(gp_x), gp(0), self._vram_matrix_row_addr(x, token_idx, 0))
+                asm.instr("S_ADDI_INT", gp(gp_w), gp(0), self._vram_matrix_row_addr(gate_weight_row, 0, 0))
+                asm.instr("C_LOOP_START", gp(gp_loop), k_blocks)
+                asm.instr("V_MUL_VV", gp(gp_scratch), gp(gp_x), gp(gp_w), 0)
+                asm.instr("V_RED_SUM", fp(fp_acc), gp(gp_scratch), 0, 0)
+                asm.instr("S_ADDI_INT", gp(gp_x), gp(gp_x), x_step)
+                asm.instr("S_ADDI_INT", gp(gp_w), gp(gp_w), w_step)
+                asm.instr("C_LOOP_END", gp(gp_loop))
+
+                # sigmoid(acc) = 1 / (1 + exp(-acc)). fp register 0 reads as zero, so
+                # the negation is a subtract rather than a multiply by a -1 constant
+                # the caller would otherwise have to preload.
+                asm.instr("S_SUB_FP", fp(fp_tmp), fp(0), fp(fp_acc))
+                asm.instr("S_EXP_FP", fp(fp_tmp), fp(fp_tmp))
+                asm.instr("S_ADD_FP", fp(fp_tmp), fp(fp_tmp), fp(fp_one))
+                asm.instr("S_RECI_FP", fp(fp_tmp), fp(fp_tmp))
+                asm.instr("S_ADDI_INT", gp(gp_out), gp(0), gate_scalars.address + token_idx)
+                asm.instr("S_ST_FP", fp(fp_tmp), gp(gp_out), 0)
+            self._emit(asm)
+        finally:
+            self.free_fp_reg([fp_acc, fp_one, fp_tmp])
+            self._reg.free_gp([gp_x, gp_w, gp_scratch, gp_out, gp_loop])
+
+        # Broadcasting one FP scalar per row across `hidden` is exactly what the
+        # routed branch does with V_TOPK route weights, so reuse that emitter
+        # instead of growing a second copy of the S_MAP_V_FP loop. It bills to the
+        # stage it is told to: re-marking *after* the call would be too late, since
+        # markers are sticky forwards and the whole broadcast would already have
+        # been attributed to `expert_route_weight`.
+        return self.moe_materialize_route_weights_for_active_rows_v0(
+            weights_fp_base=gate_scalars.address,
+            pair_indices=list(range(rows)),
+            active_rows=list(range(rows)),
+            rows=rows,
+            hidden=hidden,
+            zero_row=zero_row,
+            policy_name=policy_name,
+            stage="shared_expert_gate",
+            name=f"{name}_broadcast",
+        )
+
+    def moe_shared_expert_v0(
+        self,
+        x: VRAMMatrixVar,
+        weights: ExpertWeights,
+        *,
+        biases: ExpertBiases | None = None,
+        rows: int,
+        intermediate: int,
+        constants: GptOssFPConstants,
+        gate_weight_row: VRAMMatrixVar | None = None,
+        gate_fp_scratch: FPVar | None = None,
+        zero_row: FPVar | None = None,
+        activation_policy: str = "standard_swiglu",
+        policy_name: str = "deepseek_moe",
+        name: str = "moe_shared_expert",
+    ) -> VRAMMatrixVar:
+        """Emit the shared expert over **all** ``rows`` tokens and return its output.
+
+        Unlike :meth:`moe_dynamic_expert_pair_v0` this takes a static
+        :class:`InputVar` weight triple: the shared expert is the same for every
+        token, so there is no expert id to resolve, no ``C_SET_ADDR_REG`` dance, and
+        no per-pair HBM base computation. It is an ordinary batched projection.
+
+        ``gate_weight_row`` turns on the Qwen2-MoE sigmoid gate. Leave it ``None``
+        for DeepSeek, Llama-4 and GLM, which add the shared output unweighted.
+        """
+        if rows < 1:
+            raise ValueError(f"{name}: rows must be positive, got {rows}")
+        if intermediate % self.mlen != 0:
+            raise ValueError(f"{name}: intermediate={intermediate} must be divisible by MLEN={self.mlen}")
+        w_gate, w_up, w_down = weights
+        gate_bias, up_bias, down_bias = biases or (None, None, None)
+
+        # Matches the routed path: the K-split projection accumulates with a
+        # 64x64 block add, so keep outputs tile-backed rather than letting a
+        # short row count leave the block add walking into the next column block.
+        projection_rows = max(self.mlen, x.physical_shape[0], math.ceil(rows / self.blen) * self.blen)
+
+        self._emit(
+            IsaBuilder().comment(
+                moe_stage_marker(
+                    "shared_expert_projection",
+                    f"[{policy_name}] {name} gate/up: rows={rows}, intermediate={intermediate}",
+                )
+            )
+        )
+        gate = self.linear_projection(
+            x,
+            w_gate,
+            name=f"{name}_gate",
+            physical_shape=(projection_rows, w_gate.physical_shape[1]),
+        )
+        up = self.linear_projection(
+            x,
+            w_up,
+            name=f"{name}_up",
+            physical_shape=(projection_rows, w_up.physical_shape[1]),
+        )
+        if gate_bias is not None:
+            self.vram_add(gate, gate_bias, num_rows=rows)
+        if up_bias is not None:
+            self.vram_add(up, up_bias, num_rows=rows)
+
+        hidden = self.moe_expert_activation_v0(
+            gate,
+            up,
+            rows=rows,
+            intermediate=intermediate,
+            constants=constants,
+            activation_policy=activation_policy,
+            policy_name=policy_name,
+            stage="shared_expert_activation",
+            name=name,
+        )
+
+        self._emit(
+            IsaBuilder().comment(
+                moe_stage_marker("shared_expert_projection", f"[{policy_name}] {name} down: rows={rows}")
+            )
+        )
+        out = self.linear_projection(
+            hidden,
+            w_down,
+            name=f"{name}_out",
+            physical_shape=(projection_rows, w_down.physical_shape[1]),
+        )
+        if down_bias is not None:
+            self.vram_add(out, down_bias, num_rows=rows)
+
+        if gate_weight_row is not None:
+            gate_matrix = self.moe_shared_gate_v0(
+                x,
+                gate_weight_row,
+                rows=rows,
+                hidden=w_down.physical_shape[1],
+                constants=constants,
+                gate_fp_scratch=gate_fp_scratch,
+                zero_row=zero_row,
+                policy_name=policy_name,
+                name=f"{name}_gate_sigmoid",
+            )
+            self.vram_mul(out, gate_matrix, num_rows=rows)
+        return out
+
+    def moe_combine_shared_and_routed_v0(
+        self,
+        accumulator: VRAMMatrixVar,
+        shared_out: VRAMMatrixVar,
+        *,
+        rows: int,
+        policy_name: str = "deepseek_moe",
+        name: str = "moe_shared_combine",
+    ) -> VRAMMatrixVar:
+        """Add the shared-expert output into the routed accumulator in place.
+
+        Thin over :meth:`vram_add`, but it exists rather than being inlined at the
+        call site so the combine is attributed to ``scatter_combine`` instead of
+        inheriting whichever stage the caller happened to leave live. Under
+        marker-authoritative classification an unmarked helper is billed to the
+        previous marker, which here would be ``shared_expert_projection`` -- making
+        the shared branch look more expensive than it is.
+
+        The shared output is added *unweighted*: no architecture scales it by a
+        route weight. Qwen2-MoE's sigmoid gate is already folded into
+        ``shared_out`` by :meth:`moe_shared_expert_v0`.
+        """
+        if accumulator.physical_shape[1] != shared_out.physical_shape[1]:
+            raise ValueError(
+                f"{name}: accumulator width={accumulator.physical_shape[1]} does not match "
+                f"shared output width={shared_out.physical_shape[1]}"
+            )
+        if rows > accumulator.physical_shape[0]:
+            raise ValueError(f"{name}: rows={rows} exceeds accumulator rows={accumulator.physical_shape[0]}")
+        self._emit(IsaBuilder().comment(moe_stage_marker("scatter_combine", f"[{policy_name}] {name}: rows={rows}")))
+        self.vram_add(accumulator, shared_out, num_rows=rows)
+        return accumulator
+
+
+__all__ = [
+    "ProgramMoeSharedMixin",
+    "fused_shared_intermediate",
+]

--- a/aten/plena/program_moe_shared.py
+++ b/aten/plena/program_moe_shared.py
@@ -85,8 +85,24 @@ def fused_shared_intermediate(moe_intermediate_size: int, n_shared_experts: int)
     ``moe_intermediate_size * n_shared_experts`` whose weights are the shared
     experts concatenated along the intermediate axis. Because SwiGLU is applied
     elementwise along that axis and the down projection sums over it, the fused
-    MLP is exactly equal to the sum of the individual shared experts -- no
-    approximation.
+    MLP equals the sum of the individual shared experts **in exact real
+    arithmetic**. The fusion is an algebraic identity, not an approximation.
+
+    It is not bit-identical as emitted, for two separate reasons:
+
+    - The down projection reduces over the whole concatenated axis in one pass,
+      where the unfused form does ``n_shared_experts`` reductions and adds the
+      results. Floating-point addition is not associative, so the roundings
+      differ even in a format with no quantisation involved.
+    - Expert weights are stored MXFP8 (e4m3 elements, one e8m0 scale per block
+      of 8 along that axis). If ``moe_intermediate_size`` is not a multiple of
+      that block, the fused tensor's blocks straddle expert boundaries, so a
+      block's scale is chosen from values belonging to two different experts and
+      the quantised weights themselves differ -- not just their sum.
+
+    Both are small, and neither makes the fusion wrong. But "exactly equal" is a
+    claim about the emitted program that the emitted program does not make, and
+    a bit-exactness test written against it would fail for correct reasons.
     """
     if n_shared_experts < 1:
         raise ValueError(f"n_shared_experts must be >= 1, got {n_shared_experts}")

--- a/aten/plena/program_routed_moe.py
+++ b/aten/plena/program_routed_moe.py
@@ -12,6 +12,102 @@ GptOssFPConstants = tuple[FPVar, FPVar, FPVar, FPVar, FPVar]
 ExpertWeights = tuple[InputVar, InputVar, InputVar]
 ExpertBiases = tuple[VRAMMatrixVar | None, VRAMMatrixVar | None, VRAMMatrixVar | None]
 
+# ============================================================================
+# Stage markers
+# ============================================================================
+
+#: Prefix of the explicit stage marker comment. The emulator's stage profiler
+#: (``transactional_emulator/src/stage_profile.rs``) keys on this exact string.
+MOE_STAGE_MARKER_PREFIX = "@stage="
+
+#: Every stage name the emulator's ``StageKind`` understands.
+#:
+#: This exists because stage attribution used to be an *undeclared* cross-repo
+#: contract: the emulator substring-matched prose like ``"GPT-OSS gather token
+#: rows"`` out of the emitted comments. Any rewording here silently reclassified
+#: instructions, and there was no way at all to introduce a stage the substring
+#: table did not already know about -- which is what made shared experts
+#: unmeasurable before this module gained them.
+#:
+#: Marker emission is validated against this set, so a typo fails at ASM-gen time
+#: instead of quietly collapsing a region into ``other``.
+MOE_STAGES: frozenset[str] = frozenset(
+    {
+        "router_topk",
+        "accumulator_init",
+        "gather",
+        "expert_weight_address",
+        "expert_weight_prefetch",
+        "expert_projection",
+        "expert_activation",
+        "expert_bias",
+        "expert_route_weight",
+        "scatter_combine",
+        "shared_expert_projection",
+        "shared_expert_activation",
+        "shared_expert_gate",
+    }
+)
+
+
+# ============================================================================
+# V_TOPK routing policy
+# ============================================================================
+
+#: ``rmask`` value that makes V_TOPK read its shape from ``C_SET_TOPK_REG``
+#: instead of the two-entry hardwired table.
+_TOPK_POLICY_REGISTER_RMASK = 15
+
+#: Bit position of ``num_experts`` inside the packed ``C_SET_TOPK_REG`` value.
+#: Must match ``AcceleratorRegFile::topk_policy`` in the emulator.
+_TOPK_POLICY_EXPERT_SHIFT = 8
+
+#: Widest packed policy that still fits one ``S_ADDI_INT`` 22-bit immediate.
+_TOPK_POLICY_MAX_PACKED = (1 << 22) - 1
+
+
+def _pack_topk_policy(num_experts: int, top_k: int) -> int:
+    """Pack ``(num_experts, top_k)`` for ``C_SET_TOPK_REG``.
+
+    Layout is ``(num_experts << 8) | top_k``. The emulator unpacks it in
+    ``AcceleratorRegFile::topk_policy``; nothing but the unit tests on either side
+    checks that the two agree, so the bounds are asserted here rather than left to
+    produce a silently truncated policy.
+    """
+    if not 0 < top_k <= num_experts:
+        raise ValueError(f"top_k={top_k} must be in [1, num_experts={num_experts}]")
+    if top_k >= (1 << _TOPK_POLICY_EXPERT_SHIFT):
+        raise ValueError(
+            f"top_k={top_k} does not fit {_TOPK_POLICY_EXPERT_SHIFT} bits; the C_SET_TOPK_REG packing bounds it at 255"
+        )
+    packed = (num_experts << _TOPK_POLICY_EXPERT_SHIFT) | top_k
+    if packed > _TOPK_POLICY_MAX_PACKED:
+        raise ValueError(
+            f"num_experts={num_experts} packs to {packed}, past the 22-bit S_ADDI_INT "
+            f"immediate; C_SET_TOPK_REG tops out at {_TOPK_POLICY_MAX_PACKED >> _TOPK_POLICY_EXPERT_SHIFT} experts"
+        )
+    return packed
+
+
+def moe_stage_marker(stage: str, detail: str = "") -> str:
+    """Format the explicit stage marker comment for ``stage``.
+
+    The marker is *authoritative and sticky*: once a program contains any marker,
+    the emulator stops applying its legacy substring rules entirely and every
+    instruction is attributed to the most recent marker. So a marker must be
+    emitted whenever the stage changes, and must not be emitted mid-stage.
+
+    The corollary is that work done inside a general-purpose helper called from a
+    marked region -- ``linear_projection``'s HBM weight prefetch, for instance --
+    is attributed to the enclosing marker rather than to
+    ``expert_weight_prefetch``. That is why the routed path marks its own dynamic
+    prefetch explicitly; the shared path deliberately does not, folding weight
+    traffic into ``shared_expert_projection`` where it belongs.
+    """
+    if stage not in MOE_STAGES:
+        raise ValueError(f"unknown MoE stage {stage!r}; expected one of {sorted(MOE_STAGES)}")
+    return f"{MOE_STAGE_MARKER_PREFIX}{stage}" + (f" {detail}" if detail else "")
+
 
 class ProgramRoutedMoeMixin:
     """Routed-MoE v0 emit helpers used by GPT-OSS and Qwen bring-up.
@@ -44,7 +140,7 @@ class ProgramRoutedMoeMixin:
         row_in_block = row_idx % self.mlen
         return self.get_vram_tile_addr(matrix.name, row_block, tile_col_idx) + row_in_block * self.mlen
 
-    def gpt_oss_router_logits_bf16_v0(
+    def moe_router_logits_bf16_v0(
         self,
         x: VRAMMatrixVar,
         router_weight_rows: VRAMMatrixVar,
@@ -52,6 +148,7 @@ class ProgramRoutedMoeMixin:
         rows: int,
         hidden: int,
         num_experts: int,
+        policy_name: str = "gpt_oss",
         name: str = "gpt_oss_router_logits",
     ) -> VRAMMatrixVar:
         """Emit high-precision GPT-OSS router logits using BF16 vector dot products.
@@ -73,8 +170,7 @@ class ProgramRoutedMoeMixin:
             raise ValueError(f"router hidden={hidden} exceeds x width={x.shape[1]}")
         if num_experts > router_weight_rows.shape[0] or hidden > router_weight_rows.shape[1]:
             raise ValueError(
-                "router_weight_rows must have shape at least "
-                f"({num_experts}, {hidden}), got {router_weight_rows.shape}"
+                f"router_weight_rows must have shape at least ({num_experts}, {hidden}), got {router_weight_rows.shape}"
             )
 
         expert_blocks = math.ceil(num_experts / self.mlen)
@@ -103,7 +199,10 @@ class ProgramRoutedMoeMixin:
         fp_acc = self.allocate_fp_reg(1)[0]
         try:
             asm = IsaBuilder().comment(
-                f"GPT-OSS router BF16 vector-dot logits: rows={rows}, hidden={hidden}, experts={num_experts}"
+                moe_stage_marker(
+                    "router_topk",
+                    f"[{policy_name}] BF16 vector-dot logits: rows={rows}, hidden={hidden}, experts={num_experts}",
+                )
             )
             asm.instr("S_ADDI_INT", gp(gp_scratch), gp(0), scratch_addr)
             fp_base = fp_scratch.address
@@ -162,6 +261,7 @@ class ProgramRoutedMoeMixin:
         expert_blocks: int,
         logical_logit_rows: int,
         physical_logit_rows: int,
+        policy_name: str = "gpt_oss",
         name: str,
         label: str,
     ) -> VRAMMatrixVar:
@@ -186,7 +286,10 @@ class ProgramRoutedMoeMixin:
         gp_dst, gp_src = self._reg.allocate_gp(2)
         try:
             asm = IsaBuilder().comment(
-                f"Qwen router {label} logits pack: rows={rows}, experts={num_experts}, blocks={expert_blocks}"
+                moe_stage_marker(
+                    "router_topk",
+                    f"[{policy_name}] {label} logits pack: rows={rows}, experts={num_experts}, blocks={expert_blocks}",
+                )
             )
             for token_idx in range(rows):
                 for expert_block in range(expert_blocks):
@@ -355,7 +458,7 @@ class ProgramRoutedMoeMixin:
             label="packed-skinny",
         )
 
-    def gpt_oss_router_topk_softmax_v0(
+    def moe_router_select_v0(
         self,
         logits: VRAMMatrixVar,
         *,
@@ -364,7 +467,8 @@ class ProgramRoutedMoeMixin:
         indices_int_base: int,
         num_experts: int = 32,
         top_k: int = 4,
-        name: str = "gpt_oss_router_topk",
+        policy_name: str = "gpt_oss",
+        name: str = "moe_router_select",
     ) -> None:
         """Emit V_TOPK for one router-logit row.
 
@@ -373,6 +477,10 @@ class ProgramRoutedMoeMixin:
         ids to INT SRAM, and stores the softmax-over-selected weights to FP
         SRAM.  The instruction intentionally keeps router/top-k on the BF16
         path and does not touch MX scale state.
+
+        ``(num_experts, top_k)`` is arbitrary. The two hardwired ``rmask``
+        policies are used when they match exactly; every other shape goes through
+        ``C_SET_TOPK_REG`` and ``rmask=15``.
         """
         if token_idx < 0 or token_idx >= logits.shape[0]:
             raise ValueError(f"token_idx={token_idx} outside logits rows={logits.shape[0]}")
@@ -387,16 +495,35 @@ class ProgramRoutedMoeMixin:
                 f"V_TOPK expects token {token_idx} to occupy {expert_blocks} contiguous logit rows, "
                 f"got logits shape={logits.shape}"
             )
+        if top_k < 1 or top_k > num_experts:
+            raise ValueError(f"top_k={top_k} must be in [1, num_experts={num_experts}]")
+
+        # The fixed rmask table is preferred where it applies so existing GPT-OSS
+        # and Qwen3 programs keep emitting byte-identical ASM.
         policy_rmask = {(32, 4): 0, (128, 8): 1}.get((num_experts, top_k))
+        packed_policy = None
         if policy_rmask is None:
-            raise NotImplementedError(f"V_TOPK policy unsupported for num_experts={num_experts}, top_k={top_k}")
+            policy_rmask = _TOPK_POLICY_REGISTER_RMASK
+            packed_policy = _pack_topk_policy(num_experts, top_k)
 
         gp_weights, gp_logits, gp_indices = self._reg.allocate_gp(3)
         try:
             asm = IsaBuilder().comment(
-                f"Routed-MoE V_TOPK {name}: token={token_idx}, experts={num_experts}, top_k={top_k}, "
-                f"weights_fp={weights_fp_base}, indices_int={indices_int_base}"
+                moe_stage_marker(
+                    "router_topk",
+                    f"[{policy_name}] V_TOPK {name}: token={token_idx}, experts={num_experts}, "
+                    f"top_k={top_k}, weights_fp={weights_fp_base}, indices_int={indices_int_base}",
+                )
             )
+            if packed_policy is not None:
+                # C_SET_TOPK_REG is sticky, so a single-policy program only needs it
+                # once -- but it is re-emitted per token anyway. Skipping it would
+                # require tracking the live register value across every other emitter
+                # that might run in between, and two scalar instructions are nothing
+                # beside the (hidden/MLEN * num_experts) vector ops the router already
+                # spends per token.
+                asm.instr("S_ADDI_INT", gp(gp_weights), gp(0), packed_policy)
+                asm.instr("C_SET_TOPK_REG", gp(gp_weights))
             asm.instr("S_ADDI_INT", gp(gp_weights), gp(0), weights_fp_base)
             asm.instr(
                 "S_ADDI_INT",
@@ -430,8 +557,10 @@ class ProgramRoutedMoeMixin:
         if per_expert_stride <= 0:
             raise ValueError(f"{name}: per_expert_stride must be positive, got {per_expert_stride}")
         asm.comment(
-            f"{name}: expert_id_to_weight_base pair={pair_idx}, "
-            f"table_base={table_base}, stride={per_expert_stride}"
+            moe_stage_marker(
+                "expert_weight_address",
+                f"{name}: pair={pair_idx}, table_base={table_base}, stride={per_expert_stride}",
+            )
         )
         asm.instr("S_ADDI_INT", gp(gp_table), gp(0), expert_indices_int_base)
         asm.instr("S_LD_INT", gp(gp_expert), gp(gp_table), pair_idx)
@@ -456,15 +585,17 @@ class ProgramRoutedMoeMixin:
     ) -> None:
         """Emit expert-id -> HBM-base lookup through an IntSRAM base table."""
         asm.comment(
-            f"{name}: expert_id_to_weight_base_table pair={pair_idx}, "
-            f"base_table_int={expert_base_table_int_base}"
+            moe_stage_marker(
+                "expert_weight_address",
+                f"{name}: table lookup pair={pair_idx}, base_table_int={expert_base_table_int_base}",
+            )
         )
         asm.instr("S_ADDI_INT", gp(gp_table), gp(0), expert_indices_int_base)
         asm.instr("S_LD_INT", gp(gp_expert), gp(gp_table), pair_idx)
         asm.instr("S_LD_INT", gp(gp_base), gp(gp_expert), expert_base_table_int_base)
         asm.instr("C_SET_ADDR_REG", areg(addr_reg), gp(0), gp(gp_base))
 
-    def gpt_oss_expert_id_to_weight_base_v0(
+    def moe_expert_id_to_weight_base_v0(
         self,
         *,
         expert_indices_int_base: int,
@@ -502,7 +633,7 @@ class ProgramRoutedMoeMixin:
         finally:
             self._reg.free_gp([gp_table, gp_expert, gp_stride, gp_offset, gp_base])
 
-    def _gpt_oss_dynamic_load_sub_matrix_col_v0(
+    def _moe_dynamic_load_sub_matrix_col_v0(
         self,
         *,
         weight_template: InputVar,
@@ -535,8 +666,10 @@ class ProgramRoutedMoeMixin:
         addr_reg = self._reg.allocate_addr(1)[0]
         try:
             asm = IsaBuilder().comment(
-                f"GPT-OSS dynamic HBM weight prefetch: template={weight_template.name}, "
-                f"pair={pair_idx}, col={col_idx}"
+                moe_stage_marker(
+                    "expert_weight_prefetch",
+                    f"dynamic HBM weight prefetch: template={weight_template.name}, pair={pair_idx}, col={col_idx}",
+                )
             )
             if expert_base_table_int_base is None:
                 self._emit_expert_id_to_weight_base_v0(
@@ -582,7 +715,7 @@ class ProgramRoutedMoeMixin:
             )
             self._reg.free_addr([addr_reg])
 
-    def gpt_oss_dynamic_vram_sub_projection_to_v0(
+    def moe_dynamic_vram_sub_projection_to_v0(
         self,
         vram_matrix: VRAMMatrixVar,
         vram_row_idx: int,
@@ -610,7 +743,7 @@ class ProgramRoutedMoeMixin:
         self._ensure_hbm_sub_matrix_registered(weight_template)
         if auto_reset_mram:
             super().reset_mram()
-        self._gpt_oss_dynamic_load_sub_matrix_col_v0(
+        self._moe_dynamic_load_sub_matrix_col_v0(
             weight_template=weight_template,
             col_idx=weight_col_idx,
             expert_indices_int_base=expert_indices_int_base,
@@ -621,6 +754,17 @@ class ProgramRoutedMoeMixin:
             k_block_start=k_block_start,
             k_block_count=k_block_count,
             name=name,
+        )
+        # The helper above marked `expert_weight_prefetch`. Markers are sticky, so
+        # hand the stage back before the GEMM -- otherwise every matmul instruction
+        # in this tile is billed to weight prefetch. This is the one place the two
+        # stages meet, which is why the boundary is drawn here rather than inside
+        # `vram_sub_projection_to` (a general-purpose helper shared with non-MoE
+        # programs, which must stay marker-free).
+        self._emit(
+            IsaBuilder().comment(
+                moe_stage_marker("expert_projection", f"{name}: pair={pair_idx}, col={weight_col_idx}")
+            )
         )
         super().vram_sub_projection_to(
             vram_mat_name=vram_matrix.name,
@@ -634,7 +778,7 @@ class ProgramRoutedMoeMixin:
             k_block_count=k_block_count,
         )
 
-    def gpt_oss_dynamic_linear_projection_v0(
+    def moe_dynamic_linear_projection_v0(
         self,
         input_var: VRAMMatrixVar,
         weight_template: InputVar,
@@ -680,7 +824,7 @@ class ProgramRoutedMoeMixin:
         )
 
         def emit_projection(row_idx, col_idx, target, target_row_idx, target_col_idx, **k_split) -> None:
-            self.gpt_oss_dynamic_vram_sub_projection_to_v0(
+            self.moe_dynamic_vram_sub_projection_to_v0(
                 input_var,
                 row_idx,
                 weight_template,
@@ -717,7 +861,7 @@ class ProgramRoutedMoeMixin:
         self.free_tensor(temp)
         return output
 
-    def gpt_oss_add_dynamic_expert_bias_v0(
+    def moe_add_dynamic_expert_bias_v0(
         self,
         dst: VRAMMatrixVar,
         bias_table: VRAMMatrixVar,
@@ -741,7 +885,9 @@ class ProgramRoutedMoeMixin:
 
         gp_table, gp_expert, gp_stride, gp_expert_offset, gp_src_base, gp_src, gp_dst = self._reg.allocate_gp(7)
         try:
-            asm = IsaBuilder().comment(f"GPT-OSS dynamic expert bias add {name}: pair={pair_idx}, rows={rows}")
+            asm = IsaBuilder().comment(
+                moe_stage_marker("expert_bias", f"dynamic expert bias add {name}: pair={pair_idx}, rows={rows}")
+            )
             asm.instr("S_ADDI_INT", gp(gp_table), gp(0), expert_indices_int_base)
             asm.instr("S_LD_INT", gp(gp_expert), gp(gp_table), pair_idx)
             asm.instr("S_ADDI_INT", gp(gp_stride), gp(0), expert_row_stride)
@@ -758,7 +904,7 @@ class ProgramRoutedMoeMixin:
         finally:
             self._reg.free_gp([gp_table, gp_expert, gp_stride, gp_expert_offset, gp_src_base, gp_src, gp_dst])
 
-    def gpt_oss_materialize_topk_route_weight_v0(
+    def moe_materialize_topk_route_weight_v0(
         self,
         *,
         weights_fp_base: int,
@@ -767,6 +913,7 @@ class ProgramRoutedMoeMixin:
         hidden: int,
         zero_row: FPVar | None = None,
         fp_scratch: FPVar | None = None,
+        policy_name: str = "gpt_oss",
         name: str = "gpt_oss_device_route_weight",
     ) -> VRAMMatrixVar:
         """Expand device V_TOPK scalar weight into a VRAM route matrix."""
@@ -775,11 +922,13 @@ class ProgramRoutedMoeMixin:
         if hidden % self.mlen != 0:
             raise ValueError(f"{name}: hidden={hidden} must be divisible by MLEN={self.mlen}")
         route = self.alloc(name, rows=rows, cols=hidden, strict=False, physical_shape=(self.blen, hidden))
-        self.gpt_oss_true_zero_vram_rows_v0(
+        self.moe_true_zero_vram_rows_v0(
             route,
             rows=list(range(self.blen)),
             hidden=hidden,
             zero_row=zero_row,
+            policy_name=policy_name,
+            stage="expert_route_weight",
             name=f"{name}_zero",
         )
         fp_scratch = fp_scratch or self.fp_var(f"{name}_fp_row", size=self.mlen)
@@ -790,7 +939,10 @@ class ProgramRoutedMoeMixin:
             self.fpvar_fill_from_fpram_asm(fp_scratch.address, weights_fp_base + pair_idx, self.mlen)
             for col_block in range(hidden // self.mlen):
                 asm = IsaBuilder().comment(
-                    f"GPT-OSS materialize route weight pair={pair_idx}, col_block={col_block}"
+                    moe_stage_marker(
+                        "expert_route_weight",
+                        f"[{policy_name}] materialize route weight pair={pair_idx}, col_block={col_block}",
+                    )
                 )
                 asm.instr("S_ADDI_INT", gp(gp_dst), gp(0), self._vram_matrix_row_addr(route, 0, col_block))
                 asm.instr("S_ADDI_INT", gp(gp_fp), gp(0), fp_scratch.address)
@@ -800,7 +952,7 @@ class ProgramRoutedMoeMixin:
             self._reg.free_gp([gp_dst, gp_fp])
         return route
 
-    def gpt_oss_materialize_route_weights_for_active_rows_v0(
+    def moe_materialize_route_weights_for_active_rows_v0(
         self,
         *,
         weights_fp_base: int,
@@ -810,13 +962,21 @@ class ProgramRoutedMoeMixin:
         hidden: int,
         zero_row: FPVar | None = None,
         fp_scratch: FPVar | None = None,
-        name: str = "gpt_oss_device_route_weights_grouped",
+        policy_name: str = "gpt_oss",
+        stage: str = "expert_route_weight",
+        name: str = "moe_device_row_weights_grouped",
     ) -> VRAMMatrixVar:
-        """Expand selected scalar route weights into specific active VRAM rows."""
+        """Expand selected scalar per-row FP weights into specific active VRAM rows.
+
+        ``stage`` exists because this broadcast is not exclusive to routing. The
+        shared-expert sigmoid gate produces the same thing -- one FP scalar per
+        token, broadcast across hidden -- and reuses this emitter. Without the
+        parameter every gate instruction bills to ``expert_route_weight``, which is
+        both wrong and specifically misleading: a program with no routing at all
+        would appear to spend time computing route weights.
+        """
         if len(pair_indices) != len(active_rows):
-            raise ValueError(
-                f"{name}: pair_indices={len(pair_indices)} active_rows={len(active_rows)} length mismatch"
-            )
+            raise ValueError(f"{name}: pair_indices={len(pair_indices)} active_rows={len(active_rows)} length mismatch")
         if rows <= 0:
             raise ValueError(f"{name}: rows must be positive")
         if hidden % self.mlen != 0:
@@ -828,11 +988,13 @@ class ProgramRoutedMoeMixin:
             raise ValueError(f"{name}: active rows {active_list} exceed physical rows={physical_rows}")
 
         route = self.alloc(name, rows=rows, cols=hidden, strict=False, physical_shape=(physical_rows, hidden))
-        self.gpt_oss_true_zero_vram_rows_v0(
+        self.moe_true_zero_vram_rows_v0(
             route,
             rows=list(range(physical_rows)),
             hidden=hidden,
             zero_row=zero_row,
+            policy_name=policy_name,
+            stage=stage,
             name=f"{name}_zero",
         )
         fp_scratch = fp_scratch or self.fp_var(f"{name}_fp_row", size=self.mlen)
@@ -843,7 +1005,11 @@ class ProgramRoutedMoeMixin:
                 self.fpvar_fill_from_fpram_asm(fp_scratch.address, weights_fp_base + pair_idx, self.mlen)
                 for col_block in range(hidden // self.mlen):
                     asm = IsaBuilder().comment(
-                        f"GPT-OSS materialize route weight pair={pair_idx}, active_row={active_row}, col_block={col_block}"
+                        moe_stage_marker(
+                            stage,
+                            f"[{policy_name}] materialize row weight pair={pair_idx}, "
+                            f"active_row={active_row}, col_block={col_block}",
+                        )
                     )
                     asm.instr("S_ADDI_INT", gp(gp_dst), gp(0), self._vram_matrix_row_addr(route, active_row, col_block))
                     asm.instr("S_ADDI_INT", gp(gp_fp), gp(0), fp_scratch.address)
@@ -853,7 +1019,7 @@ class ProgramRoutedMoeMixin:
             self._reg.free_gp([gp_dst, gp_fp])
         return route
 
-    def gpt_oss_dynamic_expert_pair_v0(
+    def moe_dynamic_expert_pair_v0(
         self,
         x: VRAMMatrixVar,
         weights: ExpertWeights,
@@ -869,8 +1035,9 @@ class ProgramRoutedMoeMixin:
         constants: GptOssFPConstants,
         zero_row: FPVar | None = None,
         route_fp_scratch: FPVar | None = None,
+        policy_name: str = "gpt_oss",
         activation_policy: str = "gpt_oss_clamp_gated",
-        name: str = "gpt_oss_dynamic_expert_pair",
+        name: str = "moe_dynamic_expert_pair",
     ) -> VRAMMatrixVar:
         """Run one routed pair using true expert id from device V_TOPK output."""
         w_gate, w_up, w_down = weights
@@ -879,7 +1046,7 @@ class ProgramRoutedMoeMixin:
         gate_stride, up_stride, down_stride = weight_table_strides
         projection_rows = max(self.mlen, x.physical_shape[0], math.ceil(rows / self.blen) * self.blen)
 
-        gate = self.gpt_oss_dynamic_linear_projection_v0(
+        gate = self.moe_dynamic_linear_projection_v0(
             x,
             w_gate,
             expert_indices_int_base=expert_indices_int_base,
@@ -889,7 +1056,7 @@ class ProgramRoutedMoeMixin:
             name=f"{name}_gate",
             physical_shape=(projection_rows, w_gate.physical_shape[1]),
         )
-        up = self.gpt_oss_dynamic_linear_projection_v0(
+        up = self.moe_dynamic_linear_projection_v0(
             x,
             w_up,
             expert_indices_int_base=expert_indices_int_base,
@@ -900,7 +1067,7 @@ class ProgramRoutedMoeMixin:
             physical_shape=(projection_rows, w_up.physical_shape[1]),
         )
         if gate_bias_table is not None:
-            self.gpt_oss_add_dynamic_expert_bias_v0(
+            self.moe_add_dynamic_expert_bias_v0(
                 gate,
                 gate_bias_table,
                 expert_indices_int_base=expert_indices_int_base,
@@ -910,7 +1077,7 @@ class ProgramRoutedMoeMixin:
                 name=f"{name}_gate_bias",
             )
         if up_bias_table is not None:
-            self.gpt_oss_add_dynamic_expert_bias_v0(
+            self.moe_add_dynamic_expert_bias_v0(
                 up,
                 up_bias_table,
                 expert_indices_int_base=expert_indices_int_base,
@@ -928,7 +1095,7 @@ class ProgramRoutedMoeMixin:
             activation_policy=activation_policy,
             name=name,
         )
-        out = self.gpt_oss_dynamic_linear_projection_v0(
+        out = self.moe_dynamic_linear_projection_v0(
             hidden,
             w_down,
             expert_indices_int_base=expert_indices_int_base,
@@ -939,7 +1106,7 @@ class ProgramRoutedMoeMixin:
             physical_shape=(projection_rows, w_down.physical_shape[1]),
         )
         if down_bias_table is not None:
-            self.gpt_oss_add_dynamic_expert_bias_v0(
+            self.moe_add_dynamic_expert_bias_v0(
                 out,
                 down_bias_table,
                 expert_indices_int_base=expert_indices_int_base,
@@ -948,19 +1115,25 @@ class ProgramRoutedMoeMixin:
                 width=w_down.physical_shape[1],
                 name=f"{name}_down_bias",
             )
-        route = self.gpt_oss_materialize_topk_route_weight_v0(
+        route = self.moe_materialize_topk_route_weight_v0(
             weights_fp_base=weights_fp_base,
             pair_idx=pair_idx,
             rows=rows,
             hidden=w_down.physical_shape[1],
             zero_row=zero_row,
             fp_scratch=route_fp_scratch,
+            policy_name=policy_name,
             name=f"{name}_route",
         )
+        # Re-mark: `vram_mul` is a general-purpose helper with no marker of its own,
+        # and under marker-authoritative classification an unmarked comment inherits
+        # the previous stage. Without this the route-weight multiply would be billed
+        # to whatever `moe_materialize_topk_route_weight_v0` left current.
+        self._emit(IsaBuilder().comment(moe_stage_marker("expert_route_weight", f"[{policy_name}] apply {name}")))
         self.vram_mul(out, route, num_rows=rows)
         return out
 
-    def gpt_oss_gather_token_rows_from_hbm_v0(
+    def moe_gather_token_rows_from_hbm_v0(
         self,
         x_input: InputVar,
         *,
@@ -968,6 +1141,7 @@ class ProgramRoutedMoeMixin:
         pair_count: int,
         hidden: int,
         zero_row: FPVar | None = None,
+        policy_name: str = "gpt_oss",
         name: str = "gpt_oss_gathered_x",
     ) -> VRAMMatrixVar:
         """Gather routed token rows from HBM into compact BF16 VRAM rows.
@@ -1010,7 +1184,11 @@ class ProgramRoutedMoeMixin:
         addr_reg = self._reg.allocate_addr(1)[0]
         try:
             asm = IsaBuilder().comment(
-                f"GPT-OSS gather token rows from HBM: pairs={pair_count}, hidden={hidden}, slot_rows={self.blen}"
+                moe_stage_marker(
+                    "gather",
+                    f"[{policy_name}] gather token rows from HBM: pairs={pair_count}, "
+                    f"hidden={hidden}, slot_rows={self.blen}",
+                )
             )
             asm.instr("S_ADDI_INT", gp(gp_table), gp(0), token_offsets_int_base)
             asm.instr("S_ADDI_INT", gp(gp_scale), gp(0), x_rows * x_cols)
@@ -1037,35 +1215,36 @@ class ProgramRoutedMoeMixin:
             self._reg.free_addr([addr_reg])
 
         padding_rows = [
-            pair_idx * self.blen + pad_idx
-            for pair_idx in range(pair_count)
-            for pad_idx in range(1, self.blen)
+            pair_idx * self.blen + pad_idx for pair_idx in range(pair_count) for pad_idx in range(1, self.blen)
         ]
         if padding_rows:
             # Same true-FP-zero clear used by the VRAM gather path; keep it in one place.
-            self.gpt_oss_true_zero_vram_rows_v0(
+            self.moe_true_zero_vram_rows_v0(
                 gathered,
                 rows=padding_rows,
                 hidden=hidden,
                 zero_row=zero_row,
+                policy_name=policy_name,
+                stage="gather",
                 name=f"{name}_pad_zero",
             )
 
         return gathered
 
-    def gpt_oss_gather_token_rows_from_vram_v0(
+    def moe_gather_token_rows_from_vram_v0(
         self,
         x: VRAMMatrixVar,
         *,
         token_indices: Sequence[int],
         hidden: int,
         zero_row: FPVar | None = None,
+        policy_name: str = "gpt_oss",
         name: str = "gpt_oss_gathered_x_vram",
     ) -> VRAMMatrixVar:
         """Copy routed token rows from BF16 VRAM into BLEN-row pair slots.
 
         This is the decoder-block counterpart to
-        :meth:`gpt_oss_gather_token_rows_from_hbm_v0`.  A real block feeds MoE
+        :meth:`moe_gather_token_rows_from_hbm_v0`.  A real block feeds MoE
         from the VRAM-resident post-attention RMSNorm output, so this helper
         must not emit HBM prefetches, ``C_SET_SCALE_REG``, or activation
         quantization.  Each routed pair still owns one BLEN-row slot to match
@@ -1095,11 +1274,13 @@ class ProgramRoutedMoeMixin:
             physical_shape=(physical_rows, hidden),
         )
 
-        self.gpt_oss_true_zero_vram_rows_v0(
+        self.moe_true_zero_vram_rows_v0(
             gathered,
             rows=list(range(physical_rows)),
             hidden=hidden,
             zero_row=zero_row,
+            policy_name=policy_name,
+            stage="gather",
             name=f"{name}_zero",
         )
 
@@ -1107,7 +1288,11 @@ class ProgramRoutedMoeMixin:
         gp_dst, gp_src = self._reg.allocate_gp(2)
         try:
             asm = IsaBuilder().comment(
-                f"GPT-OSS gather token rows from VRAM: pairs={pair_count}, hidden={hidden}, slot_rows={self.blen}"
+                moe_stage_marker(
+                    "gather",
+                    f"[{policy_name}] gather token rows from VRAM: pairs={pair_count}, "
+                    f"hidden={hidden}, slot_rows={self.blen}",
+                )
             )
             for pair_idx, token_idx in enumerate(token_list):
                 active_row = pair_idx * self.blen
@@ -1124,14 +1309,16 @@ class ProgramRoutedMoeMixin:
 
         return gathered
 
-    def gpt_oss_true_zero_vram_rows_v0(
+    def moe_true_zero_vram_rows_v0(
         self,
         matrix: VRAMMatrixVar,
         *,
         rows: Sequence[int],
         hidden: int,
         zero_row: FPVar | None = None,
-        name: str = "gpt_oss_zero_rows",
+        policy_name: str = "gpt_oss",
+        stage: str = "accumulator_init",
+        name: str = "moe_zero_rows",
     ) -> None:
         """Clear selected VRAM rows by mapping a true FP zero row.
 
@@ -1139,6 +1326,13 @@ class ProgramRoutedMoeMixin:
         contain NaNs, and ``NaN * 0`` remains NaN.  This helper writes real
         zeros through ``S_MAP_V_FP`` and is therefore safe for gather padding
         and scatter accumulators.
+
+        ``stage`` exists because the same clear serves three different phases --
+        zeroing the combine accumulator, clearing gather padding rows, and
+        zeroing a route-weight tile. The emulator previously had to guess between
+        them from the *preceding* comment's stage, a stateful rule that could not
+        express "this clear belongs to the shared branch" at all. The caller knows;
+        it now says so.
         """
         if hidden % self.mlen != 0:
             raise ValueError(f"zero hidden={hidden} must be divisible by MLEN={self.mlen}")
@@ -1152,7 +1346,9 @@ class ProgramRoutedMoeMixin:
         fp_zero_row = zero_row or self.fp_var(f"{name}_zero_row", size=self.mlen)
         gp_fp, gp_dst, gp_loop = self._reg.allocate_gp(3)
         try:
-            asm = IsaBuilder().comment(f"GPT-OSS true-zero VRAM rows {row_list} in {matrix.name}")
+            asm = IsaBuilder().comment(
+                moe_stage_marker(stage, f"[{policy_name}] true-zero VRAM rows {row_list} in {matrix.name}")
+            )
             asm.instr("S_ADDI_INT", gp(gp_fp), gp(0), fp_zero_row.address)
             asm.instr("C_LOOP_START", gp(gp_loop), self.mlen)
             asm.instr("S_ST_FP", fp(0), gp(gp_fp), 0)
@@ -1170,7 +1366,7 @@ class ProgramRoutedMoeMixin:
         finally:
             self._reg.free_gp([gp_fp, gp_dst, gp_loop])
 
-    def gpt_oss_scatter_add_active_rows_v0(
+    def moe_scatter_add_active_rows_v0(
         self,
         dst: VRAMMatrixVar,
         src: VRAMMatrixVar,
@@ -1178,6 +1374,7 @@ class ProgramRoutedMoeMixin:
         token_indices: Sequence[int],
         active_rows: Sequence[int],
         hidden: int,
+        policy_name: str = "gpt_oss",
         name: str = "gpt_oss_scatter_add",
     ) -> None:
         """Add routed active slot rows into final token rows in VRAM.
@@ -1202,7 +1399,12 @@ class ProgramRoutedMoeMixin:
         num_col_blocks = hidden // self.mlen
         gp_dst, gp_src = self._reg.allocate_gp(2)
         try:
-            asm = IsaBuilder().comment(f"GPT-OSS VRAM scatter-add {name}: {len(token_list)} active rows")
+            asm = IsaBuilder().comment(
+                moe_stage_marker(
+                    "scatter_combine",
+                    f"[{policy_name}] VRAM scatter-add {name}: {len(token_list)} active rows",
+                )
+            )
             for token_idx, active_row in zip(token_list, active_list, strict=True):
                 for col_block in range(num_col_blocks):
                     dst_addr = self._vram_matrix_row_addr(dst, token_idx, col_block)
@@ -1304,7 +1506,7 @@ class ProgramRoutedMoeMixin:
         self.vram_mul(up, gate, num_rows=rows)
         return up
 
-    def gpt_oss_expert_v0(
+    def moe_expert_v0(
         self,
         x: VRAMMatrixVar,
         weights: ExpertWeights,
@@ -1357,7 +1559,7 @@ class ProgramRoutedMoeMixin:
             self.vram_add(out, down_bias, num_rows=rows)
         return out
 
-    def gpt_oss_moe_fixed_routing_v0(
+    def moe_fixed_routing_v0(
         self,
         x: VRAMMatrixVar,
         experts: Sequence[ExpertWeights],
@@ -1384,7 +1586,7 @@ class ProgramRoutedMoeMixin:
         acc: VRAMMatrixVar | None = None
         for idx, (weights, route) in enumerate(zip(experts, route_weights, strict=True)):
             biases = None if expert_biases is None else expert_biases[idx]
-            expert_out = self.gpt_oss_expert_v0(
+            expert_out = self.moe_expert_v0(
                 x,
                 weights,
                 biases=biases,
@@ -1411,9 +1613,23 @@ class ProgramRoutedMoeMixin:
         intermediate: int,
         constants: GptOssFPConstants,
         activation_policy: str = "gpt_oss_clamp_gated",
+        policy_name: str = "gpt_oss",
+        stage: str = "expert_activation",
         name: str,
     ) -> VRAMMatrixVar:
-        """Generic substrate wrapper for expert activation backends."""
+        """Generic substrate wrapper for expert activation backends.
+
+        ``stage`` lets the shared branch bill its activation to
+        ``shared_expert_activation`` while running the identical backend. The two
+        branches use the same math, so the only thing distinguishing them in the
+        profile is which marker is live.
+        """
+        # Both backends are built entirely from general-purpose tile helpers
+        # (`tile_row_exp`, `vram_mul`, ...) that emit their own unmarked comments.
+        # One marker here covers the whole region.
+        self._emit(
+            IsaBuilder().comment(moe_stage_marker(stage, f"[{policy_name}] {activation_policy} {name}: rows={rows}"))
+        )
         if activation_policy == "gpt_oss_clamp_gated":
             return self.gpt_oss_clamp_gated_activation_v0(
                 gate,
@@ -1439,4 +1655,40 @@ class ProgramRoutedMoeMixin:
         )
 
 
-__all__ = ["ProgramRoutedMoeMixin"]
+# ============================================================================
+# Deprecated aliases
+# ============================================================================
+
+#: Pre-generalization method names, kept so in-flight callers (and the GPT-OSS
+#: bring-up tests that predate the rename) keep working. Each maps to the
+#: identically-behaving ``moe_*`` method; the defaults preserve GPT-OSS behaviour,
+#: so an aliased call emits what it always did.
+_DEPRECATED_METHOD_ALIASES = {
+    "gpt_oss_router_logits_bf16_v0": "moe_router_logits_bf16_v0",
+    "gpt_oss_router_topk_softmax_v0": "moe_router_select_v0",
+    "gpt_oss_expert_v0": "moe_expert_v0",
+    "gpt_oss_dynamic_expert_pair_v0": "moe_dynamic_expert_pair_v0",
+    "gpt_oss_dynamic_linear_projection_v0": "moe_dynamic_linear_projection_v0",
+    "gpt_oss_dynamic_vram_sub_projection_to_v0": "moe_dynamic_vram_sub_projection_to_v0",
+    "gpt_oss_expert_id_to_weight_base_v0": "moe_expert_id_to_weight_base_v0",
+    "gpt_oss_add_dynamic_expert_bias_v0": "moe_add_dynamic_expert_bias_v0",
+    "gpt_oss_materialize_topk_route_weight_v0": "moe_materialize_topk_route_weight_v0",
+    "gpt_oss_materialize_route_weights_for_active_rows_v0": ("moe_materialize_route_weights_for_active_rows_v0"),
+    "gpt_oss_gather_token_rows_from_hbm_v0": "moe_gather_token_rows_from_hbm_v0",
+    "gpt_oss_gather_token_rows_from_vram_v0": "moe_gather_token_rows_from_vram_v0",
+    "gpt_oss_scatter_add_active_rows_v0": "moe_scatter_add_active_rows_v0",
+    "gpt_oss_true_zero_vram_rows_v0": "moe_true_zero_vram_rows_v0",
+    "gpt_oss_moe_fixed_routing_v0": "moe_fixed_routing_v0",
+}
+
+for _old, _new in _DEPRECATED_METHOD_ALIASES.items():
+    setattr(ProgramRoutedMoeMixin, _old, getattr(ProgramRoutedMoeMixin, _new))
+del _old, _new
+
+
+__all__ = [
+    "MOE_STAGES",
+    "MOE_STAGE_MARKER_PREFIX",
+    "ProgramRoutedMoeMixin",
+    "moe_stage_marker",
+]

--- a/aten/plena/program_routed_moe.py
+++ b/aten/plena/program_routed_moe.py
@@ -34,6 +34,13 @@ MOE_STAGE_MARKER_PREFIX = "@stage="
 MOE_STAGES: frozenset[str] = frozenset(
     {
         "router_topk",
+        # The MoE sublayer's input preparation, before any routing happens:
+        # zeroing the residual buffer, copying the post-attention hidden state
+        # into it, and the input RMSNorm with its norm-weight multiply. Distinct
+        # from `accumulator_init`, which is the combine accumulator only -- these
+        # rows are a residual copy that is added back *after* the experts run,
+        # and the work scales with rows x hidden rather than with the accumulator.
+        "residual_setup",
         "accumulator_init",
         "gather",
         "expert_weight_address",
@@ -346,6 +353,19 @@ class ProgramRoutedMoeMixin:
         logical_logit_rows = rows if expert_blocks == 1 else rows * expert_blocks
         physical_logit_rows = max(self.blen, math.ceil(logical_logit_rows / self.blen) * self.blen)
 
+        # Router logits are routing cost, same as the vector-dot path's. Without
+        # this the whole projection inherits whatever marker preceded the call,
+        # since `linear_projection_bf16*` is a general helper with no marker of
+        # its own -- which billed the router GEMM to the MoE input setup.
+        self._emit(
+            IsaBuilder().comment(
+                moe_stage_marker(
+                    "router_topk",
+                    f"[qwen3] BF16 matrix logits: rows={rows}, hidden={hidden}, experts={num_experts}",
+                )
+            )
+        )
+
         old_capacity = self.mram_tile_capacity
         self.mram_tile_capacity = mram_tile_capacity
         try:
@@ -424,6 +444,18 @@ class ProgramRoutedMoeMixin:
                 "router_weight_packed_skinny physical width is too small for "
                 f"{expert_blocks} output blocks: got {router_weight_packed_skinny.physical_shape}"
             )
+
+        # As in the matrix path above: the packed-skinny projection helper emits
+        # no marker of its own, so without this the router GEMM is billed to
+        # whichever stage the caller happened to be in.
+        self._emit(
+            IsaBuilder().comment(
+                moe_stage_marker(
+                    "router_topk",
+                    f"[qwen3] packed-skinny BF16 logits: rows={rows}, hidden={hidden}, experts={num_experts}",
+                )
+            )
+        )
 
         matrix_logits = self.alloc(
             f"{name}_matrix",

--- a/aten/plena/program_routed_moe.py
+++ b/aten/plena/program_routed_moe.py
@@ -963,7 +963,7 @@ class ProgramRoutedMoeMixin:
         zero_row: FPVar | None = None,
         fp_scratch: FPVar | None = None,
         policy_name: str = "gpt_oss",
-        stage: str = "expert_route_weight",
+        stage: str,
         name: str = "moe_device_row_weights_grouped",
     ) -> VRAMMatrixVar:
         """Expand selected scalar per-row FP weights into specific active VRAM rows.
@@ -974,6 +974,12 @@ class ProgramRoutedMoeMixin:
         parameter every gate instruction bills to ``expert_route_weight``, which is
         both wrong and specifically misleading: a program with no routing at all
         would appear to spend time computing route weights.
+
+        It is deliberately **required**. A default is what produced that exact bug:
+        the shared gate reused this emitter, inherited ``expert_route_weight``, and
+        999 instructions were misattributed with nothing failing. Under sticky
+        marker attribution a wrong stage is silent -- the totals still add up -- so
+        the omission has to be caught where it is written, not where it is read.
         """
         if len(pair_indices) != len(active_rows):
             raise ValueError(f"{name}: pair_indices={len(pair_indices)} active_rows={len(active_rows)} length mismatch")
@@ -1093,6 +1099,7 @@ class ProgramRoutedMoeMixin:
             intermediate=intermediate,
             constants=constants,
             activation_policy=activation_policy,
+            stage="expert_activation",
             name=name,
         )
         out = self.moe_dynamic_linear_projection_v0(
@@ -1317,7 +1324,7 @@ class ProgramRoutedMoeMixin:
         hidden: int,
         zero_row: FPVar | None = None,
         policy_name: str = "gpt_oss",
-        stage: str = "accumulator_init",
+        stage: str,
         name: str = "moe_zero_rows",
     ) -> None:
         """Clear selected VRAM rows by mapping a true FP zero row.
@@ -1333,6 +1340,11 @@ class ProgramRoutedMoeMixin:
         them from the *preceding* comment's stage, a stateful rule that could not
         express "this clear belongs to the shared branch" at all. The caller knows;
         it now says so.
+
+        Required rather than defaulted, because this is the emitter where a default
+        does the most damage: it serves the most stages and has the most call sites,
+        so ``accumulator_init`` silently absorbed every caller that forgot. Omitting
+        it is now a TypeError at emit time instead of a wrong number in a profile.
         """
         if hidden % self.mlen != 0:
             raise ValueError(f"zero hidden={hidden} must be divisible by MLEN={self.mlen}")
@@ -1614,7 +1626,7 @@ class ProgramRoutedMoeMixin:
         constants: GptOssFPConstants,
         activation_policy: str = "gpt_oss_clamp_gated",
         policy_name: str = "gpt_oss",
-        stage: str = "expert_activation",
+        stage: str,
         name: str,
     ) -> VRAMMatrixVar:
         """Generic substrate wrapper for expert activation backends.
@@ -1623,6 +1635,9 @@ class ProgramRoutedMoeMixin:
         ``shared_expert_activation`` while running the identical backend. The two
         branches use the same math, so the only thing distinguishing them in the
         profile is which marker is live.
+
+        Required rather than defaulted for exactly that reason: when the marker is
+        the *only* thing separating two branches, a default silently merges them.
         """
         # Both backends are built entirely from general-purpose tile helpers
         # (`tile_row_exp`, `vram_mul`, ...) that emit their own unmarked comments.

--- a/aten/tests/test_moe_stage_attribution.py
+++ b/aten/tests/test_moe_stage_attribution.py
@@ -72,6 +72,30 @@ def _functions(path: pathlib.Path):
             yield node
 
 
+def _defaulted_stage_params(func) -> list[tuple[ast.arg, ast.expr]]:
+    """Every ``stage`` parameter of *func* that carries a default, with it.
+
+    Keyword-only defaults sit in ``kw_defaults`` positionally aligned with
+    ``kwonlyargs`` (``None`` where there is no default). Positional defaults sit
+    in ``defaults``, right-aligned against ``posonlyargs + args``, hence the
+    padding.
+    """
+    args = func.args
+    defaulted = [
+        (arg, default)
+        for arg, default in zip(args.kwonlyargs, args.kw_defaults)
+        if arg.arg == "stage" and default is not None
+    ]
+    positional = args.posonlyargs + args.args
+    padding = len(positional) - len(args.defaults)
+    defaulted += [
+        (arg, args.defaults[index - padding])
+        for index, arg in enumerate(positional)
+        if arg.arg == "stage" and index >= padding
+    ]
+    return defaulted
+
+
 def _declared_moe_stages() -> set[str]:
     """Parse ``MOE_STAGES`` out of ``program_routed_moe.py``."""
     tree = ast.parse(ROUTED_MOE_SOURCE.read_text(), filename=str(ROUTED_MOE_SOURCE))
@@ -99,21 +123,7 @@ def test_stage_parameters_have_no_default() -> None:
     offenders: list[str] = []
     for path in _python_sources():
         for func in _functions(path):
-            args = func.args
-            defaulted = [
-                (arg, default)
-                for arg, default in zip(args.kwonlyargs, args.kw_defaults)
-                if arg.arg == "stage" and default is not None
-            ]
-            # Positional `stage` params: line them up with their trailing defaults.
-            positional = args.posonlyargs + args.args
-            padding = len(positional) - len(args.defaults)
-            defaulted += [
-                (arg, args.defaults[index - padding])
-                for index, arg in enumerate(positional)
-                if arg.arg == "stage" and index >= padding
-            ]
-            for arg, default in defaulted:
+            for _arg, default in _defaulted_stage_params(func):
                 offenders.append(f"{path.name}:{func.lineno} {func.name}(stage={ast.unparse(default)})")
 
     assert not offenders, (
@@ -179,34 +189,30 @@ def test_every_test_file_here_is_wired_into_ci() -> None:
     )
 
 
-def test_guard_would_catch_a_defaulted_stage_parameter() -> None:
+def test_guard_would_catch_a_defaulted_stage_parameter(tmp_path: pathlib.Path) -> None:
     """The lint above is only worth having if it can fail. Prove it does.
 
     Without this, a refactor that broke the AST walk (a renamed field, a missed
     argument category) would leave both tests passing over zero findings.
+
+    Driven through ``_functions`` and ``_defaulted_stage_params`` -- the same
+    two helpers the real lint uses -- against a fixture written to disk. A
+    self-check that reimplements the walk it is checking proves only that the
+    copy agrees with itself, which is exactly the bug it is meant to catch.
     """
-    module = ast.parse(
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text(
         "def emit(self, x, *, policy: str = 'p', stage: str = 'gather', name: str) -> None: ...\n"
         "def emit_positional(self, stage: str = 'gather') -> None: ...\n"
+        "async def emit_async(self, *, stage: str = 'gather') -> None: ...\n"
         "def emit_ok(self, x, *, stage: str, name: str) -> None: ...\n"
+        "async def emit_async_ok(self, *, stage: str) -> None: ...\n"
+        "def emit_no_stage(self, x: str = 'y') -> None: ...\n"
     )
-    found = []
-    for func in (node for node in ast.walk(module) if isinstance(node, ast.FunctionDef)):
-        args = func.args
-        hits = [
-            arg
-            for arg, default in zip(args.kwonlyargs, args.kw_defaults)
-            if arg.arg == "stage" and default is not None
-        ]
-        positional = args.posonlyargs + args.args
-        padding = len(positional) - len(args.defaults)
-        hits += [
-            arg for index, arg in enumerate(positional) if arg.arg == "stage" and index >= padding
-        ]
-        if hits:
-            found.append(func.name)
 
-    assert found == ["emit", "emit_positional"], (
+    found = sorted(func.name for func in _functions(fixture) if _defaulted_stage_params(func))
+
+    assert found == ["emit", "emit_async", "emit_positional"], (
         f"the AST walk no longer detects defaulted stage parameters, so "
         f"test_stage_parameters_have_no_default cannot fail; detected {found}"
     )

--- a/aten/tests/test_moe_stage_attribution.py
+++ b/aten/tests/test_moe_stage_attribution.py
@@ -94,17 +94,35 @@ def _is_moe_callee(name: str) -> bool:
     return name.startswith(("moe_", "gpt_oss_"))
 
 
+#: Callees taking the stage name as their *first positional* argument.
+#:
+#: ``moe_stage_marker(stage, detail)`` is the function that actually emits a
+#: marker, and all 19 call sites under ``aten/plena`` pass the stage
+#: positionally. Matching only ``stage=`` keywords left the one construct that
+#: produces a marker completely uncovered -- the lint could not have caught the
+#: typo it exists to catch.
+_POSITIONAL_STAGE_CALLEES = frozenset({"moe_stage_marker"})
+
+
 def _moe_stage_arguments(tree: ast.AST):
-    """Yield ``(callee, keyword)`` for every literal ``stage=`` on a MoE callee."""
+    """Yield ``(callee, constant)`` for every literal stage name on a MoE callee.
+
+    Covers both spellings: a ``stage=`` keyword argument, and the first
+    positional argument of the callees in :data:`_POSITIONAL_STAGE_CALLEES`.
+    """
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         callee = _callee_name(node.func)
         if callee is None or not _is_moe_callee(callee):
             continue
+        if callee in _POSITIONAL_STAGE_CALLEES and node.args:
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                yield callee, first
         for keyword in node.keywords:
             if keyword.arg == "stage" and isinstance(keyword.value, ast.Constant):
-                yield callee, keyword
+                yield callee, keyword.value
 
 
 #: Callables that pre-bind arguments, turning a required parameter into a
@@ -295,11 +313,9 @@ def test_stage_arguments_are_declared_moe_stages() -> None:
     offenders: list[str] = []
     for path in _python_sources():
         tree = ast.parse(path.read_text(), filename=str(path))
-        for callee, keyword in _moe_stage_arguments(tree):
-            if keyword.value.value not in declared:
-                offenders.append(
-                    f"{path.name}:{keyword.value.lineno} {callee}(stage={keyword.value.value!r})"
-                )
+        for callee, constant in _moe_stage_arguments(tree):
+            if constant.value not in declared:
+                offenders.append(f"{path.name}:{constant.lineno} {callee}({constant.value!r})")
 
     assert not offenders, (
         "these call sites pass a stage name that is not in MOE_STAGES:\n  " + "\n  ".join(offenders)
@@ -319,12 +335,21 @@ def test_non_moe_stage_arguments_are_not_flagged() -> None:
         'attention_softmax(stage="attn_input")\n'
         'builder.flash_attention(stage="prefill")\n'
         'moe_expert_activation_v0(builder, stage="expert_activation")\n'
+        'moe_stage_marker("gather", f"detail {x}")\n'
     )
-    matched = [(callee, keyword.value.value) for callee, keyword in _moe_stage_arguments(tree)]
+    matched = [(callee, constant.value) for callee, constant in _moe_stage_arguments(tree)]
 
-    assert matched == [("moe_expert_activation_v0", "expert_activation")], (
-        "the stage-argument matcher is not scoped to MoE callees; it picked up "
-        f"{matched}"
+    assert sorted(matched) == [
+        ("moe_expert_activation_v0", "expert_activation"),
+        ("moe_stage_marker", "gather"),
+    ], f"the stage-argument matcher is wrong; it picked up {matched}"
+
+    # The positional form is the one every real marker uses. Guard it explicitly:
+    # matching keywords alone left all 19 `moe_stage_marker` call sites uncovered.
+    typo = ast.parse('moe_stage_marker("gathr", "detail")\n')
+    assert [c.value for _callee, c in _moe_stage_arguments(typo)] == ["gathr"], (
+        "a positional stage name is invisible to the matcher, so the lint cannot "
+        "see the construct that actually emits a marker"
     )
 
 

--- a/aten/tests/test_moe_stage_attribution.py
+++ b/aten/tests/test_moe_stage_attribution.py
@@ -1,0 +1,164 @@
+"""Static guards on the MoE ``@stage=`` attribution contract.
+
+Stage markers are *sticky and authoritative*: once a program emits any marker,
+the emulator disables its legacy substring rules and bills every subsequent
+instruction to the most recent marker. Two consequences drive the tests here.
+
+1. A helper called from inside a marked region inherits the enclosing marker.
+   So an emitter reused across stages must be told which one it is serving, and
+   a **default** for that parameter is a silent wrong answer rather than a
+   missing one. This is not hypothetical: the shared-expert sigmoid gate reused
+   ``moe_materialize_route_weights_for_active_rows_v0``, inherited its
+   ``expert_route_weight`` default, and misattributed 999 instructions while
+   every total still added up and every test stayed green.
+
+2. A misattributed stage does not change instruction counts, cycle totals or
+   numerical results. Nothing downstream fails. The only place the mistake is
+   visible is the source line that omitted the argument -- so that is where it
+   has to be caught.
+
+Both tests read the source with :mod:`ast` rather than importing the modules and
+using :mod:`inspect`. Not to avoid the dependency chain -- ``aten/__init__.py``
+pulls in the op registry at collection time regardless -- but because parsing
+covers things introspection cannot:
+
+- a newly added module under ``aten/plena`` is checked the moment it lands, with
+  nobody having to remember to register it;
+- ``_DEPRECATED_METHOD_ALIASES`` rebinds emitters onto the mixin via ``setattr``,
+  so a signature-walk over class attributes sees the same function twice and the
+  declaration site not at all;
+- literal ``stage=`` *arguments* are visible, which a signature walk cannot see.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+PLENA_DIR = pathlib.Path(__file__).resolve().parents[1] / "plena"
+ROUTED_MOE_SOURCE = PLENA_DIR / "program_routed_moe.py"
+
+
+def _python_sources() -> list[pathlib.Path]:
+    sources = sorted(PLENA_DIR.rglob("*.py"))
+    assert sources, f"no Python sources found under {PLENA_DIR}; the guard would pass vacuously"
+    return sources
+
+
+def _functions(path: pathlib.Path):
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _declared_moe_stages() -> set[str]:
+    """Parse ``MOE_STAGES`` out of ``program_routed_moe.py``."""
+    tree = ast.parse(ROUTED_MOE_SOURCE.read_text(), filename=str(ROUTED_MOE_SOURCE))
+    for node in ast.walk(tree):
+        target = getattr(node, "target", None)
+        if isinstance(node, ast.AnnAssign) and isinstance(target, ast.Name) and target.id == "MOE_STAGES":
+            stages = {
+                literal.value
+                for literal in ast.walk(node.value)
+                if isinstance(literal, ast.Constant) and isinstance(literal.value, str)
+            }
+            assert stages, "parsed an empty MOE_STAGES; the literal shape changed"
+            return stages
+    pytest.fail(f"{ROUTED_MOE_SOURCE} no longer declares MOE_STAGES")
+
+
+def test_stage_parameters_have_no_default() -> None:
+    """An emitter that takes ``stage`` must force the caller to name one.
+
+    Scoped to "has a ``stage`` parameter" rather than "is reused across >= 2
+    stages", because the two coincide by construction: a helper serving exactly
+    one stage hardcodes its marker and never takes the parameter at all. Taking
+    it *is* the declaration that the emitter is stage-polymorphic.
+    """
+    offenders: list[str] = []
+    for path in _python_sources():
+        for func in _functions(path):
+            args = func.args
+            defaulted = [
+                (arg, default)
+                for arg, default in zip(args.kwonlyargs, args.kw_defaults)
+                if arg.arg == "stage" and default is not None
+            ]
+            # Positional `stage` params: line them up with their trailing defaults.
+            positional = args.posonlyargs + args.args
+            padding = len(positional) - len(args.defaults)
+            defaulted += [
+                (arg, args.defaults[index - padding])
+                for index, arg in enumerate(positional)
+                if arg.arg == "stage" and index >= padding
+            ]
+            for arg, default in defaulted:
+                offenders.append(f"{path.name}:{func.lineno} {func.name}(stage={ast.unparse(default)})")
+
+    assert not offenders, (
+        "these emitters give `stage` a default, so a caller that forgets it is "
+        "silently billed to the wrong stage instead of failing:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_stage_arguments_are_declared_moe_stages() -> None:
+    """Every literal ``stage=`` argument must name a real stage.
+
+    ``moe_stage_marker`` already rejects unknown names, but only on the paths a
+    test actually emits. A typo on a rarely-exercised branch would otherwise
+    reach the emulator, land in ``unresolved_stage_markers``, and leave that
+    region inheriting the previous marker.
+    """
+    declared = _declared_moe_stages()
+    offenders: list[str] = []
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != "stage" or not isinstance(keyword.value, ast.Constant):
+                    continue
+                if keyword.value.value not in declared:
+                    offenders.append(f"{path.name}:{node.lineno} stage={keyword.value.value!r}")
+
+    assert not offenders, (
+        "these call sites pass a stage name that is not in MOE_STAGES:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_guard_would_catch_a_defaulted_stage_parameter() -> None:
+    """The lint above is only worth having if it can fail. Prove it does.
+
+    Without this, a refactor that broke the AST walk (a renamed field, a missed
+    argument category) would leave both tests passing over zero findings.
+    """
+    module = ast.parse(
+        "def emit(self, x, *, policy: str = 'p', stage: str = 'gather', name: str) -> None: ...\n"
+        "def emit_positional(self, stage: str = 'gather') -> None: ...\n"
+        "def emit_ok(self, x, *, stage: str, name: str) -> None: ...\n"
+    )
+    found = []
+    for func in (node for node in ast.walk(module) if isinstance(node, ast.FunctionDef)):
+        args = func.args
+        hits = [
+            arg
+            for arg, default in zip(args.kwonlyargs, args.kw_defaults)
+            if arg.arg == "stage" and default is not None
+        ]
+        positional = args.posonlyargs + args.args
+        padding = len(positional) - len(args.defaults)
+        hits += [
+            arg for index, arg in enumerate(positional) if arg.arg == "stage" and index >= padding
+        ]
+        if hits:
+            found.append(func.name)
+
+    assert found == ["emit", "emit_positional"], (
+        f"the AST walk no longer detects defaulted stage parameters, so "
+        f"test_stage_parameters_have_no_default cannot fail; detected {found}"
+    )

--- a/aten/tests/test_moe_stage_attribution.py
+++ b/aten/tests/test_moe_stage_attribution.py
@@ -40,6 +40,24 @@ import pytest
 PLENA_DIR = pathlib.Path(__file__).resolve().parents[1] / "plena"
 ROUTED_MOE_SOURCE = PLENA_DIR / "program_routed_moe.py"
 
+TESTS_DIR = pathlib.Path(__file__).resolve().parent
+CI_WORKFLOW = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+
+#: Test files in this directory that no CI job runs yet.
+#:
+#: Every one of them imports torch and some want a real checkpoint, so wiring
+#: them up is its own piece of work. Pinning the set is what stops a *newly
+#: added* unwired file from hiding among them.
+_UNWIRED_TESTS = frozenset(
+    {
+        "test_bf16_numerical_stability.py",
+        "test_gpt_oss_moe_assertions.py",
+        "test_gpt_oss_moe_reference.py",
+        "test_plena_compiler.py",
+        "test_quantization_ablation.py",
+    }
+)
+
 
 def _python_sources() -> list[pathlib.Path]:
     sources = sorted(PLENA_DIR.rglob("*.py"))
@@ -128,6 +146,36 @@ def test_stage_arguments_are_declared_moe_stages() -> None:
 
     assert not offenders, (
         "these call sites pass a stage name that is not in MOE_STAGES:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_every_test_file_here_is_wired_into_ci() -> None:
+    """A guard no job runs is worth exactly nothing.
+
+    These lints sat in the tree with no workflow invoking them, which is
+    indistinguishable from never having written them. This catches the next
+    instance: a new file under ``aten/tests`` has to be named by a workflow, or
+    else declared unwired on purpose.
+
+    Matched as a substring of the workflow text rather than by parsing the job
+    graph. A file named in a commented-out step would count as covered, which is
+    the one false negative -- worth it to keep this readable and dependency-free.
+    """
+    workflow = CI_WORKFLOW.read_text()
+    present = {path.name for path in TESTS_DIR.glob("test_*.py")}
+    assert present, f"no test files found under {TESTS_DIR}; this guard would pass vacuously"
+
+    unwired = sorted(name for name in present if name not in workflow and name not in _UNWIRED_TESTS)
+    assert not unwired, (
+        "these test files are in the tree but no CI job runs them, so they cannot "
+        f"fail anything:\n  " + "\n  ".join(unwired) + f"\nadd a step to {CI_WORKFLOW.name} "
+        "or, if that is deliberate, add them to _UNWIRED_TESTS with a reason"
+    )
+
+    stale = sorted(name for name in _UNWIRED_TESTS if name not in present or name in workflow)
+    assert not stale, (
+        "_UNWIRED_TESTS names files that are now wired into CI or no longer exist; "
+        f"drop them so the exemption list keeps meaning something:\n  " + "\n  ".join(stale)
     )
 
 

--- a/aten/tests/test_moe_stage_attribution.py
+++ b/aten/tests/test_moe_stage_attribution.py
@@ -107,6 +107,62 @@ def _moe_stage_arguments(tree: ast.AST):
                 yield callee, keyword
 
 
+#: Callables that pre-bind arguments, turning a required parameter into a
+#: supplied one at the binding site rather than in a signature.
+_PARTIAL_BINDERS = frozenset({"partial", "partialmethod"})
+
+
+def _stage_defaulting_lambdas(tree: ast.AST):
+    """Yield lambdas that give ``stage`` a default.
+
+    :func:`_functions` walks ``def`` and ``async def`` only. A lambda carries
+    the same ``arguments`` node and the same failure mode, and nothing was
+    looking at it.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Lambda) and _defaulted_stage_params(node):
+            yield node
+
+
+def _stage_binding_calls(tree: ast.AST):
+    """Yield ``functools.partial``-style calls that pre-bind ``stage``.
+
+    ``partial(emit, stage="gather")`` hands back a callable whose ``stage`` is
+    already supplied. Every call through it omits the argument and is billed to
+    whatever the binding site chose -- a default by another route, with exactly
+    the consequence the required parameter exists to prevent.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _callee_name(node.func) in _PARTIAL_BINDERS and any(
+            keyword.arg == "stage" for keyword in node.keywords
+        ):
+            yield node
+
+
+def _stage_injecting_decorators(tree: ast.AST):
+    """Yield ``(func, decorator)`` for decorators handed a ``stage=`` argument.
+
+    Catches the declared shape, ``@with_stage(stage="gather")``. A decorator
+    that injects a stage without naming it in its own call -- reading it from a
+    closure, a registry or an attribute -- is not detectable without resolving
+    what the decorator does, which is well beyond a source lint.
+
+    TODO: if such a decorator is ever introduced, the check has to become a
+    convention (an explicit allowlist of stage-injecting decorators) rather than
+    a deeper analysis.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if isinstance(decorator, ast.Call) and any(
+                keyword.arg == "stage" for keyword in decorator.keywords
+            ):
+                yield node, decorator
+
+
 def _defaulted_stage_params(func) -> list[tuple[ast.arg, ast.expr]]:
     """Every ``stage`` parameter of *func* that carries a default, with it.
 
@@ -166,6 +222,61 @@ def test_stage_parameters_have_no_default() -> None:
         "silently billed to the wrong stage instead of failing:\n  "
         + "\n  ".join(offenders)
     )
+
+
+def test_stage_defaults_are_not_reintroduced_indirectly() -> None:
+    """A ``def`` signature is not the only way to supply ``stage``.
+
+    :func:`test_stage_parameters_have_no_default` walks ``def`` and ``async
+    def``. Three constructs get a stage in without one, each leaving call sites
+    that never name it -- the exact condition the required parameter exists to
+    prevent, reached by a route the lint did not look at.
+    """
+    offenders: list[str] = []
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in _stage_defaulting_lambdas(tree):
+            offenders.append(f"{path.name}:{node.lineno} lambda with a defaulted `stage`")
+        for node in _stage_binding_calls(tree):
+            offenders.append(
+                f"{path.name}:{node.lineno} {_callee_name(node.func)}(..., stage=...) pre-binds `stage`"
+            )
+        for func, decorator in _stage_injecting_decorators(tree):
+            offenders.append(
+                f"{path.name}:{decorator.lineno} @{_callee_name(decorator.func)}(stage=...) on {func.name}"
+            )
+
+    assert not offenders, (
+        "these supply `stage` without a signature default, so callers still never "
+        "have to name one:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_guard_would_catch_an_indirectly_supplied_stage(tmp_path: pathlib.Path) -> None:
+    """Prove the three indirect checks can fail.
+
+    Same reasoning as the signature self-check: a lint that has never fired is
+    indistinguishable from one that cannot.
+    """
+    tree = ast.parse(
+        "emit_gather = lambda rows, *, stage='gather': None\n"
+        "emit_clean = lambda rows, *, stage: None\n"
+        "bound = functools.partial(emit, stage='gather')\n"
+        "bound_method = partialmethod(emit, stage='gather')\n"
+        "bound_clean = functools.partial(emit, rows=[0])\n"
+        "@with_stage(stage='gather')\n"
+        "def decorated(self) -> None: ...\n"
+        "@some_other_decorator(name='x')\n"
+        "def undecorated(self) -> None: ...\n"
+    )
+
+    lambdas = [node.lineno for node in _stage_defaulting_lambdas(tree)]
+    bindings = [_callee_name(node.func) for node in _stage_binding_calls(tree)]
+    decorated = [func.name for func, _decorator in _stage_injecting_decorators(tree)]
+
+    assert lambdas == [1], f"defaulted-stage lambdas not detected; found {lambdas}"
+    assert bindings == ["partial", "partialmethod"], f"partial bindings not detected; found {bindings}"
+    assert decorated == ["decorated"], f"stage-injecting decorators not detected; found {decorated}"
 
 
 def test_stage_arguments_are_declared_moe_stages() -> None:

--- a/aten/tests/test_moe_stage_attribution.py
+++ b/aten/tests/test_moe_stage_attribution.py
@@ -72,6 +72,41 @@ def _functions(path: pathlib.Path):
             yield node
 
 
+def _callee_name(func: ast.expr) -> str | None:
+    """The bare name a call resolves to, for ``f(...)`` and ``obj.f(...)`` alike."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_moe_callee(name: str) -> bool:
+    """Whether *name*'s ``stage=`` argument means a MoE attribution stage.
+
+    ``stage`` is not a reserved word. The attention emitters take one too --
+    ``qkt_multiply(stage="decode")`` selects prefill vs decode and has nothing
+    to do with MoE attribution -- so matching every ``stage=`` keyword in the
+    tree reports those as unknown stage names. Match on the callee instead.
+
+    ``moe_stage_marker`` is covered by the ``moe_`` prefix.
+    """
+    return name.startswith(("moe_", "gpt_oss_"))
+
+
+def _moe_stage_arguments(tree: ast.AST):
+    """Yield ``(callee, keyword)`` for every literal ``stage=`` on a MoE callee."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = _callee_name(node.func)
+        if callee is None or not _is_moe_callee(callee):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "stage" and isinstance(keyword.value, ast.Constant):
+                yield callee, keyword
+
+
 def _defaulted_stage_params(func) -> list[tuple[ast.arg, ast.expr]]:
     """Every ``stage`` parameter of *func* that carries a default, with it.
 
@@ -140,22 +175,45 @@ def test_stage_arguments_are_declared_moe_stages() -> None:
     test actually emits. A typo on a rarely-exercised branch would otherwise
     reach the emulator, land in ``unresolved_stage_markers``, and leave that
     region inheriting the previous marker.
+
+    Scoped to MoE callees by :func:`_is_moe_callee`, so an unrelated emitter
+    that happens to take a ``stage`` argument is not reported as a bad stage
+    name.
     """
     declared = _declared_moe_stages()
     offenders: list[str] = []
     for path in _python_sources():
         tree = ast.parse(path.read_text(), filename=str(path))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            for keyword in node.keywords:
-                if keyword.arg != "stage" or not isinstance(keyword.value, ast.Constant):
-                    continue
-                if keyword.value.value not in declared:
-                    offenders.append(f"{path.name}:{node.lineno} stage={keyword.value.value!r}")
+        for callee, keyword in _moe_stage_arguments(tree):
+            if keyword.value.value not in declared:
+                offenders.append(
+                    f"{path.name}:{keyword.value.lineno} {callee}(stage={keyword.value.value!r})"
+                )
 
     assert not offenders, (
         "these call sites pass a stage name that is not in MOE_STAGES:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_non_moe_stage_arguments_are_not_flagged() -> None:
+    """``stage=`` on an unrelated emitter is not a MoE stage name.
+
+    The attention path calls ``qkt_multiply(stage="decode")``, where ``stage``
+    selects prefill vs decode. A matcher keyed on the argument name alone
+    reports that as an unknown MoE stage -- a false positive on correct code,
+    which is how a lint gets suppressed and then ignored.
+    """
+    tree = ast.parse(
+        'qkt_multiply(d=16, stage="decode", mlen=4)\n'
+        'attention_softmax(stage="attn_input")\n'
+        'builder.flash_attention(stage="prefill")\n'
+        'moe_expert_activation_v0(builder, stage="expert_activation")\n'
+    )
+    matched = [(callee, keyword.value.value) for callee, keyword in _moe_stage_arguments(tree)]
+
+    assert matched == [("moe_expert_activation_v0", "expert_activation")], (
+        "the stage-argument matcher is not scoped to MoE callees; it picked up "
+        f"{matched}"
     )
 
 

--- a/doc/operation.svh
+++ b/doc/operation.svh
@@ -179,7 +179,8 @@ typedef enum logic [instruction_pkg::OPCODE_WIDTH - 1:0] {
     C_BREAK                = 6'h34,
     V_MAX_VF               = 6'h35,
     V_MIN_VF               = 6'h36,
-    V_TOPK                 = 6'h37
+    V_TOPK                 = 6'h37,
+    C_SET_TOPK_REG         = 6'h38
 } CUSTOM_ISA_OPCODE;
 
 typedef enum logic [2:0] {

--- a/doc/plena_isa_spec.md
+++ b/doc/plena_isa_spec.md
@@ -323,8 +323,17 @@ index. `rmask` selects the routed-MoE policy:
   `FP_MEM[gp_reg<rd> + 0..3]` / `INT_MEM[gp_reg<rs2> + 0..3]`.
 - `rmask=1`: scan 128 logits, select top-8, and write weights/indices to
   `FP_MEM[gp_reg<rd> + 0..7]` / `INT_MEM[gp_reg<rs2> + 0..7]`.
+- `rmask=15`: take `(num_experts, top_k)` from the `TOPK_POLICY` control
+  register instead of a fixed table. See `C_SET_TOPK_REG`.
 
 Weights are softmax-over-selected logits.
+
+Values `0` and `1` are the original fixed policies and cover GPT-OSS (32/top-4)
+and Qwen3-30B-A3B (128/top-8). Every other production MoE shape — Qwen2-MoE
+60/top-4, DeepSeek-V2-Lite 64/top-6, DeepSeek-V3 256/top-8, Llama-4 Scout
+16/top-1 — needs `rmask=15`, which is why the escape exists: adding a table
+entry per model would make every new architecture an ISA change. `rmask` values
+`2..14` are reserved and trap.
 
 This is a correctness-first v0 linear scan. Bitonic/performance top-k remains a
 future optimization.
@@ -705,6 +714,33 @@ C_SET_STRIDE_REG gp4               ; STRIDE_SIZE = 128
 **Description:**
 
 Set the vector mask register for masked vector operations.
+
+### C_SET_TOPK_REG
+
+**Format:** `C_SET_TOPK_REG rd`
+
+**Operation:** `TOPK_POLICY = gp_reg<rd>`
+
+**Description:**
+
+Set the routed-MoE top-k policy consumed by `V_TOPK rmask=15`. The register holds
+both fields packed as `(num_experts << 8) | top_k`.
+
+The 8-bit shift is chosen so the packed value fits a single 22-bit `S_ADDI_INT`
+immediate for every shape up to 16383 experts, avoiding an `S_LUI_INT` pair. It
+therefore constrains `top_k <= 255`, which no published MoE approaches.
+
+Like the other `C_SET_*_REG` control registers this is sticky: it persists until
+overwritten, so a program with one routing policy sets it once. `V_TOPK` traps if
+`rmask=15` is executed while the register is unset, rather than silently routing
+with `top_k=0`.
+
+**Example:**
+```asm
+S_ADDI_INT gp4, gp0, 16390         ; (64 << 8) | 6  -- DeepSeek-V2-Lite
+C_SET_TOPK_REG gp4                 ; TOPK_POLICY = 64 experts, top-6
+V_TOPK gp1, gp2, gp3, 15           ; route one token under that policy
+```
 
 ### C_BREAK
 


### PR DESCRIPTION
## What this PR does

Stacked review hardening for the MoE stage-attribution contract. Makes `stage` a
required argument on the stage-polymorphic emitters, adds a lint that enforces it
(and the routes around it), and closes two attribution gaps found while doing so.

> **Stacked on [#69](https://github.com/AICrossSim/PLENA_Compiler/pull/69)** —
> base branch is `feat/shared-expert-moe`, not `main`. **Merge #69 first.**
> The emulator half is
> [PLENA_Simulator#101](https://github.com/AICrossSim/PLENA_Simulator/pull/101),
> stacked on PLENA_Simulator#97; the submodule pin couples them, so this branch
> must land before that one.

## 1. `stage` becomes required — and stays required

`209e299` drops the default from `moe_materialize_route_weights_for_active_rows_v0`,
`moe_true_zero_vram_rows_v0` and `moe_expert_activation_v0`. Markers are sticky, so
an emitter called from inside a marked region inherits the enclosing marker: a
*default* for that parameter is a silent wrong answer rather than a missing one.
This is not hypothetical — the shared-expert sigmoid gate inherited
`expert_route_weight` and misattributed 999 instructions while every total still
added up and every test stayed green.

A defaulted `stage` is only one of several ways to supply one without the caller
naming it. `7b9d46e` also rejects:

- **lambdas** — same `arguments` node, none of the coverage;
- **`functools.partial` / `partialmethod`** bindings that pre-bind `stage`;
- **decorators handed `stage=`**, e.g. `@with_stage(stage="gather")`.

A decorator that injects a stage without naming it in its own call cannot be
detected without resolving what the decorator does. That limit is stated at the
helper, with a TODO saying the answer is an explicit allowlist rather than deeper
analysis.

## 2. The lint now runs

`74ec261` adds a `moe-stage-guard` job. Before it, `ci.yml` ran the generator tests
and a codegen smoke and **nothing under `aten/tests` at all** — so the guard could
not have failed a pull request, which is indistinguishable from not having written
it. The job needs neither torch nor a checkpoint (the lint parses source with
`ast`), so it is pytest + pyyaml and a couple of seconds.

Naming one file in a workflow step recreates the same hole one file over, so
`test_every_test_file_here_is_wired_into_ci` asserts every `aten/tests/test_*.py`
is either named in `ci.yml` or listed in `_UNWIRED_TESTS`. The five files on that
list all import torch; pinning them is what stops a new unwired file hiding among
them, and the list is checked in both directions.

## 3. Attribution fixes

- **`residual_setup` joins `MOE_STAGES`** (`7565629`). MoE input preparation — the
  residual buffer zero, the residual copy, the input RMSNorm and its norm-weight
  multiply — was being labelled `accumulator_init`, which is the combine
  accumulator that expert outputs are scattered into. Different thing, and the cost
  scales with `rows × hidden` rather than with the accumulator.
- **The two `qwen3_router_logits_*` emitters gain the `router_topk` marker.** They
  had none, and both lower through general-purpose projection helpers that have
  none either, so the entire router GEMM was billed to whatever stage preceded the
  call. `moe_router_logits_bf16_v0` already marked itself; these now match. This is
  part of the same fix rather than a separate one: relabelling the residual zero
  without it would have moved the Qwen router GEMM into `residual_setup` — a new
  wrong attribution instead of the old one.

Markers are comments (`IsaBuilder().comment(...)`), so no instruction count, cycle
total or numerical result changes — only which stage the profile bills.

## 4. Caveat de-duplication

`SHARED_VS_ROUTED_NOTE` becomes a module constant in `program_moe_shared.py`
(`916f990`). The warning that a shared-vs-routed ratio measures this compiler's
lowering rather than MoE hardware previously existed as prose here *and*, in
different words, as a hardcoded string in the emulator that ships it in the profile
JSON — with nothing checking they agreed. The wording of a caveat is the whole of
its content. The emulator keeps its own copy (it writes that JSON with no Python
available) and a test on that side asserts byte equality.

`a387f98` also qualifies `fused_shared_intermediate`'s "exactly equal" as holding
in exact real arithmetic: as emitted, FP associativity and MXFP8 block alignment
(e4m3, one e8m0 scale per block of 8) both make it non-bit-identical. Small, and it
does not make the fusion wrong — but a bit-exactness test written against the old
wording would have failed for entirely correct reasons.

## Validation

`pytest aten/tests/test_moe_stage_attribution.py` — 7/7, on pytest + pyyaml with no
torch installed. Each guard was also verified to *fail* correctly: an injected
defaulted-stage lambda, a `partial` binding and a `partialmethod` binding are each
reported with file and line; a `stage="acumulator_init"` typo on a MoE callee is
reported while `qkt_multiply(stage="decode")` is not; an unwired test file and a
stale `_UNWIRED_TESTS` entry each fail by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
