### PR TITLE
Add symbolic final-schedule CostTrace backend

### DIFF
--- a/aten/cost_frontend.py
+++ b/aten/cost_frontend.py
@@ -1,0 +1,610 @@
+"""Shape-only frontends that meter the production compiler lowering.
+
+No model weights are loaded.  Inputs carry only logical/physical shape and HBM
+ownership, then the ordinary :class:`PlenaCompiler` methods emit the final ISA
+and its symbolic CostTrace together.  This keeps workload construction outside
+the timing model while preserving the compiler as the sole source of opcode
+and DMA work.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import math
+from pathlib import Path
+import json
+from typing import Any
+
+import compiler.aten.ops as ops
+from compiler.aten.model_extract import ModelConfig
+from compiler.aten.ops.registry import Backend, OpRegistry
+from compiler.aten.plena import PlenaCompiler
+from compiler.aten.plena_frontend import (
+    AttentionHeadPacking,
+    LayerInputVars,
+    _emit_attention_block,
+    _emit_ffn_block,
+    _emit_packed_attention_block,
+)
+from compiler.aten.program_sink import CostTrace
+
+
+def _ceil(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _value(mapping: Mapping[str, Any], *names: str, default: Any = None) -> Any:
+    for name in names:
+        if name in mapping:
+            return mapping[name]
+    return default
+
+
+@dataclass(frozen=True)
+class DecoderModelSpec:
+    hidden_size: int
+    intermediate_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    num_hidden_layers: int = 1
+    model_type: str = "qwen3"
+    rms_norm_eps: float = 1e-5
+    num_experts: int = 0
+    experts_per_token: int = 0
+    moe_intermediate_size: int | None = None
+
+    @classmethod
+    def load(cls, value: "DecoderModelSpec | Mapping[str, Any] | str | Path") -> "DecoderModelSpec":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, (str, Path)):
+            with Path(value).open() as handle:
+                value = json.load(handle)
+        if not isinstance(value, Mapping):
+            raise TypeError("model specification must be a mapping or JSON path")
+        hidden = int(_value(value, "hidden_size"))
+        heads = int(_value(value, "num_attention_heads", "num_heads"))
+        kv_heads = int(_value(value, "num_key_value_heads", "num_kv_heads", default=heads))
+        return cls(
+            hidden_size=hidden,
+            intermediate_size=int(_value(value, "intermediate_size", default=4 * hidden)),
+            num_attention_heads=heads,
+            num_key_value_heads=kv_heads,
+            head_dim=int(_value(value, "head_dim", default=hidden // heads)),
+            num_hidden_layers=int(_value(value, "num_hidden_layers", "num_layers", default=1)),
+            model_type=str(_value(value, "model_type", default="qwen3")),
+            rms_norm_eps=float(_value(value, "rms_norm_eps", default=1e-5)),
+            num_experts=int(_value(value, "num_experts", default=0) or 0),
+            experts_per_token=int(
+                _value(value, "num_experts_per_tok", "experts_per_token", default=0) or 0
+            ),
+            moe_intermediate_size=(
+                None
+                if _value(value, "moe_intermediate_size", "moe_inter_dim") is None
+                else int(_value(value, "moe_intermediate_size", "moe_inter_dim"))
+            ),
+        )
+
+    def validate(self) -> None:
+        for name in (
+            "hidden_size",
+            "intermediate_size",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "head_dim",
+            "num_hidden_layers",
+        ):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.num_attention_heads % self.num_key_value_heads:
+            raise ValueError("num_attention_heads must be divisible by num_key_value_heads")
+
+
+@dataclass(frozen=True)
+class CompilerHardwareSpec:
+    mlen: int
+    blen: int
+    mram_tile_capacity: int = 4
+    hlen: int | None = None
+    broadcast_amount: int | None = None
+    attention_head_packing: bool = False
+    hbm_v_prefetch_amount: int = 4
+    hbm_v_writeback_amount: int = 4
+
+    def validate(self) -> None:
+        if self.mlen <= 0 or self.blen <= 0 or self.mram_tile_capacity <= 0:
+            raise ValueError("MLEN, BLEN and MRAM tile capacity must be positive")
+        if self.mlen % self.blen:
+            raise ValueError("MLEN must be divisible by BLEN")
+        if self.attention_head_packing:
+            if self.hlen is None or self.broadcast_amount is None:
+                raise ValueError("packed attention requires HLEN and broadcast_amount")
+            if self.hlen * self.broadcast_amount != self.mlen:
+                raise ValueError("packed attention requires HLEN*broadcast_amount == MLEN")
+
+
+@dataclass(frozen=True)
+class RoutingHistogram:
+    """Explicit routed-token counts, one entry per expert."""
+
+    routes_per_expert: tuple[int, ...]
+    token_count: int
+    top_k: int
+    label: str = "explicit"
+
+    def __post_init__(self) -> None:
+        if self.token_count <= 0 or self.top_k <= 0:
+            raise ValueError("token_count and top_k must be positive")
+        if not self.routes_per_expert or any(count < 0 for count in self.routes_per_expert):
+            raise ValueError("routes_per_expert must be a non-empty nonnegative histogram")
+        expected = self.token_count * self.top_k
+        if sum(self.routes_per_expert) != expected:
+            raise ValueError(
+                f"routing histogram has {sum(self.routes_per_expert)} routes, expected {expected}"
+            )
+
+    @classmethod
+    def balanced(cls, *, token_count: int, top_k: int, num_experts: int) -> "RoutingHistogram":
+        total = token_count * top_k
+        base, remainder = divmod(total, num_experts)
+        return cls(
+            routes_per_expert=tuple(base + (expert < remainder) for expert in range(num_experts)),
+            token_count=token_count,
+            top_k=top_k,
+            label="balanced-fixture",
+        )
+
+    @classmethod
+    def skewed(
+        cls,
+        *,
+        token_count: int,
+        top_k: int,
+        num_experts: int,
+        hot_fraction: float = 0.5,
+    ) -> "RoutingHistogram":
+        if not 0 < hot_fraction < 1:
+            raise ValueError("hot_fraction must lie in (0, 1)")
+        total = token_count * top_k
+        hot = int(total * hot_fraction)
+        tail = total - hot
+        base, remainder = divmod(tail, max(1, num_experts - 1))
+        values = [hot]
+        values.extend(base + (idx < remainder) for idx in range(num_experts - 1))
+        return cls(tuple(values), token_count, top_k, label="skewed-fixture")
+
+
+@dataclass(frozen=True)
+class CompilerTraceResult:
+    trace: CostTrace
+    assembly: str | None
+    metadata: dict[str, Any]
+
+
+def _model_config(spec: DecoderModelSpec) -> ModelConfig:
+    return ModelConfig(
+        hidden_size=spec.hidden_size,
+        inter_dim=spec.intermediate_size,
+        num_heads=spec.num_attention_heads,
+        num_kv_heads=spec.num_key_value_heads,
+        head_dim=spec.head_dim,
+        eps=spec.rms_norm_eps,
+        rope_theta=10_000.0,
+        vocab_size=None,
+        model_type=spec.model_type,
+    )
+
+
+def _register_dense_layer_inputs(
+    program: PlenaCompiler,
+    model: DecoderModelSpec,
+    *,
+    padded_hidden: int,
+    padded_intermediate: int,
+    padded_head_dim: int,
+    total_q_dim: int,
+) -> LayerInputVars:
+    return LayerInputVars(
+        w_q=program.input(
+            "W_q_0", (padded_hidden, total_q_dim), memory_role="weight"
+        ),
+        w_o=program.input(
+            "W_o_0", (total_q_dim, padded_hidden), memory_role="weight"
+        ),
+        w_k_heads=[
+            program.input(
+                f"W_k_0_h{head}",
+                (padded_hidden, padded_head_dim),
+                memory_role="weight",
+            )
+            for head in range(model.num_key_value_heads)
+        ],
+        w_v_heads=[
+            program.input(
+                f"W_v_0_h{head}",
+                (padded_hidden, padded_head_dim),
+                memory_role="weight",
+            )
+            for head in range(model.num_key_value_heads)
+        ],
+        w_gate=program.input(
+            "W_gate_0", (padded_hidden, padded_intermediate), memory_role="weight"
+        ),
+        w_up=program.input(
+            "W_up_0", (padded_hidden, padded_intermediate), memory_role="weight"
+        ),
+        w_down=program.input(
+            "W_down_0", (padded_intermediate, padded_hidden), memory_role="weight"
+        ),
+    )
+
+
+def compile_dense_decoder_trace(
+    model_config: DecoderModelSpec | Mapping[str, Any] | str | Path,
+    hardware: CompilerHardwareSpec,
+    *,
+    seq_len: int,
+    batch_size: int = 1,
+    num_layers: int | None = None,
+    compiler_hash: str = "unknown",
+    include_assembly: bool = False,
+) -> CompilerTraceResult:
+    """Lower one representative dense layer through the production compiler."""
+    model = DecoderModelSpec.load(model_config)
+    model.validate()
+    hardware.validate()
+    if seq_len <= 0 or batch_size <= 0:
+        raise ValueError("seq_len and batch_size must be positive")
+    layers = model.num_hidden_layers if num_layers is None else int(num_layers)
+    if layers <= 0:
+        raise ValueError("num_layers must be positive")
+
+    OpRegistry.load().set_backend(Backend.PLENA)
+    mlen, blen = hardware.mlen, hardware.blen
+    padded_seq = _ceil(seq_len, mlen if seq_len < mlen else blen)
+    rows_per_batch = padded_seq if batch_size == 1 else _ceil(max(mlen, padded_seq), mlen)
+    physical_rows = batch_size * rows_per_batch
+    padded_hidden = _ceil(model.hidden_size, mlen)
+    padded_intermediate = _ceil(model.intermediate_size, mlen)
+    padded_head_dim = _ceil(model.head_dim, mlen)
+    ratio = model.num_attention_heads // model.num_key_value_heads
+
+    head_packing: AttentionHeadPacking | None = None
+    if hardware.attention_head_packing:
+        assert hardware.hlen is not None and hardware.broadcast_amount is not None
+        if seq_len > mlen:
+            raise ValueError("main packed-GQA lowering does not support sequence-tiled attention")
+        if model.head_dim > hardware.hlen or ratio > hardware.broadcast_amount:
+            raise ValueError("model heads do not fit the requested main packed-GQA layout")
+        head_packing = AttentionHeadPacking(
+            enabled=True,
+            hlen=hardware.hlen,
+            broadcast_amount=hardware.broadcast_amount,
+            head_slot_dim=hardware.hlen,
+            group_width=mlen,
+            total_q_dim=model.num_key_value_heads * mlen,
+        )
+    total_q_dim = (
+        head_packing.total_q_dim
+        if head_packing is not None
+        else model.num_attention_heads * padded_head_dim
+    )
+
+    program = PlenaCompiler(
+        mlen=mlen,
+        blen=blen,
+        mram_tile_capacity=hardware.mram_tile_capacity,
+        hbm_v_prefetch_amount=hardware.hbm_v_prefetch_amount,
+        hbm_v_writeback_amount=hardware.hbm_v_writeback_amount,
+        cost_trace=True,
+        compiler_hash=compiler_hash,
+    )
+    layer_inputs = _register_dense_layer_inputs(
+        program,
+        model,
+        padded_hidden=padded_hidden,
+        padded_intermediate=padded_intermediate,
+        padded_head_dim=padded_head_dim,
+        total_q_dim=total_q_dim,
+    )
+    x_input = program.input(
+        "X", (physical_rows, padded_hidden), memory_role="activation"
+    )
+    pos_input = program.input(
+        "POS", (physical_rows, padded_hidden), memory_role="activation"
+    )
+    rope_width = head_packing.group_width if head_packing is not None else padded_head_dim
+    r_input = program.input("R_rope", (rope_width, rope_width), memory_role="weight")
+    cos_input = program.input("COS", (physical_rows, rope_width), memory_role="activation")
+    sin_input = program.input("SIN", (physical_rows, rope_width), memory_role="activation")
+    mask_input = program.input("causal_mask", (mlen, mlen), memory_role="activation")
+
+    with program.cost_stage("global/setup"):
+        cos = program.load_batch(cos_input, name="COS")
+        sin = program.load_batch(sin_input, name="SIN")
+        causal_mask = program.load_batch(mask_input, name="CAUSAL_MASK")
+        current = program.load_batch(x_input, name="X")
+        pos = program.load_batch(pos_input, name="POS")
+        ops.embedding_add(program, current, pos)
+
+    scratch = program.alloc(
+        "residual_scratch",
+        physical_rows,
+        padded_hidden,
+        strict=False,
+        physical_shape=(physical_rows, padded_hidden),
+    )
+    scale = 1.0 / math.sqrt(model.head_dim)
+    with program.cost_stage("decoder/layer/attention"):
+        if head_packing is not None:
+            current = _emit_packed_attention_block(
+                program,
+                current,
+                layer_inputs,
+                (r_input, cos, sin),
+                causal_mask,
+                scratch,
+                scale,
+                0,
+                padded_seq,
+                model.head_dim,
+                model.num_key_value_heads,
+                ratio,
+                head_packing,
+                batch_size=batch_size,
+                rows_per_batch=rows_per_batch,
+                active_seq_len_per_batch=seq_len,
+            )
+        else:
+            current = _emit_attention_block(
+                program,
+                current,
+                layer_inputs,
+                (r_input, cos, sin),
+                causal_mask,
+                scratch,
+                scale,
+                0,
+                padded_seq,
+                padded_head_dim,
+                total_q_dim,
+                model.num_attention_heads,
+                model.num_key_value_heads,
+                ratio,
+                batch_size=batch_size,
+                rows_per_batch=rows_per_batch,
+                active_seq_len_per_batch=seq_len,
+            )
+    with program.cost_stage("decoder/layer/ffn"):
+        current = _emit_ffn_block(program, current, layer_inputs, scratch)
+    with program.cost_stage("decoder/final_norm"):
+        ops.rms_norm(program, current, eps_offset=3, reci_hid_offset=4)
+
+    trace = program.get_cost_trace(
+        frontend="shape-only-dense-v1",
+        model_type=model.model_type,
+        representative_layer_count=1,
+        requested_layer_count=layers,
+        layer_scaling_required=layers != 1,
+        seq_len=seq_len,
+        batch_size=batch_size,
+        hardware={
+            "mlen": mlen,
+            "blen": blen,
+            "mram_tile_capacity": hardware.mram_tile_capacity,
+        },
+    )
+    metadata = {
+        "model": model,
+        "hardware": hardware,
+        "physical_rows": physical_rows,
+        "rows_per_batch": rows_per_batch,
+        "padded_hidden": padded_hidden,
+        "padded_intermediate": padded_intermediate,
+        "padded_head_dim": padded_head_dim,
+        "requested_layers": layers,
+        "trace_layer_semantics": "one representative layer plus global setup/final norm",
+    }
+    return CompilerTraceResult(
+        trace=trace,
+        assembly=program.compile() if include_assembly else None,
+        metadata=metadata,
+    )
+
+
+def compile_routed_moe_trace(
+    model_config: DecoderModelSpec | Mapping[str, Any] | str | Path,
+    hardware: CompilerHardwareSpec,
+    routing: RoutingHistogram,
+    *,
+    compiler_hash: str = "unknown",
+    include_assembly: bool = False,
+    max_detailed_routes: int = 4096,
+) -> CompilerTraceResult:
+    """Meter main's routed expert/gather/scatter path for an explicit histogram.
+
+    This detailed backend intentionally rejects production route counts; the
+    algebraically compressed backend added in the next layer lowers each bucket
+    shape once.  It never invents a balanced runtime routing policy.
+    """
+    model = DecoderModelSpec.load(model_config)
+    model.validate()
+    hardware.validate()
+    if model.num_experts <= 0 or model.moe_intermediate_size is None:
+        raise ValueError("routed-MoE tracing requires num_experts and moe_intermediate_size")
+    if len(routing.routes_per_expert) != model.num_experts:
+        raise ValueError("routing histogram expert count does not match the model")
+    if routing.top_k != model.experts_per_token:
+        raise ValueError("routing histogram top_k does not match the model")
+    if sum(routing.routes_per_expert) > max_detailed_routes:
+        raise ValueError("routing histogram is too large for detailed mode; use summary mode")
+
+    OpRegistry.load().set_backend(Backend.PLENA)
+    mlen, blen = hardware.mlen, hardware.blen
+    hidden = _ceil(model.hidden_size, mlen)
+    intermediate = _ceil(model.moe_intermediate_size, mlen)
+    physical_tokens = max(blen, _ceil(routing.token_count, blen))
+    program = PlenaCompiler(
+        mlen=mlen,
+        blen=blen,
+        mram_tile_capacity=hardware.mram_tile_capacity,
+        hbm_v_prefetch_amount=hardware.hbm_v_prefetch_amount,
+        hbm_v_writeback_amount=hardware.hbm_v_writeback_amount,
+        cost_trace=True,
+        compiler_hash=compiler_hash,
+    )
+    x_input = program.input(
+        "moe_x", (physical_tokens, hidden), memory_role="activation"
+    )
+    router_weight = program.input(
+        "router_weight", (hidden, model.num_experts),
+        physical_shape=(hidden, _ceil(model.num_experts, mlen)),
+        memory_role="weight",
+    )
+    expert_weights = [
+        (
+            program.input(f"expert{expert}_gate", (hidden, intermediate), memory_role="weight"),
+            program.input(f"expert{expert}_up", (hidden, intermediate), memory_role="weight"),
+            program.input(f"expert{expert}_down", (intermediate, hidden), memory_role="weight"),
+        )
+        for expert in range(model.num_experts)
+    ]
+    with program.cost_stage("decoder/moe/input"):
+        x = program.load_batch(x_input, name="moe_x")
+    # Main's routed helpers reserve FPRAM address zero for the true-zero row.
+    zero_row = program.fp_var("moe_zero_row", size=mlen)
+    max_expert_rows = max(1, max(routing.routes_per_expert) * blen)
+    one = program.fp_var("moe_one", size=max_expert_rows)
+    neg_one = program.fp_var("moe_neg_one", size=max_expert_rows)
+    constants = (zero_row, zero_row, zero_row, one, neg_one)
+    with program.cost_stage("decoder/moe/router"):
+        logits = program.qwen3_router_logits_matrix_bf16_rowpacked_v0(
+            x,
+            router_weight,
+            rows=routing.token_count,
+            hidden=hidden,
+            num_experts=model.num_experts,
+            mram_tile_capacity=hardware.mram_tile_capacity,
+            name="router_logits",
+        )
+        weights = program.fp_var("router_topk_weights", size=routing.token_count * routing.top_k)
+        indices = 0
+        for token in range(routing.token_count):
+            program.gpt_oss_router_topk_softmax_v0(
+                logits,
+                token_idx=token,
+                weights_fp_base=weights.address + token * routing.top_k,
+                indices_int_base=indices + token * routing.top_k,
+                num_experts=model.num_experts,
+                top_k=routing.top_k,
+                name=f"token{token}",
+            )
+
+    accumulator = program.alloc(
+        "moe_accumulator",
+        routing.token_count,
+        hidden,
+        strict=False,
+        physical_shape=(physical_tokens, hidden),
+    )
+    with program.cost_stage("decoder/moe/combine_init"):
+        program.gpt_oss_true_zero_vram_rows_v0(
+            accumulator,
+            rows=range(physical_tokens),
+            hidden=hidden,
+            zero_row=zero_row,
+            name="accumulator_zero",
+        )
+
+    route_cursor = 0
+    for expert, route_count in enumerate(routing.routes_per_expert):
+        if route_count == 0:
+            continue
+        token_indices = [
+            (route_cursor + route) % routing.token_count for route in range(route_count)
+        ]
+        route_cursor += route_count
+        with program.cost_stage("decoder/moe/dispatch"):
+            gathered = program.gpt_oss_gather_token_rows_from_vram_v0(
+                x,
+                token_indices=token_indices,
+                hidden=hidden,
+                zero_row=zero_row,
+                name=f"expert{expert}_gather",
+            )
+        projection_rows = max(mlen, route_count * blen)
+        with program.cost_stage("decoder/moe/expert"):
+            gate = program.linear_projection(
+                gathered,
+                expert_weights[expert][0],
+                name=f"expert{expert}_gate_out",
+                physical_shape=(projection_rows, intermediate),
+            )
+            up = program.linear_projection(
+                gathered,
+                expert_weights[expert][1],
+                name=f"expert{expert}_up_out",
+                physical_shape=(projection_rows, intermediate),
+            )
+            hidden_out = program.moe_expert_activation_v0(
+                gate,
+                up,
+                rows=route_count * blen,
+                intermediate=intermediate,
+                constants=constants,
+                activation_policy="standard_swiglu",
+                name=f"expert{expert}",
+            )
+            expert_out = program.linear_projection(
+                hidden_out,
+                expert_weights[expert][2],
+                name=f"expert{expert}_down_out",
+                physical_shape=(projection_rows, hidden),
+            )
+            route_scale = program.alloc(
+                f"expert{expert}_route_scale",
+                projection_rows,
+                hidden,
+                strict=False,
+                physical_shape=(projection_rows, hidden),
+            )
+            program.vram_mul(expert_out, route_scale, num_rows=route_count * blen)
+        with program.cost_stage("decoder/moe/combine"):
+            program.gpt_oss_scatter_add_active_rows_v0(
+                accumulator,
+                expert_out,
+                token_indices=token_indices,
+                active_rows=[route * blen for route in range(route_count)],
+                hidden=hidden,
+                name=f"expert{expert}_scatter",
+            )
+
+    trace = program.get_cost_trace(
+        frontend="shape-only-routed-moe-detailed-v1",
+        model_type=model.model_type,
+        routing_label=routing.label,
+        routing_histogram=list(routing.routes_per_expert),
+        route_object_count=sum(routing.routes_per_expert),
+    )
+    return CompilerTraceResult(
+        trace=trace,
+        assembly=program.compile() if include_assembly else None,
+        metadata={
+            "model": model,
+            "hardware": hardware,
+            "routing": routing,
+            "trace_mode": "detailed",
+        },
+    )
+
+
+__all__ = [
+    "CompilerHardwareSpec",
+    "CompilerTraceResult",
+    "DecoderModelSpec",
+    "RoutingHistogram",
+    "compile_dense_decoder_trace",
+    "compile_routed_moe_trace",
+]

--- a/aten/cost_frontend.py
+++ b/aten/cost_frontend.py
@@ -10,6 +10,7 @@ and DMA work.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
 import math
 from pathlib import Path
@@ -17,6 +18,7 @@ import json
 from typing import Any
 
 import compiler.aten.ops as ops
+from compiler.aten.isa_builder import RepeatAxis
 from compiler.aten.model_extract import ModelConfig
 from compiler.aten.ops.registry import Backend, OpRegistry
 from compiler.aten.plena import PlenaCompiler
@@ -277,6 +279,11 @@ def compile_dense_decoder_trace(
     layers = model.num_hidden_layers if num_layers is None else int(num_layers)
     if layers <= 0:
         raise ValueError("num_layers must be positive")
+    if cost_trace_granularity == COST_TRACE_GRANULARITY_DETAILED and layers != 1:
+        raise ValueError(
+            "detailed dense tracing materializes one decoder layer; "
+            "use summary mode for an exact symbolic multi-layer trace"
+        )
 
     OpRegistry.load().set_backend(Backend.PLENA)
     mlen, blen = hardware.mlen, hardware.blen
@@ -356,48 +363,58 @@ def compile_dense_decoder_trace(
         physical_shape=(physical_rows, padded_hidden),
     )
     scale = 1.0 / math.sqrt(model.head_dim)
-    with program.cost_stage("decoder/layer/attention"):
-        if head_packing is not None:
-            current = _emit_packed_attention_block(
-                program,
-                current,
-                layer_inputs,
-                (r_input, cos, sin),
-                causal_mask,
-                scratch,
-                scale,
-                0,
-                padded_seq,
-                model.head_dim,
-                model.num_key_value_heads,
-                ratio,
-                head_packing,
-                batch_size=batch_size,
-                rows_per_batch=rows_per_batch,
-                active_seq_len_per_batch=seq_len,
-            )
-        else:
-            current = _emit_attention_block(
-                program,
-                current,
-                layer_inputs,
-                (r_input, cos, sin),
-                causal_mask,
-                scratch,
-                scale,
-                0,
-                padded_seq,
-                padded_head_dim,
-                total_q_dim,
-                model.num_attention_heads,
-                model.num_key_value_heads,
-                ratio,
-                batch_size=batch_size,
-                rows_per_batch=rows_per_batch,
-                active_seq_len_per_batch=seq_len,
-            )
-    with program.cost_stage("decoder/layer/ffn"):
-        current = _emit_ffn_block(program, current, layer_inputs, scratch)
+    layer_repeat = (
+        program.cost_repeat_region(
+            layers,
+            axis=RepeatAxis.from_mapping("decoder_layer", layers, {}),
+            kind="model-layer",
+        )
+        if cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY
+        else nullcontext(program)
+    )
+    with layer_repeat:
+        with program.cost_stage("decoder/layer/attention"):
+            if head_packing is not None:
+                current = _emit_packed_attention_block(
+                    program,
+                    current,
+                    layer_inputs,
+                    (r_input, cos, sin),
+                    causal_mask,
+                    scratch,
+                    scale,
+                    0,
+                    padded_seq,
+                    model.head_dim,
+                    model.num_key_value_heads,
+                    ratio,
+                    head_packing,
+                    batch_size=batch_size,
+                    rows_per_batch=rows_per_batch,
+                    active_seq_len_per_batch=seq_len,
+                )
+            else:
+                current = _emit_attention_block(
+                    program,
+                    current,
+                    layer_inputs,
+                    (r_input, cos, sin),
+                    causal_mask,
+                    scratch,
+                    scale,
+                    0,
+                    padded_seq,
+                    padded_head_dim,
+                    total_q_dim,
+                    model.num_attention_heads,
+                    model.num_key_value_heads,
+                    ratio,
+                    batch_size=batch_size,
+                    rows_per_batch=rows_per_batch,
+                    active_seq_len_per_batch=seq_len,
+                )
+        with program.cost_stage("decoder/layer/ffn"):
+            current = _emit_ffn_block(program, current, layer_inputs, scratch)
     with program.cost_stage("decoder/final_norm"):
         ops.rms_norm(program, current, eps_offset=3, reci_hid_offset=4)
 
@@ -406,7 +423,8 @@ def compile_dense_decoder_trace(
         model_type=model.model_type,
         representative_layer_count=1,
         requested_layer_count=layers,
-        layer_scaling_required=layers != 1,
+        layer_scaling_required=False,
+        layer_scaling_semantics="symbolic-repeat-materialized",
         seq_len=seq_len,
         batch_size=batch_size,
         materialized_block_pair_count=(

--- a/aten/cost_frontend.py
+++ b/aten/cost_frontend.py
@@ -20,6 +20,10 @@ import compiler.aten.ops as ops
 from compiler.aten.model_extract import ModelConfig
 from compiler.aten.ops.registry import Backend, OpRegistry
 from compiler.aten.plena import PlenaCompiler
+from compiler.aten.plena.cost_kernels import (
+    projection_hbm_base_cost_summary,
+    router_topk_cost_summary,
+)
 from compiler.aten.plena_frontend import (
     AttentionHeadPacking,
     LayerInputVars,
@@ -27,7 +31,12 @@ from compiler.aten.plena_frontend import (
     _emit_ffn_block,
     _emit_packed_attention_block,
 )
-from compiler.aten.program_sink import CostTrace
+from compiler.aten.program_sink import (
+    COST_TRACE_GRANULARITIES,
+    COST_TRACE_GRANULARITY_DETAILED,
+    COST_TRACE_GRANULARITY_SUMMARY,
+    CostTrace,
+)
 
 
 def _ceil(value: int, multiple: int) -> int:
@@ -250,6 +259,7 @@ def compile_dense_decoder_trace(
     num_layers: int | None = None,
     compiler_hash: str = "unknown",
     include_assembly: bool = False,
+    cost_trace_granularity: str = COST_TRACE_GRANULARITY_DETAILED,
 ) -> CompilerTraceResult:
     """Lower one representative dense layer through the production compiler."""
     model = DecoderModelSpec.load(model_config)
@@ -257,6 +267,13 @@ def compile_dense_decoder_trace(
     hardware.validate()
     if seq_len <= 0 or batch_size <= 0:
         raise ValueError("seq_len and batch_size must be positive")
+    if cost_trace_granularity not in COST_TRACE_GRANULARITIES:
+        raise ValueError(
+            f"unsupported cost_trace_granularity {cost_trace_granularity!r}; "
+            f"expected one of {COST_TRACE_GRANULARITIES}"
+        )
+    if include_assembly and cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY:
+        raise ValueError("summary cost tracing cannot materialize full assembly")
     layers = model.num_hidden_layers if num_layers is None else int(num_layers)
     if layers <= 0:
         raise ValueError("num_layers must be positive")
@@ -300,6 +317,8 @@ def compile_dense_decoder_trace(
         hbm_v_writeback_amount=hardware.hbm_v_writeback_amount,
         cost_trace=True,
         compiler_hash=compiler_hash,
+        cost_trace_granularity=cost_trace_granularity,
+        emit_assembly=include_assembly,
     )
     layer_inputs = _register_dense_layer_inputs(
         program,
@@ -390,6 +409,9 @@ def compile_dense_decoder_trace(
         layer_scaling_required=layers != 1,
         seq_len=seq_len,
         batch_size=batch_size,
+        materialized_block_pair_count=(
+            0 if cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY else None
+        ),
         hardware={
             "mlen": mlen,
             "blen": blen,
@@ -422,23 +444,34 @@ def compile_routed_moe_trace(
     compiler_hash: str = "unknown",
     include_assembly: bool = False,
     max_detailed_routes: int = 4096,
+    cost_trace_granularity: str = COST_TRACE_GRANULARITY_DETAILED,
 ) -> CompilerTraceResult:
     """Meter main's routed expert/gather/scatter path for an explicit histogram.
 
-    This detailed backend intentionally rejects production route counts; the
-    algebraically compressed backend added in the next layer lowers each bucket
-    shape once.  It never invents a balanced runtime routing policy.
+    Detailed mode materializes small validation routes. Summary mode chunks
+    routes to the fixed main FPRAM capacity and lowers each distinct bucket
+    shape once. Neither mode invents a runtime routing distribution.
     """
     model = DecoderModelSpec.load(model_config)
     model.validate()
     hardware.validate()
+    if cost_trace_granularity not in COST_TRACE_GRANULARITIES:
+        raise ValueError(
+            f"unsupported cost_trace_granularity {cost_trace_granularity!r}; "
+            f"expected one of {COST_TRACE_GRANULARITIES}"
+        )
+    if include_assembly and cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY:
+        raise ValueError("summary cost tracing cannot materialize full assembly")
     if model.num_experts <= 0 or model.moe_intermediate_size is None:
         raise ValueError("routed-MoE tracing requires num_experts and moe_intermediate_size")
     if len(routing.routes_per_expert) != model.num_experts:
         raise ValueError("routing histogram expert count does not match the model")
     if routing.top_k != model.experts_per_token:
         raise ValueError("routing histogram top_k does not match the model")
-    if sum(routing.routes_per_expert) > max_detailed_routes:
+    if (
+        cost_trace_granularity == COST_TRACE_GRANULARITY_DETAILED
+        and sum(routing.routes_per_expert) > max_detailed_routes
+    ):
         raise ValueError("routing histogram is too large for detailed mode; use summary mode")
 
     OpRegistry.load().set_backend(Backend.PLENA)
@@ -454,6 +487,8 @@ def compile_routed_moe_trace(
         hbm_v_writeback_amount=hardware.hbm_v_writeback_amount,
         cost_trace=True,
         compiler_hash=compiler_hash,
+        cost_trace_granularity=cost_trace_granularity,
+        emit_assembly=include_assembly,
     )
     x_input = program.input(
         "moe_x", (physical_tokens, hidden), memory_role="activation"
@@ -473,12 +508,19 @@ def compile_routed_moe_trace(
     ]
     with program.cost_stage("decoder/moe/input"):
         x = program.load_batch(x_input, name="moe_x")
-    # Main's routed helpers reserve FPRAM address zero for the true-zero row.
-    zero_row = program.fp_var("moe_zero_row", size=mlen)
     max_expert_rows = max(1, max(routing.routes_per_expert) * blen)
-    one = program.fp_var("moe_one", size=max_expert_rows)
-    neg_one = program.fp_var("moe_neg_one", size=max_expert_rows)
-    constants = (zero_row, zero_row, zero_row, one, neg_one)
+    summary_mode = cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY
+    if summary_mode:
+        # Production histograms can exceed the fixed main FPRAM.  V_TOPK uses
+        # the true-zero row as reusable scratch; every later true-zero helper
+        # rewrites that row before consuming it. Expert activation state is
+        # allocated after the router and chunked to the remaining capacity.
+        zero_row = program.fp_var("moe_zero_row", size=mlen)
+        one = neg_one = None
+    else:
+        zero_row = program.fp_var("moe_zero_row", size=mlen)
+        one = program.fp_var("moe_one", size=max_expert_rows)
+        neg_one = program.fp_var("moe_neg_one", size=max_expert_rows)
     with program.cost_stage("decoder/moe/router"):
         logits = program.qwen3_router_logits_matrix_bf16_rowpacked_v0(
             x,
@@ -489,18 +531,61 @@ def compile_routed_moe_trace(
             mram_tile_capacity=hardware.mram_tile_capacity,
             name="router_logits",
         )
-        weights = program.fp_var("router_topk_weights", size=routing.token_count * routing.top_k)
-        indices = 0
-        for token in range(routing.token_count):
-            program.gpt_oss_router_topk_softmax_v0(
-                logits,
-                token_idx=token,
-                weights_fp_base=weights.address + token * routing.top_k,
-                indices_int_base=indices + token * routing.top_k,
-                num_experts=model.num_experts,
-                top_k=routing.top_k,
-                name=f"token{token}",
+        weights = (
+            None
+            if summary_mode
+            else program.fp_var(
+                "router_topk_weights",
+                size=routing.token_count * routing.top_k,
             )
+        )
+        weights_fp_base = zero_row.address if summary_mode else weights.address
+        indices = 0
+        if summary_mode:
+            expert_blocks = math.ceil(model.num_experts / mlen)
+            topk_summary = router_topk_cost_summary(
+                token_count=routing.token_count,
+                top_k=routing.top_k,
+                weights_fp_base=weights_fp_base,
+                indices_int_base=indices,
+                logits_base=program._vram_matrix_row_addr(logits, 0, 0),
+                logits_token_stride=expert_blocks * mlen,
+                weights_stride=0,
+                indices_stride=0,
+            )
+            program.emit_cost_opcode_counts(
+                topk_summary.opcodes,
+                provenance="main-router-topk-v0",
+            )
+        else:
+            for token in range(routing.token_count):
+                program.gpt_oss_router_topk_softmax_v0(
+                    logits,
+                    token_idx=token,
+                    weights_fp_base=weights_fp_base + token * routing.top_k,
+                    indices_int_base=indices + token * routing.top_k,
+                    num_experts=model.num_experts,
+                    top_k=routing.top_k,
+                    name=f"token{token}",
+                )
+
+    if summary_mode:
+        fpram_capacity = program.fpram_allocator.total_size
+        if mlen >= fpram_capacity:
+            raise MemoryError(
+                f"routed MoE requires a {mlen}-entry true-zero row in "
+                f"main's {fpram_capacity}-entry FPRAM"
+            )
+        max_constant_rows = ((fpram_capacity - mlen) // (2 * blen)) * blen
+        if max_constant_rows <= 0:
+            raise MemoryError("main FPRAM cannot hold routed activation constants")
+        max_constant_rows = min(max_expert_rows, max_constant_rows)
+        one = program.fp_var("moe_one", size=max_constant_rows)
+        neg_one = program.fp_var("moe_neg_one", size=max_constant_rows)
+    else:
+        max_constant_rows = max_expert_rows
+    assert zero_row is not None and one is not None and neg_one is not None
+    constants = (zero_row, zero_row, zero_row, one, neg_one)
 
     accumulator = program.alloc(
         "moe_accumulator",
@@ -510,44 +595,72 @@ def compile_routed_moe_trace(
         physical_shape=(physical_tokens, hidden),
     )
     with program.cost_stage("decoder/moe/combine_init"):
-        program.gpt_oss_true_zero_vram_rows_v0(
-            accumulator,
-            rows=range(physical_tokens),
-            hidden=hidden,
-            zero_row=zero_row,
-            name="accumulator_zero",
-        )
-
-    route_cursor = 0
-    for expert, route_count in enumerate(routing.routes_per_expert):
-        if route_count == 0:
-            continue
-        token_indices = [
-            (route_cursor + route) % routing.token_count for route in range(route_count)
-        ]
-        route_cursor += route_count
-        with program.cost_stage("decoder/moe/dispatch"):
-            gathered = program.gpt_oss_gather_token_rows_from_vram_v0(
-                x,
-                token_indices=token_indices,
+        if cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY:
+            program.gpt_oss_true_zero_vram_rows_summary_v0(
+                accumulator,
+                row_start=0,
+                row_step=1,
+                row_count=physical_tokens,
                 hidden=hidden,
                 zero_row=zero_row,
-                name=f"expert{expert}_gather",
+                name="accumulator_zero",
             )
+        else:
+            program.gpt_oss_true_zero_vram_rows_v0(
+                accumulator,
+                rows=range(physical_tokens),
+                hidden=hidden,
+                zero_row=zero_row,
+                name="accumulator_zero",
+            )
+
+    def lower_expert(
+        expert: int,
+        route_count: int,
+        route_start: int,
+        token_indices: list[int] | None,
+        chunk_index: int | None,
+    ) -> None:
+        expert_label = (
+            f"expert{expert}"
+            if chunk_index is None
+            else f"expert{expert}_chunk{chunk_index}"
+        )
+        with program.cost_stage("decoder/moe/dispatch"):
+            if cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY:
+                gathered = program.gpt_oss_gather_token_rows_from_vram_summary_v0(
+                    x,
+                    route_start=route_start,
+                    route_count=route_count,
+                    token_count=routing.token_count,
+                    hidden=hidden,
+                    zero_row=zero_row,
+                    name=f"{expert_label}_gather",
+                )
+            else:
+                assert token_indices is not None
+                gathered = program.gpt_oss_gather_token_rows_from_vram_v0(
+                    x,
+                    token_indices=token_indices,
+                    hidden=hidden,
+                    zero_row=zero_row,
+                    name=f"{expert_label}_gather",
+                )
         projection_rows = max(mlen, route_count * blen)
         with program.cost_stage("decoder/moe/expert"):
             gate = program.linear_projection(
                 gathered,
                 expert_weights[expert][0],
-                name=f"expert{expert}_gate_out",
+                name=f"{expert_label}_gate_out",
                 physical_shape=(projection_rows, intermediate),
             )
             up = program.linear_projection(
                 gathered,
                 expert_weights[expert][1],
-                name=f"expert{expert}_up_out",
+                name=f"{expert_label}_up_out",
                 physical_shape=(projection_rows, intermediate),
             )
+            program.free_tensor(gathered)
             hidden_out = program.moe_expert_activation_v0(
                 gate,
                 up,
@@ -555,38 +668,192 @@ def compile_routed_moe_trace(
                 intermediate=intermediate,
                 constants=constants,
                 activation_policy="standard_swiglu",
-                name=f"expert{expert}",
+                name=expert_label,
             )
             expert_out = program.linear_projection(
                 hidden_out,
                 expert_weights[expert][2],
-                name=f"expert{expert}_down_out",
+                name=f"{expert_label}_down_out",
                 physical_shape=(projection_rows, hidden),
             )
+            program.free_tensor(hidden_out)
             route_scale = program.alloc(
-                f"expert{expert}_route_scale",
+                f"{expert_label}_route_scale",
                 projection_rows,
                 hidden,
                 strict=False,
                 physical_shape=(projection_rows, hidden),
             )
             program.vram_mul(expert_out, route_scale, num_rows=route_count * blen)
+            program.free_tensor(route_scale)
         with program.cost_stage("decoder/moe/combine"):
-            program.gpt_oss_scatter_add_active_rows_v0(
-                accumulator,
-                expert_out,
-                token_indices=token_indices,
-                active_rows=[route * blen for route in range(route_count)],
-                hidden=hidden,
-                name=f"expert{expert}_scatter",
+            if cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY:
+                program.gpt_oss_scatter_add_active_rows_summary_v0(
+                    accumulator,
+                    expert_out,
+                    route_start=route_start,
+                    route_count=route_count,
+                    token_count=routing.token_count,
+                    hidden=hidden,
+                    name=f"{expert_label}_scatter",
+                )
+            else:
+                assert token_indices is not None
+                program.gpt_oss_scatter_add_active_rows_v0(
+                    accumulator,
+                    expert_out,
+                    token_indices=token_indices,
+                    active_rows=[route * blen for route in range(route_count)],
+                    hidden=hidden,
+                    name=f"{expert_label}_scatter",
+                )
+        program.free_tensor(expert_out)
+
+    route_cursor = 0
+    expert_chunk_count = 0
+    max_routes_per_chunk = max(1, max_constant_rows // blen)
+    expert_templates: dict[tuple[object, ...], tuple[int, int]] = {}
+
+    def emit_expert_projection_base_cost(expert: int, route_count: int) -> None:
+        projection_rows = max(mlen, route_count * blen)
+        row_blocks = math.ceil(projection_rows / mlen)
+        hidden_tiles = hidden // mlen
+        intermediate_tiles = intermediate // mlen
+        hidden_chunks = math.ceil(hidden_tiles / hardware.mram_tile_capacity)
+        intermediate_chunks = math.ceil(
+            intermediate_tiles / hardware.mram_tile_capacity
+        )
+        gate, up, down = expert_weights[expert]
+        summary = projection_hbm_base_cost_summary(
+            [
+                (
+                    program.get_hbm_layout(gate.name).hbm_base_addr,
+                    row_blocks * intermediate_tiles * hidden_chunks,
+                ),
+                (
+                    program.get_hbm_layout(up.name).hbm_base_addr,
+                    row_blocks * intermediate_tiles * hidden_chunks,
+                ),
+                (
+                    program.get_hbm_layout(down.name).hbm_base_addr,
+                    row_blocks * hidden_tiles * intermediate_chunks,
+                ),
+            ]
+        )
+        with program.cost_stage("decoder/moe/expert"):
+            program.emit_cost_opcode_counts(
+                summary.opcodes,
+                provenance="main-routed-expert-hbm-base-v0",
             )
 
+    for expert, route_count in enumerate(routing.routes_per_expert):
+        remaining = route_count
+        chunk_index = 0
+        while remaining:
+            chunk_routes = (
+                min(remaining, max_routes_per_chunk)
+                if summary_mode
+                else remaining
+            )
+            token_indices: list[int] | None = None
+            if not summary_mode:
+                token_indices = [
+                    (route_cursor + route) % routing.token_count
+                    for route in range(chunk_routes)
+                ]
+            emitted_chunk_index = (
+                chunk_index if summary_mode and route_count > chunk_routes else None
+            )
+            if summary_mode:
+                emit_expert_projection_base_cost(expert, chunk_routes)
+                template_key = (
+                    "routed-expert-chunk-v2",
+                    chunk_routes,
+                    hidden,
+                    intermediate,
+                    mlen,
+                    blen,
+                )
+                representative = expert_templates.get(template_key)
+                if representative is None:
+                    program._suppress_summary_projection_hbm_base = True
+                    try:
+                        with program.cost_summary_template(template_key):
+                            lower_expert(
+                                expert,
+                                chunk_routes,
+                                route_cursor,
+                                token_indices,
+                                emitted_chunk_index,
+                            )
+                    finally:
+                        program._suppress_summary_projection_hbm_base = False
+                    representative_base = program.get_hbm_layout(
+                        expert_weights[expert][0].name
+                    ).hbm_base_addr
+                    expert_templates[template_key] = (expert, representative_base)
+                else:
+                    _representative_expert, representative_base = representative
+                    replay_base = program.get_hbm_layout(
+                        expert_weights[expert][0].name
+                    ).hbm_base_addr
+                    if not program.replay_cost_summary_template(
+                        template_key,
+                        dma_address_delta_bytes=replay_base - representative_base,
+                    ):
+                        raise RuntimeError(
+                            f"missing routed expert template {template_key!r}"
+                        )
+            else:
+                lower_expert(
+                    expert,
+                    chunk_routes,
+                    route_cursor,
+                    token_indices,
+                    emitted_chunk_index,
+                )
+            route_cursor += chunk_routes
+            remaining -= chunk_routes
+            chunk_index += 1
+            expert_chunk_count += 1
+
     trace = program.get_cost_trace(
-        frontend="shape-only-routed-moe-detailed-v1",
+        frontend=(
+            "shape-only-routed-moe-summary-v1"
+            if summary_mode
+            else "shape-only-routed-moe-detailed-v1"
+        ),
         model_type=model.model_type,
         routing_label=routing.label,
         routing_histogram=list(routing.routes_per_expert),
-        route_object_count=sum(routing.routes_per_expert),
+        route_object_count=(
+            0
+            if cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY
+            else sum(routing.routes_per_expert)
+        ),
+        expanded_route_equivalent=sum(routing.routes_per_expert),
+        expert_template_count=(
+            len(expert_templates) if summary_mode else 0
+        ),
+        expert_chunk_count=expert_chunk_count,
+        max_routes_per_chunk=max_routes_per_chunk,
+        route_storage_mode=(
+            "streamed-histogram-scratch"
+            if summary_mode
+            else "materialized-main-fpram"
+        ),
+        routing_semantics="explicit-expert-count-histogram",
+        routing_order_semantics=(
+            "affine-symbolic-routes"
+            if summary_mode
+            else "deterministic-validation-fixture"
+        ),
+        route_weight_semantics="shape-only-main-lowering",
+        summary_fidelity=(
+            "exact-algebraic-final-schedule"
+            if summary_mode
+            else "ordered-final-schedule"
+        ),
     )
     return CompilerTraceResult(
         trace=trace,
@@ -595,7 +862,11 @@ def compile_routed_moe_trace(
             "model": model,
             "hardware": hardware,
             "routing": routing,
-            "trace_mode": "detailed",
+            "trace_mode": (
+                "summary"
+                if cost_trace_granularity == COST_TRACE_GRANULARITY_SUMMARY
+                else "detailed"
+            ),
         },
     )
 

--- a/aten/isa_builder.py
+++ b/aten/isa_builder.py
@@ -363,6 +363,82 @@ def render_asm(value: AsmInput) -> str:
     return value.render()
 
 
+def final_sequence(value: AsmInput) -> Sequence:
+    """Normalize typed or legacy emission into one legalized final schedule."""
+    if isinstance(value, IsaBuilder):
+        return fold_rendered_hardware_loops(value.finalized())
+    # Other Renderable implementations are uncommon and have no structured
+    # metadata contract.  Parse their final spelling exactly like legacy ASM.
+    rendered = value if isinstance(value, str) else value.render()
+    parsed = parse_legacy_asm(rendered)
+    return fold_rendered_hardware_loops(
+        Sequence(tuple(legalize_large_immediates(parsed.items)))
+    )
+
+
+def fold_rendered_hardware_loops(sequence: Sequence) -> Sequence:
+    """Recover symbolic loop nodes from finalized legacy instruction text.
+
+    Existing templates already contain the authoritative loop boundaries.  A
+    stack parser is sufficient to preserve them without reconstructing any
+    tensor-level operation.  Rendering the result is byte-identical.
+    """
+
+    def fold_items(items: tuple[AsmItem, ...]) -> tuple[AsmItem, ...]:
+        output: list[AsmItem] = []
+        index = 0
+        while index < len(items):
+            item = items[index]
+            if isinstance(item, str):
+                output.extend(fold_items(parse_legacy_asm(item).items))
+                index += 1
+                continue
+            if isinstance(item, Sequence):
+                output.append(Sequence(fold_items(item.items)))
+                index += 1
+                continue
+            if isinstance(item, Stage):
+                output.append(Stage(item.path, Sequence(fold_items(item.body.items))))
+                index += 1
+                continue
+            if isinstance(item, CompileTimeRepeat):
+                output.append(
+                    CompileTimeRepeat(item.count, Sequence(fold_items(item.body.items)), axis=item.axis)
+                )
+                index += 1
+                continue
+            if not (isinstance(item, Instr) and item.opcode == "C_LOOP_START"):
+                output.append(item)
+                index += 1
+                continue
+            if len(item.args) != 2 or not isinstance(item.args[1], int):
+                raise ValueError(f"C_LOOP_START requires (register, immediate count), got {item.args!r}")
+            loop_register, count = item.args
+            depth = 1
+            cursor = index + 1
+            while cursor < len(items) and depth:
+                candidate = items[cursor]
+                if isinstance(candidate, Instr) and candidate.opcode == "C_LOOP_START":
+                    depth += 1
+                elif isinstance(candidate, Instr) and candidate.opcode == "C_LOOP_END":
+                    depth -= 1
+                cursor += 1
+            if depth:
+                raise ValueError("unmatched C_LOOP_START in finalized assembly")
+            end = items[cursor - 1]
+            assert isinstance(end, Instr)
+            if end.args and end.args[0] != loop_register:
+                raise ValueError(
+                    f"loop register mismatch: start={loop_register!r}, end={end.args[0]!r}"
+                )
+            body = Sequence(fold_items(items[index + 1 : cursor - 1]))
+            output.append(HardwareLoop(loop_register=loop_register, count=count, body=body))
+            index = cursor
+        return tuple(output)
+
+    return Sequence(fold_items(sequence.items))
+
+
 def instr_from_rendered_line(line: str) -> Instr:
     """Parse one already-legal instruction without changing its spelling."""
     stripped = line.strip()
@@ -486,6 +562,8 @@ __all__ = [
     "addr",
     "as_sequence",
     "fp",
+    "final_sequence",
+    "fold_rendered_hardware_loops",
     "gp",
     "legalize_large_immediates",
     "parse_legacy_asm",

--- a/aten/isa_builder.py
+++ b/aten/isa_builder.py
@@ -101,8 +101,8 @@ class DmaTransfer:
             raise ValueError(f"DMA opcode must start with H_, got {self.opcode!r}")
         if self.direction not in {"read", "write"}:
             raise ValueError(f"DMA direction must be read/write, got {self.direction!r}")
-        if not self.role:
-            raise ValueError("DMA role must be non-empty")
+        if self.role not in {"weight", "activation", "kv", "integer", "output"}:
+            raise ValueError(f"unsupported DMA semantic role {self.role!r}")
         for name in ("element_base_bytes", "dim", "amount", "stride_bytes", "rstride", "write_amount"):
             if int(getattr(self, name)) < 0:
                 raise ValueError(f"DmaTransfer.{name} must be nonnegative")

--- a/aten/isa_builder.py
+++ b/aten/isa_builder.py
@@ -1,14 +1,19 @@
-"""Typed ISA builder for the ATen PLENA compiler path.
+"""Typed final-schedule IR for the ATen PLENA compiler path.
 
-This is intentionally small: it models the physical instruction stream and
-prints the same assembly syntax the existing compiler emits.
+The production compiler still has a mixture of typed builders and legacy ASM
+templates.  This module gives both paths one final-schedule representation:
+rendering and analytical accounting traverse the same nodes *after* immediate
+legalization and loop formation.  The metadata is deliberately hardware and
+model agnostic; consumers may interpret stages and variants without teaching
+the compiler a latency formula.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Protocol, Union
+from functools import lru_cache
+from typing import Any, Protocol, Union
 
 from asm_templates._imm import add_large_int as _add_large_int_lines
 from asm_templates._imm import load_large_int as _load_large_int_lines
@@ -50,14 +55,136 @@ def render_arg(arg: AsmArg) -> str:
 
 
 @dataclass(frozen=True)
+class RepeatAxis:
+    """Affine address movement attached to one symbolic repeat axis."""
+
+    name: str
+    count: int
+    deltas: tuple[tuple[str, int], ...] = ()
+
+    @classmethod
+    def from_mapping(cls, name: str, count: int, deltas: Mapping[str, int]) -> "RepeatAxis":
+        return cls(name=name, count=count, deltas=tuple(sorted((str(k), int(v)) for k, v in deltas.items())))
+
+    def __post_init__(self) -> None:
+        if self.count < 0:
+            raise ValueError(f"RepeatAxis count must be nonnegative, got {self.count}")
+
+
+@dataclass(frozen=True)
+class DmaTransfer:
+    """Compiler-owned physical DMA geometry.
+
+    Units are explicit.  Base addresses and strides are bytes; ``amount`` and
+    ``write_amount`` retain the ISA transfer-count semantics.  ``role`` is a
+    semantic ownership label such as ``weight``, ``activation`` or ``kv``.
+    """
+
+    opcode: str
+    direction: str
+    role: str
+    element_base_bytes: int
+    scale_base_bytes: int | None
+    dim: int
+    amount: int
+    stride_bytes: int
+    rstride: int = 0
+    write_amount: int = 1
+    precision: str = "runtime"
+    element_bytes: int = 1
+    axes: tuple[RepeatAxis, ...] = ()
+    geometry_fidelity: str = "exact"
+    memory_object: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.opcode.startswith("H_"):
+            raise ValueError(f"DMA opcode must start with H_, got {self.opcode!r}")
+        if self.direction not in {"read", "write"}:
+            raise ValueError(f"DMA direction must be read/write, got {self.direction!r}")
+        if not self.role:
+            raise ValueError("DMA role must be non-empty")
+        for name in ("element_base_bytes", "dim", "amount", "stride_bytes", "rstride", "write_amount"):
+            if int(getattr(self, name)) < 0:
+                raise ValueError(f"DmaTransfer.{name} must be nonnegative")
+        if self.scale_base_bytes is not None and self.scale_base_bytes < 0:
+            raise ValueError("DmaTransfer.scale_base_bytes must be nonnegative")
+        if self.element_bytes <= 0:
+            raise ValueError("DmaTransfer.element_bytes must be positive")
+
+
+@dataclass(frozen=True)
+class ActiveDimensions:
+    """Logical activity carried by a physical instruction."""
+
+    rows: int | None = None
+    cols: int | None = None
+    lanes: int | None = None
+    total_lanes: int | None = None
+    bits: int | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("rows", "cols", "lanes", "total_lanes", "bits"):
+            value = getattr(self, name)
+            if value is not None and value < 0:
+                raise ValueError(f"ActiveDimensions.{name} must be nonnegative")
+        if self.lanes is not None and self.total_lanes is not None and self.lanes > self.total_lanes:
+            raise ValueError("active lanes cannot exceed total lanes")
+
+
+@dataclass(frozen=True)
+class SramActivity:
+    """One compiler-known SRAM access made by an instruction."""
+
+    memory: str
+    direction: str
+    accesses: int = 1
+    bytes_per_access: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.direction not in {"read", "write"}:
+            raise ValueError(f"SRAM direction must be read/write, got {self.direction!r}")
+        if self.accesses < 0:
+            raise ValueError("SramActivity.accesses must be nonnegative")
+        if self.bytes_per_access is not None and self.bytes_per_access < 0:
+            raise ValueError("SramActivity.bytes_per_access must be nonnegative")
+
+
+@dataclass(frozen=True)
 class Instr:
     opcode: str
     args: tuple[AsmArg, ...] = ()
+    variant: tuple[tuple[str, str], ...] = ()
+    active: ActiveDimensions | None = None
+    dma: DmaTransfer | None = None
+    sram: tuple[SramActivity, ...] = ()
 
     def render(self) -> str:
         if not self.args:
             return self.opcode
         return f"{self.opcode} {', '.join(render_arg(arg) for arg in self.args)}"
+
+    @classmethod
+    def with_metadata(
+        cls,
+        opcode: str,
+        args: Iterable[AsmArg] = (),
+        *,
+        variant: Mapping[str, Any] | None = None,
+        active: ActiveDimensions | None = None,
+        dma: DmaTransfer | None = None,
+        sram: Iterable[SramActivity] = (),
+    ) -> "Instr":
+        normalized_variant = tuple(
+            sorted((str(key), str(value)) for key, value in (variant or {}).items())
+        )
+        return cls(
+            opcode=opcode,
+            args=tuple(args),
+            variant=normalized_variant,
+            active=active,
+            dma=dma,
+            sram=tuple(sram),
+        )
 
 
 @dataclass(frozen=True)
@@ -71,7 +198,40 @@ class Comment:
         return f"; {text}"
 
 
-AsmItem = Union[str, Instr, Comment]
+@dataclass(frozen=True)
+class Sequence:
+    items: tuple["AsmItem", ...]
+
+
+@dataclass(frozen=True)
+class CompileTimeRepeat:
+    count: int
+    body: Sequence
+    axis: RepeatAxis | None = None
+
+
+@dataclass(frozen=True)
+class HardwareLoop:
+    loop_register: AsmArg
+    count: int
+    body: Sequence
+    effective_count: int | None = None
+    axis: RepeatAxis | None = None
+
+
+@dataclass(frozen=True)
+class Stage:
+    """Opaque hierarchical ownership path for a final schedule subtree."""
+
+    path: str
+    body: Sequence
+
+    def __post_init__(self) -> None:
+        if not self.path or self.path.startswith("/") or self.path.endswith("/"):
+            raise ValueError(f"stage path must be a non-empty relative path, got {self.path!r}")
+
+
+AsmItem = Union[str, Instr, Comment, Sequence, CompileTimeRepeat, HardwareLoop, Stage]
 IMM2_BOUND = 1 << 18
 
 
@@ -79,26 +239,86 @@ IMM2_BOUND = 1 << 18
 class IsaBuilder:
     items: list[AsmItem] = field(default_factory=list)
 
-    def comment(self, text: str) -> IsaBuilder:
+    def comment(self, text: str) -> "IsaBuilder":
         self.items.append(Comment(text))
         return self
 
-    def instr(self, opcode: str, *args: AsmArg) -> IsaBuilder:
-        self.items.append(Instr(opcode, args))
+    def instr(
+        self,
+        opcode: str,
+        *args: AsmArg,
+        variant: Mapping[str, Any] | None = None,
+        active: ActiveDimensions | None = None,
+        dma: DmaTransfer | None = None,
+        sram: Iterable[SramActivity] = (),
+    ) -> "IsaBuilder":
+        if dma is not None and dma.opcode != opcode:
+            raise ValueError(f"DMA metadata opcode {dma.opcode!r} does not match {opcode!r}")
+        self.items.append(
+            Instr.with_metadata(
+                opcode,
+                args,
+                variant=variant,
+                active=active,
+                dma=dma,
+                sram=sram,
+            )
+        )
         return self
 
-    def raw(self, line: str) -> IsaBuilder:
+    def raw(self, line: str) -> "IsaBuilder":
         self.items.append(line.rstrip("\n"))
         return self
 
-    def extend(self, items: Iterable[AsmItem]) -> IsaBuilder:
+    def extend(self, items: Iterable[AsmItem]) -> "IsaBuilder":
         self.items.extend(items)
         return self
 
+    def sequence(self, items: Iterable[AsmItem]) -> "IsaBuilder":
+        self.items.append(Sequence(tuple(items)))
+        return self
+
+    def repeat(
+        self,
+        count: int,
+        body: "IsaBuilder | Sequence | Iterable[AsmItem]",
+        *,
+        axis: RepeatAxis | None = None,
+    ) -> "IsaBuilder":
+        self.items.append(CompileTimeRepeat(count=count, body=as_sequence(body), axis=axis))
+        return self
+
+    def hardware_loop(
+        self,
+        loop_register: AsmArg,
+        count: int,
+        body: "IsaBuilder | Sequence | Iterable[AsmItem]",
+        *,
+        effective_count: int | None = None,
+        axis: RepeatAxis | None = None,
+    ) -> "IsaBuilder":
+        self.items.append(
+            HardwareLoop(
+                loop_register=loop_register,
+                count=count,
+                body=as_sequence(body),
+                effective_count=effective_count,
+                axis=axis,
+            )
+        )
+        return self
+
+    def stage(self, path: str, body: "IsaBuilder | Sequence | Iterable[AsmItem]") -> "IsaBuilder":
+        self.items.append(Stage(path=path, body=as_sequence(body)))
+        return self
+
+    def finalized(self) -> Sequence:
+        """Return the immutable schedule after compiler-wide legalization."""
+        return Sequence(tuple(legalize_large_immediates(self.items)))
+
     def render(self) -> str:
-        if not self.items:
-            return ""
-        return "\n".join(render_item(item) for item in legalize_large_immediates(self.items)) + "\n"
+        rendered = list(render_items(self.finalized().items))
+        return "\n".join(rendered) + ("\n" if rendered else "")
 
 
 AsmInput = Union[str, Renderable]
@@ -107,7 +327,34 @@ AsmInput = Union[str, Renderable]
 def render_item(item: AsmItem) -> str:
     if isinstance(item, str):
         return item.rstrip("\n")
-    return item.render()
+    if isinstance(item, (Instr, Comment)):
+        return item.render()
+    return "\n".join(render_items((item,)))
+
+
+def render_items(items: Iterable[AsmItem]) -> Iterable[str]:
+    for item in items:
+        if isinstance(item, str):
+            yield item.rstrip("\n")
+        elif isinstance(item, (Instr, Comment)):
+            yield item.render()
+        elif isinstance(item, Sequence):
+            yield from render_items(item.items)
+        elif isinstance(item, CompileTimeRepeat):
+            if item.count < 0:
+                raise ValueError(f"CompileTimeRepeat count must be >= 0, got {item.count}")
+            for _ in range(item.count):
+                yield from render_items(item.body.items)
+        elif isinstance(item, HardwareLoop):
+            if item.count <= 0:
+                raise ValueError(f"HardwareLoop count must be > 0, got {item.count}")
+            yield Instr("C_LOOP_START", (item.loop_register, item.count)).render()
+            yield from render_items(item.body.items)
+            yield Instr("C_LOOP_END", (item.loop_register,)).render()
+        elif isinstance(item, Stage):
+            yield from render_items(item.body.items)
+        else:
+            raise TypeError(f"Unsupported ASM item: {type(item).__name__}")
 
 
 def render_asm(value: AsmInput) -> str:
@@ -116,19 +363,89 @@ def render_asm(value: AsmInput) -> str:
     return value.render()
 
 
+def instr_from_rendered_line(line: str) -> Instr:
+    """Parse one already-legal instruction without changing its spelling."""
+    stripped = line.strip()
+    opcode, separator, tail = stripped.partition(" ")
+    if not separator:
+        return Instr(opcode)
+    args: list[AsmArg] = []
+    for value in tail.split(","):
+        value = value.strip()
+        if value.startswith("gp") and value[2:].isdigit():
+            args.append(gp(int(value[2:])))
+        elif value.startswith("f") and value[1:].isdigit():
+            args.append(fp(int(value[1:])))
+        elif value.startswith("a") and value[1:].isdigit():
+            args.append(addr(int(value[1:])))
+        else:
+            try:
+                args.append(int(value, 0))
+            except ValueError:
+                args.append(value)
+    return Instr(opcode, tuple(args))
+
+
+@lru_cache(maxsize=4096)
+def parse_legacy_asm(text: str) -> Sequence:
+    """Convert finalized legacy-template text into typed schedule leaves."""
+    items: list[AsmItem] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith(";"):
+            items.append(Comment(line))
+            continue
+        opcode = line.split(maxsplit=1)[0]
+        if not opcode.startswith(("S_", "C_", "H_", "V_", "M_")):
+            raise ValueError(f"unsupported raw ASM line in final schedule: {line}")
+        items.append(instr_from_rendered_line(line))
+    return Sequence(tuple(items))
+
+
+def as_sequence(value: "IsaBuilder | Sequence | Iterable[AsmItem]") -> Sequence:
+    if isinstance(value, IsaBuilder):
+        return Sequence(tuple(value.items))
+    if isinstance(value, Sequence):
+        return value
+    return Sequence(tuple(value))
+
+
 def is_gp_zero(arg: AsmArg) -> bool:
     return isinstance(arg, Register) and arg.prefix == "gp" and arg.index == 0
 
 
 def legalize_large_immediates(items: Iterable[AsmItem]) -> list[AsmItem]:
-    """Split typed S_ADDI_INT instructions that exceed the immediate field.
-
-    This is the typed equivalent of plena_frontend._fix_large_immediates. Raw
-    string items are intentionally left alone until those call sites move onto
-    typed instructions.
-    """
+    """Legalize typed immediates recursively without changing schedule metadata."""
     legalized: list[AsmItem] = []
     for item in items:
+        if isinstance(item, Sequence):
+            legalized.append(Sequence(tuple(legalize_large_immediates(item.items))))
+            continue
+        if isinstance(item, CompileTimeRepeat):
+            legalized.append(
+                CompileTimeRepeat(
+                    item.count,
+                    Sequence(tuple(legalize_large_immediates(item.body.items))),
+                    axis=item.axis,
+                )
+            )
+            continue
+        if isinstance(item, HardwareLoop):
+            legalized.append(
+                HardwareLoop(
+                    loop_register=item.loop_register,
+                    count=item.count,
+                    body=Sequence(tuple(legalize_large_immediates(item.body.items))),
+                    effective_count=item.effective_count,
+                    axis=item.axis,
+                )
+            )
+            continue
+        if isinstance(item, Stage):
+            legalized.append(Stage(item.path, Sequence(tuple(legalize_large_immediates(item.body.items)))))
+            continue
         if isinstance(item, Instr) and item.opcode == "S_ADDI_INT" and len(item.args) == 3:
             rd, rs, imm = item.args
             if (
@@ -144,7 +461,35 @@ def legalize_large_immediates(items: Iterable[AsmItem]) -> list[AsmItem]:
                     if is_gp_zero(rs)
                     else _add_large_int_lines(rd.index, rs.index, imm, temp_reg=None)
                 )
-                legalized.extend(replacement)
+                legalized.extend(instr_from_rendered_line(line) for line in replacement)
                 continue
         legalized.append(item)
     return legalized
+
+
+__all__ = [
+    "ActiveDimensions",
+    "AsmArg",
+    "AsmInput",
+    "AsmItem",
+    "Comment",
+    "CompileTimeRepeat",
+    "DmaTransfer",
+    "HardwareLoop",
+    "Instr",
+    "IsaBuilder",
+    "Register",
+    "RepeatAxis",
+    "Sequence",
+    "SramActivity",
+    "Stage",
+    "addr",
+    "as_sequence",
+    "fp",
+    "gp",
+    "legalize_large_immediates",
+    "parse_legacy_asm",
+    "render_arg",
+    "render_asm",
+    "render_items",
+]

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -77,6 +77,9 @@ class PlenaCompiler(
         mram_tile_capacity: int = 4,
         hbm_v_prefetch_amount: int | None = None,
         hbm_v_writeback_amount: int | None = None,
+        cost_trace: bool = False,
+        compiler_hash: str = "unknown",
+        default_cost_stage: str | None = None,
     ):
         """
         Args:
@@ -105,6 +108,9 @@ class PlenaCompiler(
             real_data_ratio=real_data_ratio,
             unroll_loops=unroll_loops,
             mram_tile_capacity=mram_tile_capacity,
+            cost_trace=cost_trace,
+            compiler_hash=compiler_hash,
+            default_cost_stage=default_cost_stage,
         )
         if hbm_v_prefetch_amount is None:
             hbm_v_prefetch_amount = _behavior_config_value("HBM_V_Prefetch_Amount", 4)

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -80,6 +80,8 @@ class PlenaCompiler(
         cost_trace: bool = False,
         compiler_hash: str = "unknown",
         default_cost_stage: str | None = None,
+        cost_trace_granularity: str = "detailed",
+        emit_assembly: bool = True,
     ):
         """
         Args:
@@ -111,6 +113,8 @@ class PlenaCompiler(
             cost_trace=cost_trace,
             compiler_hash=compiler_hash,
             default_cost_stage=default_cost_stage,
+            cost_trace_granularity=cost_trace_granularity,
+            emit_assembly=emit_assembly,
         )
         if hbm_v_prefetch_amount is None:
             hbm_v_prefetch_amount = _behavior_config_value("HBM_V_Prefetch_Amount", 4)

--- a/aten/plena/cost_kernels.py
+++ b/aten/plena/cost_kernels.py
@@ -1,0 +1,1144 @@
+"""Algebraic cost adapters for legacy compiler templates.
+
+Main still renders the FFN kernel through a Python-unrolled assembly template.
+That representation is useful for executable output but scales poorly for
+shape-only analytical compilation.  The adapter below is compiler-owned and
+mirrors the template after large-immediate legalization.  Tests compare it
+opcode-for-opcode with the rendered final schedule on representative shapes.
+Timing and memory models consume only the resulting CostTrace.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import math
+
+from compiler.asm_templates._imm import IMM2_BOUND
+from compiler.asm_templates._k_split import k_chunks
+from compiler.aten.isa_builder import DmaTransfer, RepeatAxis
+
+
+@dataclass(frozen=True)
+class KernelDmaStream:
+    transfer: DmaTransfer
+    multiplicity: int
+    axes: tuple[RepeatAxis, ...] = ()
+
+
+@dataclass
+class KernelCostSummary:
+    opcodes: Counter[str] = field(default_factory=Counter)
+    dma_streams: list[KernelDmaStream] = field(default_factory=list)
+
+    def add(self, opcode: str, count: int = 1) -> None:
+        if count < 0:
+            raise ValueError(f"negative {opcode} count")
+        self.opcodes[opcode] += count
+
+    def merge(self, other: "KernelCostSummary") -> None:
+        self.opcodes.update(other.opcodes)
+        self.dma_streams.extend(other.dma_streams)
+
+
+def _load_large(result: KernelCostSummary, value: int, count: int = 1) -> None:
+    if value < IMM2_BOUND:
+        result.add("S_ADDI_INT", count)
+        return
+    result.add("S_LUI_INT", count)
+    if value & 0xFFF:
+        result.add("S_ADDI_INT", count)
+
+
+def _load_large_sequence(
+    result: KernelCostSummary,
+    *,
+    start: int,
+    step: int,
+    count: int,
+    multiplier: int = 1,
+) -> None:
+    """Count ``load_large_int`` over an affine sequence in O(1)."""
+    if count <= 0:
+        return
+    if step < 0:
+        raise ValueError("negative affine address step is unsupported")
+    if step == 0:
+        _load_large(result, start, count * multiplier)
+        return
+    below = (
+        max(0, min(count, (IMM2_BOUND - start + step - 1) // step))
+        if start < IMM2_BOUND
+        else 0
+    )
+    high = count - below
+    zero_low = 0
+    if high:
+        modulus = 1 << 12
+        divisor = math.gcd(step, modulus)
+        rhs = -start
+        if rhs % divisor == 0:
+            reduced_modulus = modulus // divisor
+            first = (
+                (rhs // divisor) * pow(step // divisor, -1, reduced_modulus)
+            ) % reduced_modulus
+            if first < below:
+                first += (
+                    (below - first + reduced_modulus - 1) // reduced_modulus
+                ) * reduced_modulus
+            if first < count:
+                zero_low = 1 + (count - 1 - first) // reduced_modulus
+    result.add("S_LUI_INT", high * multiplier)
+    result.add("S_ADDI_INT", (below + high - zero_low) * multiplier)
+
+
+def _direct_addi(
+    result: KernelCostSummary,
+    value: int,
+    *,
+    source_is_zero: bool,
+    count: int = 1,
+) -> None:
+    """Count a raw S_ADDI_INT after final-schedule legalization."""
+    if value < IMM2_BOUND:
+        result.add("S_ADDI_INT", count)
+    elif source_is_zero:
+        _load_large(result, value, count)
+    else:
+        chunks = (value + IMM2_BOUND - 2) // (IMM2_BOUND - 1)
+        result.add("S_ADDI_INT", count * chunks)
+
+
+def _addi_with_temp(result: KernelCostSummary, value: int, count: int = 1) -> None:
+    if value < IMM2_BOUND:
+        result.add("S_ADDI_INT", count)
+        return
+    _load_large(result, value, count)
+    result.add("S_ADD_INT", count)
+
+
+def _addi_with_temp_sequence(
+    result: KernelCostSummary,
+    *,
+    start: int,
+    step: int,
+    count: int,
+    multiplier: int = 1,
+) -> None:
+    """Count ``addi_large_int(..., temp)`` over an affine sequence."""
+    if count <= 0:
+        return
+    below = (
+        max(0, min(count, (IMM2_BOUND - start + step - 1) // step))
+        if start < IMM2_BOUND
+        else 0
+    )
+    high = count - below
+    result.add("S_ADDI_INT", below * multiplier)
+    if not high:
+        return
+    modulus = 1 << 12
+    divisor = math.gcd(step, modulus)
+    zero_low = 0
+    rhs = -start
+    if rhs % divisor == 0:
+        reduced_modulus = modulus // divisor
+        first = (
+            (rhs // divisor) * pow(step // divisor, -1, reduced_modulus)
+        ) % reduced_modulus
+        if first < below:
+            first += (
+                (below - first + reduced_modulus - 1) // reduced_modulus
+            ) * reduced_modulus
+        if first < count:
+            zero_low = 1 + (count - 1 - first) // reduced_modulus
+    result.add("S_LUI_INT", high * multiplier)
+    result.add("S_ADD_INT", high * multiplier)
+    result.add("S_ADDI_INT", (high - zero_low) * multiplier)
+
+
+def _projection_chunk(
+    *,
+    mlen: int,
+    blen: int,
+    batch_rows: int,
+    k_size: int,
+    out_size: int,
+    weight_stride: int,
+    result_base: int,
+    activation_base: int | None,
+    activation_register_base: int | None,
+    k_start_tile: int,
+    k_tile_count: int,
+    target_base: int,
+    weight_dma: DmaTransfer,
+) -> KernelCostSummary:
+    result = KernelCostSummary()
+    num_act_cols = batch_rows // blen
+    tiles_per_mlen = mlen // blen
+    weight_rows = out_size // blen
+    block_rows = out_size // mlen
+    chunk_hbm_offset = k_start_tile * mlen * weight_stride
+    chunk_act_offset = k_start_tile * mlen * batch_rows
+
+    _load_large(result, target_base)
+    if activation_base is None:
+        if activation_register_base is None:
+            raise ValueError("register activation requires a canonical base")
+        _load_large(result, activation_register_base)
+
+    # Once per output MLEN block: MRAM reset, HBM offset and output pointer.
+    result.add("S_ADDI_INT", block_rows)
+    _addi_with_temp_sequence(
+        result,
+        start=chunk_hbm_offset,
+        step=mlen,
+        count=block_rows,
+    )
+    result.add("S_ADDI_INT", block_rows)
+
+    prefetches = block_rows * k_tile_count
+    result.add("H_PREFETCH_M", prefetches)
+    _direct_addi(result, mlen * mlen, source_is_zero=False, count=prefetches)
+    _addi_with_temp(result, mlen * weight_stride, prefetches)
+    result.add("S_ADDI_INT", block_rows)
+
+    # The remaining BLEN tiles in each MLEN block select MRAM/output columns.
+    subtile_rows = weight_rows - block_rows
+    for subtile in range(1, tiles_per_mlen):
+        _direct_addi(
+            result,
+            subtile * blen * mlen,
+            source_is_zero=True,
+            count=block_rows,
+        )
+        result.add("S_ADDI_INT", block_rows)
+    if subtile_rows != block_rows * (tiles_per_mlen - 1):
+        raise AssertionError("FFN output tiling is inconsistent")
+
+    pointer_start = chunk_act_offset + (activation_base or 0)
+    _addi_with_temp_sequence(
+        result,
+        start=pointer_start,
+        step=mlen * blen,
+        count=num_act_cols,
+        multiplier=weight_rows,
+    )
+    cells = weight_rows * num_act_cols
+    result.add("S_ADDI_INT", cells)  # w_temp = w_actual
+    if k_tile_count > 1:
+        result.add("C_LOOP_START", cells)
+    result.add("M_MM", cells * k_tile_count)
+    _direct_addi(
+        result,
+        mlen * mlen,
+        source_is_zero=False,
+        count=cells * k_tile_count,
+    )
+    _direct_addi(
+        result,
+        mlen * batch_rows,
+        source_is_zero=False,
+        count=cells * k_tile_count,
+    )
+    if k_tile_count > 1:
+        result.add("C_LOOP_END", cells * k_tile_count)
+    result.add("M_MM_WO", cells)
+    _direct_addi(
+        result,
+        blen * mlen,
+        source_is_zero=False,
+        count=cells,
+    )
+    if block_rows > 1:
+        _direct_addi(
+            result,
+            mlen * batch_rows,
+            source_is_zero=False,
+            count=block_rows - 1,
+        )
+
+    result.dma_streams.append(
+        KernelDmaStream(
+            transfer=DmaTransfer(
+                **{
+                    **weight_dma.__dict__,
+                    "element_base_bytes": (
+                        weight_dma.element_base_bytes + chunk_hbm_offset
+                    ),
+                    "scale_base_bytes": (
+                        None
+                        if weight_dma.scale_base_bytes is None
+                        else weight_dma.scale_base_bytes + chunk_hbm_offset // 8
+                    ),
+                }
+            ),
+            multiplicity=prefetches,
+            axes=(
+                RepeatAxis.from_mapping(
+                    "output_mlen_block",
+                    block_rows,
+                    {
+                        "element_base_bytes": mlen,
+                        "scale_base_bytes": mlen // 8,
+                    },
+                ),
+                RepeatAxis.from_mapping(
+                    "k_tile",
+                    k_tile_count,
+                    {
+                        "element_base_bytes": mlen * weight_stride,
+                        "scale_base_bytes": mlen * weight_stride // 8,
+                    },
+                ),
+            ),
+        )
+    )
+    return result
+
+
+def _projection(
+    *,
+    mlen: int,
+    vlen: int,
+    blen: int,
+    batch_rows: int,
+    k_size: int,
+    out_size: int,
+    weight_stride: int,
+    result_base: int,
+    activation_base: int | None,
+    activation_register_base: int | None,
+    max_k_tiles: int,
+    scratch_base: int,
+    weight_dma: DmaTransfer,
+) -> KernelCostSummary:
+    result = KernelCostSummary()
+    chunks = k_chunks(k_size // mlen, max_k_tiles)
+    for chunk_index, (k_start, k_count) in enumerate(chunks):
+        result.merge(
+            _projection_chunk(
+                mlen=mlen,
+                blen=blen,
+                batch_rows=batch_rows,
+                k_size=k_size,
+                out_size=out_size,
+                weight_stride=weight_stride,
+                result_base=result_base,
+                activation_base=activation_base,
+                activation_register_base=activation_register_base,
+                k_start_tile=k_start,
+                k_tile_count=k_count,
+                target_base=result_base if chunk_index == 0 else scratch_base,
+                weight_dma=weight_dma,
+            )
+        )
+        if chunk_index:
+            _load_large(result, result_base)
+            _load_large(result, scratch_base)
+            adds = math.ceil(out_size * batch_rows / vlen)
+            result.add("V_ADD_VV", adds)
+            result.add("S_ADDI_INT", 2 * adds)
+    return result
+
+
+def ffn_unrolled_cost_summary(
+    *,
+    mlen: int,
+    vlen: int,
+    blen: int,
+    batch_rows: int,
+    hidden_size: int,
+    intermediate_size: int,
+    activation_base: int,
+    workspace_base: int,
+    matrix_sram_size: int,
+    gate_weight_dma: DmaTransfer,
+    up_weight_dma: DmaTransfer,
+    down_weight_dma: DmaTransfer,
+) -> KernelCostSummary:
+    """Exact dynamic census for main's ``_ffn_asm_unrolled`` schedule."""
+    if batch_rows <= 0 or batch_rows % blen:
+        raise ValueError("FFN rows must be a positive BLEN multiple")
+    up_base = workspace_base
+    gate_base = up_base + batch_rows * intermediate_size
+    scratch_base = gate_base + batch_rows * intermediate_size
+    max_k_tiles = max(1, matrix_sram_size // mlen)
+    result = KernelCostSummary()
+
+    _load_large(result, hidden_size * intermediate_size)
+    result.add("C_SET_SCALE_REG")
+    _load_large(result, intermediate_size)
+    result.add("C_SET_STRIDE_REG")
+    result.add("S_ADDI_INT")
+    _load_large(result, up_base)
+    _load_large(result, gate_base)
+
+    for result_base, dma in ((up_base, up_weight_dma), (gate_base, gate_weight_dma)):
+        result.merge(
+            _projection(
+                mlen=mlen,
+                vlen=vlen,
+                blen=blen,
+                batch_rows=batch_rows,
+                k_size=hidden_size,
+                out_size=intermediate_size,
+                weight_stride=intermediate_size,
+                result_base=result_base,
+                activation_base=activation_base,
+                activation_register_base=None,
+                max_k_tiles=max_k_tiles,
+                scratch_base=scratch_base,
+                weight_dma=dma,
+            )
+        )
+
+    result.add("S_LD_FP")
+    _load_large(result, up_base)
+    _load_large(result, gate_base)
+    _load_large(result, activation_base)
+    silu = batch_rows * (intermediate_size // vlen)
+    for opcode in ("V_SUB_VF", "V_EXP_V", "V_ADD_VF", "V_RECI_V"):
+        result.add(opcode, silu)
+    result.add("V_MUL_VV", 2 * silu)
+    result.add("S_ADDI_INT", 2 * silu)
+
+    _load_large(result, hidden_size * intermediate_size)
+    result.add("C_SET_SCALE_REG")
+    _load_large(result, hidden_size)
+    result.add("C_SET_STRIDE_REG")
+    result.add("S_ADDI_INT", 2)  # w_actual reset and historical m_stride load
+    result.merge(
+        _projection(
+            mlen=mlen,
+            vlen=vlen,
+            blen=blen,
+            batch_rows=batch_rows,
+            k_size=intermediate_size,
+            out_size=hidden_size,
+            weight_stride=hidden_size,
+            result_base=activation_base,
+            activation_base=None,
+            activation_register_base=up_base,
+            max_k_tiles=max_k_tiles,
+            scratch_base=scratch_base,
+            weight_dma=down_weight_dma,
+        )
+    )
+    return result
+
+
+def router_topk_cost_summary(
+    *,
+    token_count: int,
+    top_k: int,
+    weights_fp_base: int,
+    indices_int_base: int,
+    logits_base: int,
+    logits_token_stride: int,
+    weights_stride: int | None = None,
+    indices_stride: int | None = None,
+) -> KernelCostSummary:
+    """Census repeated V_TOPK rows without materializing per-token objects."""
+    if token_count <= 0 or top_k <= 0 or logits_token_stride <= 0:
+        raise ValueError("router dimensions must be positive")
+    weights_stride = top_k if weights_stride is None else weights_stride
+    indices_stride = top_k if indices_stride is None else indices_stride
+    if weights_stride < 0 or indices_stride < 0:
+        raise ValueError("router output strides must be nonnegative")
+    result = KernelCostSummary()
+    _load_large_sequence(
+        result,
+        start=weights_fp_base,
+        step=weights_stride,
+        count=token_count,
+    )
+    _load_large_sequence(
+        result,
+        start=logits_base,
+        step=logits_token_stride,
+        count=token_count,
+    )
+    _load_large_sequence(
+        result,
+        start=indices_int_base,
+        step=indices_stride,
+        count=token_count,
+    )
+    result.add("V_TOPK", token_count)
+    return result
+
+
+def vram_matrix_binary_cost_summary(
+    *,
+    opcode: str,
+    mlen: int,
+    dst_base: int,
+    src_base: int,
+    dst_physical_rows: int,
+    src_physical_rows: int,
+    physical_cols: int,
+    dst_row_offset: int,
+    src_row_offset: int,
+    num_rows: int,
+    block_add: bool,
+) -> KernelCostSummary:
+    """Census main's VRAM add/multiply lowering without row expansion."""
+    result = KernelCostSummary()
+    col_blocks = physical_cols // mlen
+    if block_add:
+        if num_rows % mlen:
+            raise ValueError("block-add rows must be MLEN aligned")
+        row_blocks = num_rows // mlen
+        blocks = row_blocks * col_blocks
+        for col in range(col_blocks):
+            dst_start = (
+                dst_base
+                + col * dst_physical_rows * mlen
+                + dst_row_offset * mlen
+            )
+            src_start = (
+                src_base
+                + col * src_physical_rows * mlen
+                + src_row_offset * mlen
+            )
+            _load_large_sequence(
+                result,
+                start=dst_start,
+                step=mlen * mlen,
+                count=row_blocks,
+                multiplier=2,
+            )
+            _load_large_sequence(
+                result,
+                start=src_start,
+                step=mlen * mlen,
+                count=row_blocks,
+            )
+        result.add("C_LOOP_START", blocks)
+        result.add(opcode, blocks * mlen)
+        result.add("S_ADDI_INT", 3 * blocks * mlen)
+        result.add("C_LOOP_END", blocks * mlen)
+        return result
+
+    for col in range(col_blocks):
+        _load_large_sequence(
+            result,
+            start=(
+                dst_base
+                + col * dst_physical_rows * mlen
+                + dst_row_offset * mlen
+            ),
+            step=mlen,
+            count=num_rows,
+        )
+        _load_large_sequence(
+            result,
+            start=(
+                src_base
+                + col * src_physical_rows * mlen
+                + src_row_offset * mlen
+            ),
+            step=mlen,
+            count=num_rows,
+        )
+    result.add(opcode, num_rows * col_blocks)
+    return result
+
+
+def normalization_cost_summary(
+    *,
+    mode: str,
+    activation_base: int,
+    scratchpad_base: int,
+    vlen: int,
+    batch_size: int,
+    hidden_dim: int,
+    unroll: bool,
+) -> KernelCostSummary:
+    """Exact census for main's RMSNorm/LayerNorm assembly templates."""
+    mode = mode.lower()
+    if mode not in {"rms", "layer"}:
+        raise ValueError(f"unsupported normalization mode {mode!r}")
+    chunks = hidden_dim // vlen
+    stride = vlen * batch_size
+    result = KernelCostSummary()
+    _load_large(result, scratchpad_base)
+
+    if mode == "rms":
+        result.add("S_LD_FP", 2)
+        result.add("S_ADD_FP")
+        _load_large_sequence(
+            result,
+            start=activation_base,
+            step=vlen,
+            count=batch_size,
+            multiplier=2,
+        )
+        if unroll:
+            result.add("V_MUL_VV", batch_size * chunks)
+            result.add("V_RED_SUM", batch_size * chunks)
+            _direct_addi(
+                result,
+                stride,
+                source_is_zero=False,
+                count=batch_size * chunks,
+            )
+        else:
+            result.add("C_LOOP_START", batch_size)
+            result.add("V_MUL_VV", batch_size * chunks)
+            result.add("V_RED_SUM", batch_size * chunks)
+            _direct_addi(
+                result,
+                stride,
+                source_is_zero=False,
+                count=batch_size * chunks,
+            )
+            result.add("C_LOOP_END", batch_size * chunks)
+        if chunks > 1:
+            _load_large_sequence(
+                result,
+                start=activation_base + stride,
+                step=vlen,
+                count=batch_size,
+            )
+        result.add("S_MUL_FP", batch_size)
+        result.add("S_ADD_FP", 2 * batch_size)  # epsilon plus reset
+        result.add("S_SQRT_FP", batch_size)
+        result.add("S_RECI_FP", batch_size)
+        result.add("S_ADDI_INT", 4 * batch_size)
+        result.add("V_MUL_VF", batch_size * chunks)
+        for chunk in range(2, chunks):
+            _load_large_sequence(
+                result,
+                start=activation_base + stride * chunk,
+                step=vlen,
+                count=batch_size,
+            )
+        if chunks > 1:
+            result.add("S_ADDI_INT", batch_size)
+        return result
+
+    result.add("S_LD_FP", 2)
+    result.add("S_ADD_FP", 2)
+    _load_large_sequence(
+        result,
+        start=activation_base,
+        step=vlen,
+        count=batch_size,
+        multiplier=2,
+    )
+    if not unroll:
+        result.add("C_LOOP_START", 2 * batch_size)
+    result.add("V_RED_SUM", 2 * batch_size * chunks)
+    result.add("V_MUL_VV", batch_size * chunks)
+    _direct_addi(
+        result,
+        stride,
+        source_is_zero=False,
+        count=2 * batch_size * chunks,
+    )
+    if not unroll:
+        result.add("C_LOOP_END", 2 * batch_size * chunks)
+    result.add("S_MUL_FP", 3 * batch_size)
+    result.add("S_SUB_FP", batch_size)
+    result.add("S_ADD_FP", 3 * batch_size)  # epsilon plus two resets
+    result.add("S_SQRT_FP", batch_size)
+    result.add("S_RECI_FP", batch_size)
+    result.add("V_SUB_VF", batch_size * chunks)
+    result.add("V_MUL_VF", batch_size * chunks)
+    return result
+
+
+def linear_projection_cost_summary(
+    *,
+    mlen: int,
+    blen: int,
+    full_batch: int,
+    hbm_base: int,
+    hbm_rows: int,
+    hbm_cols: int,
+    input_base: int,
+    input_physical_rows: int,
+    output_base: int,
+    output_physical_rows: int,
+    temp_base: int | None,
+    num_row_blocks: int,
+    num_col_blocks: int,
+    chunks: list[tuple[int, int]],
+    row_loop_counts: list[int],
+    hbm_offsets: list[list[int]],
+    dma_prototypes: list[DmaTransfer],
+    include_hbm_base_setup: bool = True,
+) -> KernelCostSummary:
+    """Aggregate main's tiled ``linear_projection`` in O(K+C) space."""
+    result = KernelCostSummary()
+    tiles_per_mlen = mlen // blen
+    calls_per_chunk = num_row_blocks * num_col_blocks
+    total_k_tiles = sum(k_count for _k_start, k_count in chunks)
+
+    for col, prototype in enumerate(dma_prototypes):
+        result.dma_streams.append(
+            KernelDmaStream(
+                transfer=prototype,
+                multiplicity=num_row_blocks * total_k_tiles,
+                axes=(
+                    RepeatAxis.from_mapping(
+                        "output_row_tile",
+                        num_row_blocks,
+                        {},
+                    ),
+                    RepeatAxis.from_mapping(
+                        "k_tile",
+                        total_k_tiles,
+                        {
+                            "element_base_bytes": mlen * hbm_cols,
+                            "scale_base_bytes": mlen * hbm_cols // 8,
+                        },
+                    ),
+                ),
+            )
+        )
+
+    for chunk_index, (k_start, k_count) in enumerate(chunks):
+        if include_hbm_base_setup:
+            _load_large(result, hbm_base, calls_per_chunk)
+        result.add("C_SET_ADDR_REG", calls_per_chunk)
+        _direct_addi(
+            result,
+            hbm_rows * hbm_cols,
+            source_is_zero=True,
+            count=calls_per_chunk,
+        )
+        result.add("C_SET_SCALE_REG", calls_per_chunk)
+        _direct_addi(
+            result,
+            hbm_cols,
+            source_is_zero=True,
+            count=calls_per_chunk,
+        )
+        result.add("C_SET_STRIDE_REG", calls_per_chunk)
+
+        for col in range(num_col_blocks):
+            offsets = hbm_offsets[col][k_start : k_start + k_count]
+            for local_k, offset in enumerate(offsets):
+                _direct_addi(
+                    result,
+                    local_k * mlen * mlen,
+                    source_is_zero=True,
+                    count=num_row_blocks,
+                )
+                _direct_addi(
+                    result,
+                    offset,
+                    source_is_zero=True,
+                    count=num_row_blocks,
+                )
+            result.add("H_PREFETCH_M", num_row_blocks * k_count)
+
+        result.add("S_ADDI_INT", calls_per_chunk)
+        if chunk_index == 0:
+            for col in range(num_col_blocks):
+                _load_large_sequence(
+                    result,
+                    start=output_base + col * output_physical_rows * mlen,
+                    step=mlen * mlen,
+                    count=num_row_blocks,
+                )
+        else:
+            if temp_base is None:
+                raise ValueError("K-split projection requires temp_base")
+            _load_large(result, temp_base, calls_per_chunk)
+
+        _load_large_sequence(
+            result,
+            start=input_base + k_start * input_physical_rows * mlen,
+            step=mlen * mlen,
+            count=num_row_blocks,
+            multiplier=num_col_blocks * tiles_per_mlen,
+        )
+
+        for row_loop_count in set(row_loop_counts):
+            calls = row_loop_counts.count(row_loop_count) * num_col_blocks
+            outer_middle = calls * tiles_per_mlen * row_loop_count
+            result.add("C_LOOP_START", calls)
+            result.add("S_ADDI_INT", calls * tiles_per_mlen)
+            result.add("C_LOOP_START", calls * tiles_per_mlen)
+            result.add("S_ADDI_INT", 2 * outer_middle)
+            result.add("C_LOOP_START", outer_middle)
+            result.add("M_MM", outer_middle * k_count)
+            _direct_addi(
+                result,
+                full_batch * mlen,
+                source_is_zero=False,
+                count=outer_middle * k_count,
+            )
+            _direct_addi(
+                result,
+                mlen * mlen,
+                source_is_zero=False,
+                count=outer_middle * k_count,
+            )
+            result.add("C_LOOP_END", outer_middle * k_count)
+            result.add("M_MM_WO", outer_middle)
+            _direct_addi(
+                result,
+                blen * mlen,
+                source_is_zero=False,
+                count=2 * outer_middle,
+            )
+            result.add("C_LOOP_END", outer_middle)
+            _direct_addi(
+                result,
+                blen,
+                source_is_zero=False,
+                count=2 * calls * tiles_per_mlen,
+            )
+            result.add("C_LOOP_END", calls * tiles_per_mlen)
+
+        if chunk_index:
+            assert temp_base is not None
+            for col in range(num_col_blocks):
+                _load_large_sequence(
+                    result,
+                    start=output_base + col * output_physical_rows * mlen,
+                    step=mlen * mlen,
+                    count=num_row_blocks,
+                    multiplier=2,
+                )
+            _load_large(result, temp_base, calls_per_chunk)
+            result.add("C_LOOP_START", calls_per_chunk)
+            result.add("V_ADD_VV", calls_per_chunk * mlen)
+            result.add("S_ADDI_INT", 3 * calls_per_chunk * mlen)
+            result.add("C_LOOP_END", calls_per_chunk * mlen)
+    return result
+
+
+def projection_hbm_base_cost_summary(
+    base_loads: list[tuple[int, int]],
+) -> KernelCostSummary:
+    """Count absolute HBM-base materialization for projection calls."""
+    result = KernelCostSummary()
+    for base, count in base_loads:
+        if count < 0:
+            raise ValueError("projection HBM-base load count must be nonnegative")
+        _load_large(result, base, count)
+    return result
+
+
+def true_zero_rows_cost_summary(
+    *,
+    mlen: int,
+    matrix_base: int,
+    matrix_physical_rows: int,
+    hidden: int,
+    fp_zero_base: int,
+    row_start: int,
+    row_step: int,
+    row_count: int,
+) -> KernelCostSummary:
+    """Census routed-MoE true-zero row initialization."""
+    result = KernelCostSummary()
+    _load_large(result, fp_zero_base)
+    result.add("C_LOOP_START")
+    result.add("S_ST_FP", mlen)
+    result.add("S_ADDI_INT", mlen)
+    result.add("C_LOOP_END", mlen)
+    _load_large(result, fp_zero_base)
+    for col in range(hidden // mlen):
+        _load_large_sequence(
+            result,
+            start=(
+                matrix_base
+                + col * matrix_physical_rows * mlen
+                + row_start * mlen
+            ),
+            step=row_step * mlen,
+            count=row_count,
+        )
+    result.add("S_MAP_V_FP", row_count * (hidden // mlen))
+    return result
+
+
+def _load_modulo_sequence(
+    result: KernelCostSummary,
+    *,
+    base: int,
+    step: int,
+    start_index: int,
+    count: int,
+    modulus: int,
+) -> None:
+    remaining = count
+    index = start_index % modulus
+    first = min(remaining, modulus - index)
+    _load_large_sequence(
+        result,
+        start=base + index * step,
+        step=step,
+        count=first,
+    )
+    remaining -= first
+    if not remaining:
+        return
+    full, tail = divmod(remaining, modulus)
+    if full:
+        _load_large_sequence(
+            result,
+            start=base,
+            step=step,
+            count=modulus,
+            multiplier=full,
+        )
+    if tail:
+        _load_large_sequence(
+            result,
+            start=base,
+            step=step,
+            count=tail,
+        )
+
+
+def routed_row_copy_cost_summary(
+    *,
+    opcode: str,
+    mlen: int,
+    hidden: int,
+    route_start: int,
+    route_count: int,
+    token_count: int,
+    slot_rows: int,
+    dst_base: int,
+    dst_physical_rows: int,
+    src_base: int,
+    src_physical_rows: int,
+    token_is_destination: bool,
+) -> KernelCostSummary:
+    """Census affine gather/scatter row copies without route objects."""
+    result = KernelCostSummary()
+    blocks = hidden // mlen
+    for col in range(blocks):
+        dst_col = dst_base + col * dst_physical_rows * mlen
+        src_col = src_base + col * src_physical_rows * mlen
+        if token_is_destination:
+            _load_modulo_sequence(
+                result,
+                base=dst_col,
+                step=mlen,
+                start_index=route_start,
+                count=route_count,
+                modulus=token_count,
+            )
+            _load_large_sequence(
+                result,
+                start=src_col,
+                step=slot_rows * mlen,
+                count=route_count,
+            )
+        else:
+            _load_large_sequence(
+                result,
+                start=dst_col,
+                step=slot_rows * mlen,
+                count=route_count,
+            )
+            _load_modulo_sequence(
+                result,
+                base=src_col,
+                step=mlen,
+                start_index=route_start,
+                count=route_count,
+                modulus=token_count,
+            )
+    result.add(opcode, route_count * blocks)
+    return result
+
+
+def bf16_stream_k_accum_cost_summary(
+    *,
+    mlen: int,
+    blen: int,
+    hbm_base: int,
+    hbm_cols: int,
+    full_batch: int,
+    output_physical_rows: int,
+    input_vram_bases: list[list[int]],
+    output_tile_bases: list[list[int]],
+    row_loop_counts: list[int],
+    chunks: list[tuple[int, int]],
+    hbm_offsets: list[list[int]],
+    dma_prototypes: list[DmaTransfer],
+    hbm_element_bytes: int = 2,
+) -> KernelCostSummary:
+    """Census main's BF16 microtile cross-K accumulator projection.
+
+    The production lowering reloads each K chunk for every output microtile,
+    keeps the Matrix accumulator live across chunks, and writes once.  This
+    adapter follows those exact addresses without mutating MRAM allocator state.
+    """
+    if mlen <= 0 or blen <= 0 or mlen % blen:
+        raise ValueError("MLEN and BLEN must be positive with BLEN dividing MLEN")
+    if len(input_vram_bases) != len(row_loop_counts):
+        raise ValueError("input row blocks and row-loop counts differ")
+    if len(output_tile_bases) != len(row_loop_counts):
+        raise ValueError("output row blocks and row-loop counts differ")
+    if len(hbm_offsets) != len(dma_prototypes):
+        raise ValueError("HBM offsets and DMA prototypes differ")
+
+    result = KernelCostSummary()
+    tiles_per_mlen = mlen // blen
+    matrix_block_size = mlen * mlen
+    output_row_stride = blen * mlen
+    matrix_col_stride = blen * mlen
+    microtiles_per_col = tiles_per_mlen * sum(row_loop_counts)
+
+    micro_rows = sum(row_loop_counts)
+    all_microtiles = len(hbm_offsets) * tiles_per_mlen * micro_rows
+    setup_calls = all_microtiles * len(chunks)
+    total_k_tiles = len(hbm_offsets[0]) if hbm_offsets else 0
+    if any(len(offsets) != total_k_tiles for offsets in hbm_offsets):
+        raise ValueError("ragged HBM K offsets")
+    input_base = input_vram_bases[0][0]
+    output_base = output_tile_bases[0][0]
+
+    # Every microtile/chunk reload repeats the same address-register and stride
+    # setup. Count those calls directly instead of walking the microtile grid.
+    _load_large(result, hbm_base, setup_calls)
+    result.add("C_SET_ADDR_REG", setup_calls)
+    _load_large(result, hbm_cols * hbm_element_bytes, setup_calls)
+    result.add("C_SET_STRIDE_REG", setup_calls)
+
+    for col_idx, (col_offsets, prototype) in enumerate(
+        zip(hbm_offsets, dma_prototypes, strict=True)
+    ):
+        result.dma_streams.append(
+            KernelDmaStream(
+                transfer=prototype,
+                multiplicity=microtiles_per_col * len(col_offsets),
+                axes=(
+                    RepeatAxis.from_mapping(
+                        "router_microtile_reload",
+                        microtiles_per_col,
+                        {},
+                    ),
+                    RepeatAxis.from_mapping(
+                        "k_tile",
+                        len(col_offsets),
+                        {"element_base_bytes": mlen * hbm_cols * hbm_element_bytes},
+                    ),
+                ),
+            )
+        )
+        chunk_microtiles = tiles_per_mlen * micro_rows
+        for k_start, k_count in chunks:
+            if k_count <= 0 or k_start < 0 or k_start + k_count > len(col_offsets):
+                raise ValueError(f"invalid K chunk {(k_start, k_count)}")
+            for local_k, k_idx in enumerate(range(k_start, k_start + k_count)):
+                _load_large(result, local_k * matrix_block_size, chunk_microtiles)
+                _load_large(
+                    result,
+                    col_offsets[k_idx] * hbm_element_bytes,
+                    chunk_microtiles,
+                )
+
+    result.add("H_PREFETCH_M", all_microtiles * total_k_tiles)
+
+    # Activation addresses form one contiguous BLEN-row progression for each K
+    # tile. The same progression is reused by every output column/micro-column.
+    for k_idx in range(total_k_tiles):
+        _load_large_sequence(
+            result,
+            start=input_base + k_idx * full_batch * mlen,
+            step=output_row_stride,
+            count=micro_rows,
+            multiplier=len(hbm_offsets) * tiles_per_mlen,
+        )
+
+    # MRAM addresses repeat for every row and output column but depend only on
+    # the local K position inside a chunk and the micro-column.
+    for _k_start, k_count in chunks:
+        for micro_col_idx in range(tiles_per_mlen):
+            for local_k in range(k_count):
+                _load_large(
+                    result,
+                    micro_col_idx * matrix_col_stride + local_k * matrix_block_size,
+                    micro_rows * len(hbm_offsets),
+                )
+
+    result.add("M_MM", all_microtiles * total_k_tiles)
+
+    # Each output microtile is written once after the final K chunk.
+    for col_idx in range(len(hbm_offsets)):
+        for micro_col_idx in range(tiles_per_mlen):
+            _load_large_sequence(
+                result,
+                start=(
+                    output_base
+                    + col_idx * output_physical_rows * mlen
+                    + micro_col_idx * blen
+                ),
+                step=output_row_stride,
+                count=micro_rows,
+            )
+    result.add("M_MM_WO", all_microtiles)
+    return result
+
+
+def standard_swiglu_cost_summary(
+    *,
+    mlen: int,
+    sigmoid_base: int,
+    sigmoid_physical_rows: int,
+    intermediate: int,
+    rows: int,
+    one_fp_base: int,
+    neg_one_fp_base: int,
+) -> KernelCostSummary:
+    """Census main's contiguous-row standard SwiGLU tile operations."""
+    if rows <= 0 or intermediate <= 0 or intermediate % mlen:
+        raise ValueError("SwiGLU rows must be positive and width MLEN-aligned")
+    result = KernelCostSummary()
+    for col in range(intermediate // mlen):
+        base = sigmoid_base + col * sigmoid_physical_rows * mlen
+
+        # vram_fill_zero(sigmoid)
+        _load_large(result, base)
+        result.add("C_LOOP_START")
+        result.add("V_MUL_VF", rows)
+        _direct_addi(result, mlen, source_is_zero=False, count=rows)
+        result.add("C_LOOP_END", rows)
+
+        # Multiply by -1 and add 1 use matching contiguous FPRAM rows.
+        for opcode, fp_base in (("V_MUL_VF", neg_one_fp_base), ("V_ADD_VF", one_fp_base)):
+            _load_large(result, base)
+            _load_large(result, fp_base)
+            result.add("C_LOOP_START")
+            result.add("S_LD_FP", rows)
+            result.add(opcode, rows)
+            _direct_addi(result, mlen, source_is_zero=False, count=rows)
+            _direct_addi(result, 1, source_is_zero=False, count=rows)
+            result.add("C_LOOP_END", rows)
+
+        for opcode in ("V_EXP_V", "V_RECI_V"):
+            _load_large(result, base)
+            result.add("C_LOOP_START")
+            result.add(opcode, rows)
+            _direct_addi(result, mlen, source_is_zero=False, count=rows)
+            result.add("C_LOOP_END", rows)
+    return result
+
+
+__all__ = [
+    "KernelCostSummary",
+    "KernelDmaStream",
+    "ffn_unrolled_cost_summary",
+    "router_topk_cost_summary",
+    "vram_matrix_binary_cost_summary",
+    "normalization_cost_summary",
+    "linear_projection_cost_summary",
+    "projection_hbm_base_cost_summary",
+    "true_zero_rows_cost_summary",
+    "routed_row_copy_cost_summary",
+    "bf16_stream_k_accum_cost_summary",
+    "standard_swiglu_cost_summary",
+]

--- a/aten/plena/isa_attention.py
+++ b/aten/plena/isa_attention.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 
 from compiler.asm_templates._imm import load_large_int
+from compiler.aten.isa_builder import DmaTransfer, RepeatAxis
 
 
 class IsaAttentionMixin:
@@ -918,7 +919,44 @@ class IsaAttentionMixin:
         self.register_allocator.free_gp(gp_regs)
         self.register_allocator.free_addr(addr_regs)
 
-        return self._emit(isa_code)
+        rendered = self._emit(isa_code)
+        num_v_col_blocks = max(1, math.ceil(head_dim / self.mlen))
+        role = getattr(getattr(self, "_inputs", {}).get(v_sub_matrix), "memory_role", "kv")
+        rows_total, cols_total = v_layout.physical_shape or v_layout.full_shape
+        self.record_dma(
+            DmaTransfer(
+                opcode="H_PREFETCH_M",
+                direction="read",
+                role=role,
+                element_base_bytes=(v_layout.hbm_base_addr + v_hbm_offset)
+                * v_hbm_element_bytes,
+                scale_base_bytes=(
+                    v_layout.hbm_base_addr
+                    + rows_total * cols_total
+                    + v_hbm_offset // 8
+                )
+                * v_hbm_element_bytes,
+                dim=self.mlen,
+                amount=1,
+                stride_bytes=physical_head_dim * v_hbm_element_bytes,
+                rstride=1,
+                precision="matrix_kv",
+                element_bytes=v_hbm_element_bytes,
+                memory_object=v_sub_matrix,
+            ),
+            multiplicity=num_v_col_blocks,
+            axes=(
+                RepeatAxis.from_mapping(
+                    "v_column_block",
+                    num_v_col_blocks,
+                    {
+                        "element_base_bytes": self.mlen * v_hbm_element_bytes,
+                        "scale_base_bytes": self.mlen * v_hbm_element_bytes // 8,
+                    },
+                ),
+            ),
+        )
+        return rendered
 
     def warm_v_prefetch(self, v_sub_matrix: str, k_idx: int, v_hbm_element_bytes: int = 1) -> str:
         """Prefetch V[k_idx] into MSRAM ONCE (High precision) before the per-head P@V

--- a/aten/plena/isa_compiler.py
+++ b/aten/plena/isa_compiler.py
@@ -18,9 +18,11 @@ from compiler.aten.plena.isa_emit import IsaEmitMixin
 from compiler.aten.plena.isa_fp_ops import IsaFPOpsMixin
 from compiler.aten.plena.isa_matrix import IsaMatrixMixin
 from compiler.aten.plena.isa_tile_rows import IsaTileRowMixin
+from compiler.aten.plena.cost_kernels import normalization_cost_summary
 from compiler.aten.plena.memory_state import MemoryStateMixin
 from compiler.aten.plena.registers import RegisterAllocator
 from compiler.aten.program_sink import SymbolicCostSink
+from compiler.aten.program_sink import COST_TRACE_GRANULARITY_DETAILED
 from compiler.aten.isa_builder import DmaTransfer, RepeatAxis
 
 
@@ -50,6 +52,8 @@ class IsaCompiler(
         cost_trace: bool = False,
         compiler_hash: str = "unknown",
         default_cost_stage: str | None = None,
+        cost_trace_granularity: str = COST_TRACE_GRANULARITY_DETAILED,
+        emit_assembly: bool = True,
     ):
         # MemoryStateMixin.__init__ sets dimensions, layout tables, and memory allocators.
         super().__init__(
@@ -63,8 +67,13 @@ class IsaCompiler(
         self.generated_code = ""
         self.unroll_attention = unroll_loops
         self._cost_stage_stack: list[str] = []
+        self._emit_assembly = bool(emit_assembly)
         self._symbolic_cost_sink = (
-            SymbolicCostSink(compiler_hash=compiler_hash, default_stage=default_cost_stage)
+            SymbolicCostSink(
+                compiler_hash=compiler_hash,
+                default_stage=default_cost_stage,
+                granularity=cost_trace_granularity,
+            )
             if cost_trace
             else None
         )
@@ -397,6 +406,21 @@ class IsaCompiler(
             scratchpad_vram_addr = self.vram_allocator.allocate(vlen, name=temp_scratchpad_name)
 
         try:
+            if self.cost_summary_enabled:
+                summary = normalization_cost_summary(
+                    mode=mode,
+                    activation_base=tensor_info.vram_addr,
+                    scratchpad_base=scratchpad_vram_addr,
+                    vlen=vlen,
+                    batch_size=batch_size,
+                    hidden_dim=hidden_dim,
+                    unroll=self._unroll,
+                )
+                self.emit_cost_opcode_counts(
+                    summary.opcodes,
+                    provenance=f"main-{mode}-norm-v1",
+                )
+                return ""
             isa_code = (
                 f"; Normalize ({mode}) {tensor_name}, "
                 f"logical=({logical_batch_size}, {logical_hidden_dim}) "

--- a/aten/plena/isa_compiler.py
+++ b/aten/plena/isa_compiler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 from compiler.asm_templates import (
     layer_norm_asm,
     preload_act_asm,
@@ -18,6 +20,8 @@ from compiler.aten.plena.isa_matrix import IsaMatrixMixin
 from compiler.aten.plena.isa_tile_rows import IsaTileRowMixin
 from compiler.aten.plena.memory_state import MemoryStateMixin
 from compiler.aten.plena.registers import RegisterAllocator
+from compiler.aten.program_sink import SymbolicCostSink
+from compiler.aten.isa_builder import DmaTransfer, RepeatAxis
 
 
 class IsaCompiler(
@@ -43,6 +47,9 @@ class IsaCompiler(
         real_data_ratio: float = 1.125,
         unroll_loops: bool = False,
         mram_tile_capacity: int = 4,
+        cost_trace: bool = False,
+        compiler_hash: str = "unknown",
+        default_cost_stage: str | None = None,
     ):
         # MemoryStateMixin.__init__ sets dimensions, layout tables, and memory allocators.
         super().__init__(
@@ -55,6 +62,12 @@ class IsaCompiler(
         self.register_allocator = RegisterAllocator()
         self.generated_code = ""
         self.unroll_attention = unroll_loops
+        self._cost_stage_stack: list[str] = []
+        self._symbolic_cost_sink = (
+            SymbolicCostSink(compiler_hash=compiler_hash, default_stage=default_cost_stage)
+            if cost_trace
+            else None
+        )
 
     def load_batch(
         self,
@@ -62,6 +75,7 @@ class IsaCompiler(
         vram_object_name: str,
         vlen: int = 64,
         preload_len: int | None = None,
+        memory_role: str = "activation",
     ) -> str:
         """
         Load a Batch tensor from HBM to VRAM.
@@ -121,7 +135,58 @@ class IsaCompiler(
         self.register_allocator.free_gp(gp_regs_for_preload)
         self.register_allocator.free_addr([addr_reg])
 
-        return self._emit(isa_code)
+        rendered = self._emit(isa_code)
+        if h == 1:
+            stream_count = math.ceil(w / (vlen * preload_len))
+            axes = (
+                RepeatAxis.from_mapping(
+                    "hidden_prefetch",
+                    stream_count,
+                    {
+                        "element_base_bytes": vlen * preload_len,
+                        "scale_base_bytes": vlen * preload_len // 8,
+                    },
+                ),
+            )
+            rstride = 0
+        else:
+            hidden_blocks = math.ceil(w / vlen)
+            batch_blocks = math.ceil(h / preload_len)
+            stream_count = hidden_blocks * batch_blocks
+            axes = (
+                RepeatAxis.from_mapping(
+                    "hidden_block",
+                    hidden_blocks,
+                    {"element_base_bytes": vlen, "scale_base_bytes": vlen // 8},
+                ),
+                RepeatAxis.from_mapping(
+                    "batch_block",
+                    batch_blocks,
+                    {
+                        "element_base_bytes": w * preload_len,
+                        "scale_base_bytes": w * preload_len // 8,
+                    },
+                ),
+            )
+            rstride = 1
+        self.record_dma(
+            DmaTransfer(
+                opcode="H_PREFETCH_V",
+                direction="read",
+                role=memory_role,
+                element_base_bytes=hbm_addr,
+                scale_base_bytes=hbm_addr + size,
+                dim=vlen,
+                amount=preload_len,
+                stride_bytes=w,
+                rstride=rstride,
+                precision=memory_role,
+                memory_object=hbm_object_name,
+            ),
+            multiplicity=stream_count,
+            axes=axes,
+        )
+        return rendered
 
     def store_to_hbm(
         self,
@@ -134,6 +199,7 @@ class IsaCompiler(
         store_amount: int | None = None,  # HBM_V_Writeback_Amount
         hbm_element_bytes: int = 1,
         hbm_real_data_ratio: float | None = None,
+        memory_role: str = "activation",
     ) -> str:
         """
         Write tensor from VRAM back to HBM.
@@ -220,7 +286,64 @@ class IsaCompiler(
                 real_data_ratio=hbm_real_data_ratio or self.real_data_ratio,
             )
 
-        return self._emit(isa_code)
+        rendered = self._emit(isa_code)
+        total_elements = batch_size * hidden_size
+        if batch_size == 1:
+            stream_count = math.ceil(hidden_size / (vlen * store_amount))
+            axes = (
+                RepeatAxis.from_mapping(
+                    "hidden_store",
+                    stream_count,
+                    {
+                        "element_base_bytes": vlen * store_amount * hbm_element_bytes,
+                        "scale_base_bytes": vlen * store_amount * hbm_element_bytes // 8,
+                    },
+                ),
+            )
+            rstride = 0
+        else:
+            hidden_blocks = math.ceil(hidden_size / vlen)
+            batch_blocks = math.ceil(batch_size / store_amount)
+            stream_count = hidden_blocks * batch_blocks
+            axes = (
+                RepeatAxis.from_mapping(
+                    "hidden_block",
+                    hidden_blocks,
+                    {
+                        "element_base_bytes": vlen * hbm_element_bytes,
+                        "scale_base_bytes": vlen * hbm_element_bytes // 8,
+                    },
+                ),
+                RepeatAxis.from_mapping(
+                    "batch_block",
+                    batch_blocks,
+                    {
+                        "element_base_bytes": hidden_size * store_amount * hbm_element_bytes,
+                        "scale_base_bytes": hidden_size * store_amount * hbm_element_bytes // 8,
+                    },
+                ),
+            )
+            rstride = 1
+        self.record_dma(
+            DmaTransfer(
+                opcode="H_STORE_V",
+                direction="write",
+                role=memory_role,
+                element_base_bytes=hbm_addr * hbm_element_bytes,
+                scale_base_bytes=(hbm_addr + total_elements) * hbm_element_bytes,
+                dim=vlen,
+                amount=store_amount,
+                stride_bytes=hidden_size * hbm_element_bytes,
+                rstride=rstride,
+                write_amount=store_amount,
+                precision=memory_role,
+                element_bytes=hbm_element_bytes,
+                memory_object=hbm_object_name or tensor_name,
+            ),
+            multiplicity=stream_count,
+            axes=axes,
+        )
+        return rendered
 
     def normalize(
         self,

--- a/aten/plena/isa_emit.py
+++ b/aten/plena/isa_emit.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 
-from compiler.aten.isa_builder import AsmInput, IsaBuilder, Sequence, Stage, final_sequence, render_asm
+from compiler.aten.isa_builder import (
+    AsmInput,
+    IsaBuilder,
+    RepeatAxis,
+    Sequence,
+    Stage,
+    final_sequence,
+    render_asm,
+)
 from compiler.aten.plena.registers import RegisterAllocator
 
 
@@ -44,8 +52,9 @@ class IsaEmitMixin:
 
     def _emit(self, isa_code: AsmInput) -> str:
         """Append ISA text to the output buffer and return it."""
-        rendered = render_asm(isa_code)
-        self._code_chunks.append(rendered)
+        rendered = render_asm(isa_code) if getattr(self, "_emit_assembly", True) else ""
+        if rendered:
+            self._code_chunks.append(rendered)
         sink = getattr(self, "_symbolic_cost_sink", None)
         if sink is not None:
             schedule = final_sequence(isa_code)
@@ -97,6 +106,87 @@ class IsaEmitMixin:
                 sink.record_dma(transfer, multiplicity=multiplicity, axes=tuple(axes))
             finally:
                 sink.end_stage(stage)
+
+    @property
+    def cost_summary_enabled(self) -> bool:
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        return bool(sink is not None and sink.summary_enabled)
+
+    @contextmanager
+    def cost_repeat_region(
+        self,
+        count: int,
+        *,
+        axis: RepeatAxis | None = None,
+        kind: str = "compiler-summary",
+    ):
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is None or not sink.summary_enabled:
+            raise RuntimeError("cost_repeat_region requires summary cost tracing")
+        sink.begin_repeat(count, axis, kind)
+        try:
+            yield self
+        finally:
+            sink.end_repeat(count, axis, kind)
+
+    @contextmanager
+    def suppress_cost_dma(self):
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is None:
+            yield self
+            return
+        sink.begin_dma_suppression()
+        try:
+            yield self
+        finally:
+            sink.end_dma_suppression()
+
+    @contextmanager
+    def cost_summary_template(self, key: tuple[object, ...]):
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is None or not sink.summary_enabled:
+            yield self
+            return
+        sink.begin_template(key)
+        try:
+            yield self
+        finally:
+            sink.end_template(key)
+
+    def replay_cost_summary_template(
+        self,
+        key: tuple[object, ...],
+        *,
+        count: int = 1,
+        axes: tuple[RepeatAxis, ...] = (),
+        dma_address_delta_bytes: int = 0,
+    ) -> bool:
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        return bool(
+            sink is not None
+            and sink.summary_enabled
+            and sink.replay_template(
+                key,
+                count=count,
+                axes=axes,
+                dma_address_delta_bytes=dma_address_delta_bytes,
+            )
+        )
+
+    def emit_cost_opcode_counts(self, counts, *, provenance: str) -> None:
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is None:
+            raise RuntimeError("cost tracing is not enabled")
+        stage_stack = getattr(self, "_cost_stage_stack", ())
+        if not stage_stack:
+            sink.add_opcode_counts(counts, provenance=provenance)
+            return
+        stage = "/".join(stage_stack)
+        sink.begin_stage(stage)
+        try:
+            sink.add_opcode_counts(counts, provenance=provenance)
+        finally:
+            sink.end_stage(stage)
 
     # ------------------------------------------------------------------
     # FP Register management

--- a/aten/plena/isa_emit.py
+++ b/aten/plena/isa_emit.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from compiler.aten.isa_builder import AsmInput, IsaBuilder, render_asm
+from contextlib import contextmanager
+
+from compiler.aten.isa_builder import AsmInput, IsaBuilder, Sequence, Stage, final_sequence, render_asm
 from compiler.aten.plena.registers import RegisterAllocator
 
 
@@ -44,6 +46,13 @@ class IsaEmitMixin:
         """Append ISA text to the output buffer and return it."""
         rendered = render_asm(isa_code)
         self._code_chunks.append(rendered)
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is not None:
+            schedule = final_sequence(isa_code)
+            stage_stack = getattr(self, "_cost_stage_stack", ())
+            if stage_stack:
+                schedule = Sequence((Stage("/".join(stage_stack), schedule),))
+            sink.consume(schedule)
         return rendered
 
     def emit(self, isa_code: AsmInput) -> str:
@@ -53,6 +62,41 @@ class IsaEmitMixin:
     def emit_comment(self, text: str) -> str:
         """Append one assembly comment line."""
         return self._emit(IsaBuilder().comment(text))
+
+    @contextmanager
+    def cost_stage(self, stage_path: str):
+        """Assign opaque hierarchical ownership to subsequently emitted ISA."""
+        if not stage_path or stage_path.startswith("/") or stage_path.endswith("/"):
+            raise ValueError(f"invalid stage path {stage_path!r}")
+        self._cost_stage_stack.append(stage_path)
+        try:
+            yield self
+        finally:
+            popped = self._cost_stage_stack.pop()
+            if popped != stage_path:
+                raise RuntimeError("cost stage stack corrupted")
+
+    def get_cost_trace(self, **metadata):
+        """Finalize the compiler-assisted trace without affecting ASM output."""
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is None:
+            raise RuntimeError("cost tracing was not enabled for this compiler")
+        return sink.finish(**metadata)
+
+    def record_dma(self, transfer, *, multiplicity: int = 1, axes=()) -> None:
+        """Attach exact compiler-owned DMA geometry to the active stage."""
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is not None:
+            stage_stack = getattr(self, "_cost_stage_stack", ())
+            if not stage_stack:
+                sink.record_dma(transfer, multiplicity=multiplicity, axes=tuple(axes))
+                return
+            stage = "/".join(stage_stack)
+            sink.begin_stage(stage)
+            try:
+                sink.record_dma(transfer, multiplicity=multiplicity, axes=tuple(axes))
+            finally:
+                sink.end_stage(stage)
 
     # ------------------------------------------------------------------
     # FP Register management

--- a/aten/plena/isa_matrix.py
+++ b/aten/plena/isa_matrix.py
@@ -7,10 +7,47 @@ import math
 from compiler.asm_templates._imm import load_large_int
 from compiler.asm_templates import preload_addr_reg_asm
 from compiler.asm_templates.vram_sub_projection_asm import vram_sub_projection_asm_impl
-from compiler.aten.isa_builder import IsaBuilder, addr as areg, gp
+from compiler.aten.isa_builder import DmaTransfer, IsaBuilder, RepeatAxis, addr as areg, gp
 
 
 class IsaMatrixMixin:
+    def _matrix_dma_transfer(
+        self,
+        *,
+        name: str,
+        layout,
+        row_idx: int,
+        col_idx: int,
+        precision: int,
+        set_scale: bool,
+        hbm_element_bytes: int,
+    ) -> DmaTransfer:
+        rows, cols = layout.physical_shape or layout.full_shape
+        block = layout.get_sub_block(row_idx, col_idx)
+        role = getattr(getattr(self, "_inputs", {}).get(name), "memory_role", None)
+        if role is None:
+            role = "weight" if precision == 0 else "kv"
+        element_offset = block.hbm_offset * hbm_element_bytes
+        scale_base = None
+        if set_scale:
+            scale_base = (
+                layout.hbm_base_addr + rows * cols + block.hbm_offset // 8
+            ) * hbm_element_bytes
+        return DmaTransfer(
+            opcode="H_PREFETCH_M",
+            direction="read",
+            role=role,
+            element_base_bytes=layout.hbm_base_addr * hbm_element_bytes + element_offset,
+            scale_base_bytes=scale_base,
+            dim=self.mlen,
+            amount=1,
+            stride_bytes=cols * hbm_element_bytes,
+            rstride=1,
+            precision="weight" if precision == 0 else "matrix_kv",
+            element_bytes=hbm_element_bytes,
+            memory_object=name,
+        )
+
     def _emit_hbm_matrix_load(self, layout, gp_count: int, build_body) -> str:
         gp_regs = self.register_allocator.allocate_gp(gp_count)
         gp_for_addr = self.register_allocator.allocate_gp(2)
@@ -741,7 +778,7 @@ class IsaMatrixMixin:
             total_size = num_col_blocks * block_size
             mram_start_addr = self.mram_allocator.allocate(f"{name}[{row_idx}][:]", total_size)
 
-        return self._emit_hbm_matrix_load(
+        rendered = self._emit_hbm_matrix_load(
             layout,
             3,
             lambda addr_reg, gp_regs: self.load_row_sub_matrices_asm(
@@ -755,6 +792,29 @@ class IsaMatrixMixin:
                 hbm_element_bytes=hbm_element_bytes,
             ),
         )
+        first_col = 0
+        axis = RepeatAxis.from_mapping(
+            "matrix_col_block",
+            num_col_blocks,
+            {
+                "element_base_bytes": self.mlen * hbm_element_bytes,
+                "scale_base_bytes": self.mlen * hbm_element_bytes // 8,
+            },
+        )
+        self.record_dma(
+            self._matrix_dma_transfer(
+                name=name,
+                layout=layout,
+                row_idx=row_idx,
+                col_idx=first_col,
+                precision=precision,
+                set_scale=set_scale,
+                hbm_element_bytes=hbm_element_bytes,
+            ),
+            multiplicity=num_col_blocks,
+            axes=(axis,),
+        )
+        return rendered
 
     def load_sub_matrix(
         self,
@@ -773,7 +833,7 @@ class IsaMatrixMixin:
         if mram_dest_addr is None:
             mram_dest_addr = self.mram_allocator.allocate(f"{name}[{row_idx}][{col_idx}]", block_size)
 
-        return self._emit_hbm_matrix_load(
+        rendered = self._emit_hbm_matrix_load(
             layout,
             3,
             lambda addr_reg, gp_regs: self.load_sub_matrix_asm(
@@ -788,6 +848,18 @@ class IsaMatrixMixin:
                 hbm_element_bytes=hbm_element_bytes,
             ),
         )
+        self.record_dma(
+            self._matrix_dma_transfer(
+                name=name,
+                layout=layout,
+                row_idx=row_idx,
+                col_idx=col_idx,
+                precision=precision,
+                set_scale=set_scale,
+                hbm_element_bytes=hbm_element_bytes,
+            )
+        )
+        return rendered
 
     def load_sub_matrix_col(
         self,
@@ -813,7 +885,7 @@ class IsaMatrixMixin:
             total_size = effective_count * block_size
             mram_start_addr = self.mram_allocator.allocate(f"{name}[:][{col_idx}]", total_size)
 
-        return self._emit_hbm_matrix_load(
+        rendered = self._emit_hbm_matrix_load(
             layout,
             3,
             lambda addr_reg, gp_regs: self.load_col_sub_matrices_asm(
@@ -829,6 +901,29 @@ class IsaMatrixMixin:
                 hbm_element_bytes=hbm_element_bytes,
             ),
         )
+        effective_count = k_block_count if k_block_count is not None else num_row_blocks
+        axis = RepeatAxis.from_mapping(
+            "matrix_k_block",
+            effective_count,
+            {
+                "element_base_bytes": self.mlen * layout.physical_shape[1] * hbm_element_bytes,
+                "scale_base_bytes": self.mlen * layout.physical_shape[1] * hbm_element_bytes // 8,
+            },
+        )
+        self.record_dma(
+            self._matrix_dma_transfer(
+                name=name,
+                layout=layout,
+                row_idx=k_block_start,
+                col_idx=col_idx,
+                precision=precision,
+                set_scale=set_scale,
+                hbm_element_bytes=hbm_element_bytes,
+            ),
+            multiplicity=effective_count,
+            axes=(axis,),
+        )
+        return rendered
 
     def allocate_vram_matrix(
         self,

--- a/aten/plena/isa_matrix.py
+++ b/aten/plena/isa_matrix.py
@@ -8,6 +8,7 @@ from compiler.asm_templates._imm import load_large_int
 from compiler.asm_templates import preload_addr_reg_asm
 from compiler.asm_templates.vram_sub_projection_asm import vram_sub_projection_asm_impl
 from compiler.aten.isa_builder import DmaTransfer, IsaBuilder, RepeatAxis, addr as areg, gp
+from compiler.aten.plena.cost_kernels import vram_matrix_binary_cost_summary
 
 
 class IsaMatrixMixin:
@@ -1073,6 +1074,26 @@ class IsaMatrixMixin:
             and num_rows % self.mlen == 0
         )
 
+        if self.cost_summary_enabled:
+            summary = vram_matrix_binary_cost_summary(
+                opcode="V_ADD_VV",
+                mlen=self.mlen,
+                dst_base=dst_addr,
+                src_base=src_addr,
+                dst_physical_rows=dst_physical_rows,
+                src_physical_rows=src_physical_rows,
+                physical_cols=dst_physical_cols,
+                dst_row_offset=dst_row_offset,
+                src_row_offset=src_row_offset,
+                num_rows=num_rows,
+                block_add=block_aligned,
+            )
+            self.emit_cost_opcode_counts(
+                summary.opcodes,
+                provenance="main-vram-matrix-add-v1",
+            )
+            return ""
+
         if block_aligned:
             num_row_blocks = num_rows // self.mlen
             num_col_blocks = dst_physical_cols // self.mlen
@@ -1155,6 +1176,26 @@ class IsaMatrixMixin:
         assert src_row_offset + num_rows <= src_rows, (
             f"src row range out of bounds: offset={src_row_offset}, num_rows={num_rows}, src_rows={src_rows}"
         )
+
+        if self.cost_summary_enabled:
+            summary = vram_matrix_binary_cost_summary(
+                opcode="V_MUL_VV",
+                mlen=self.mlen,
+                dst_base=dst_addr,
+                src_base=src_addr,
+                dst_physical_rows=dst_physical_rows,
+                src_physical_rows=src_physical_rows,
+                physical_cols=dst_physical_cols,
+                dst_row_offset=dst_row_offset,
+                src_row_offset=src_row_offset,
+                num_rows=num_rows,
+                block_add=False,
+            )
+            self.emit_cost_opcode_counts(
+                summary.opcodes,
+                provenance="main-vram-matrix-mul-v1",
+            )
+            return ""
 
         lines = [
             f"; === VRAM Matrix Mul: "

--- a/aten/plena/program_attention.py
+++ b/aten/plena/program_attention.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from compiler.asm_templates._imm import add_large_int
 from compiler.asm_templates._imm import load_large_int
+from compiler.aten.isa_builder import DmaTransfer, RepeatAxis
 from compiler.aten.plena.vars import InputVar, VRAMMatrixVar
 
 
@@ -277,6 +278,34 @@ class ProgramAttentionMixin:
         # seq_len) this is 0.
         q_offset = kv_seq_len - seq_len
 
+        if self.cost_summary_enabled:
+            if q_offset != 0:
+                raise ValueError(
+                    "affine attention summary currently requires prefill geometry "
+                    "with seq_len == kv_seq_len"
+                )
+            return self._flash_attention_mha_summary(
+                Q=Q,
+                K=K,
+                V=V,
+                O=O,
+                S_block=S_block,
+                PV=PV,
+                scale=scale,
+                causal_mask=causal_mask,
+                valid_col_masks=valid_col_masks,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                head_dim=head_dim,
+                q_rows_per_batch=q_rows_per_batch,
+                k_rows_per_batch=k_rows_per_batch,
+                k_row_blocks_per_batch=k_row_blocks_per_batch,
+                q_base=q_base,
+                o_base=o_base,
+                q_batch_stride=q_batch_stride,
+                o_batch_stride=o_batch_stride,
+            )
+
         for batch_idx in range(batch_size):
             if batch_size == 1 and total_q_rows == seq_len:
                 Q_batch = Q
@@ -363,6 +392,346 @@ class ProgramAttentionMixin:
             self.free_tensor(mask)
 
         return O
+
+    def _flash_attention_mha_summary(
+        self,
+        *,
+        Q: VRAMMatrixVar,
+        K: InputVar,
+        V: InputVar,
+        O: VRAMMatrixVar,
+        S_block: VRAMMatrixVar,
+        PV: VRAMMatrixVar,
+        scale: float,
+        causal_mask: VRAMMatrixVar | None,
+        valid_col_masks: dict[int, VRAMMatrixVar],
+        batch_size: int,
+        seq_len: int,
+        head_dim: int,
+        q_rows_per_batch: int,
+        k_rows_per_batch: int,
+        k_row_blocks_per_batch: int,
+        q_base: int,
+        o_base: int,
+        q_batch_stride: int,
+        o_batch_stride: int,
+    ) -> VRAMMatrixVar:
+        """Algebraically meter main's causal MHA block schedule.
+
+        The production primitives are emitted once per full/tail kernel class.
+        Their final schedules are replayed by exact multiplicity.  K/V address
+        streams remain one affine descriptor per query block, so the trace is
+        O(sequence tiles) rather than O(causal Q/K pairs).
+        """
+
+        mlen = self.mlen
+        num_blocks = math.ceil(seq_len / mlen)
+        tail_rows = seq_len - (num_blocks - 1) * mlen
+        has_tail = tail_rows != mlen
+        full_blocks = num_blocks - int(has_tail)
+        stage = "/".join(getattr(self, "_cost_stage_stack", ())) or "global"
+
+        if batch_size == 1 and Q.shape[0] == seq_len:
+            q_sample = Q
+            o_sample = O
+        else:
+            q_sample = self.alloc_at(
+                "_mha_summary_Q",
+                seq_len,
+                head_dim,
+                q_base,
+                physical_shape=Q.physical_shape,
+            )
+            o_sample = self.alloc_at(
+                "_mha_summary_O",
+                seq_len,
+                head_dim,
+                o_base,
+                physical_shape=O.physical_shape,
+            )
+
+        def replay_or_emit(key, count, emitter):
+            if count <= 0:
+                return
+            full_key = (stage, *key)
+            if self.replay_cost_summary_template(full_key, count=count):
+                return
+            with self.cost_summary_template(full_key):
+                with self.suppress_cost_dma():
+                    emitter()
+            if count > 1:
+                if not self.replay_cost_summary_template(full_key, count=count - 1):
+                    raise RuntimeError(f"failed to replay attention template {full_key!r}")
+
+        def emit_init(q_idx: int, rows: int):
+            self.init_online_softmax(q_idx, o_sample, rows=rows)
+
+        def emit_final(q_idx: int, rows: int):
+            self.final_scale_o(q_idx, o_sample, rows=rows)
+
+        replay_or_emit(
+            ("mha-init", mlen, head_dim, mlen),
+            batch_size * full_blocks,
+            lambda: emit_init(0, mlen),
+        )
+        replay_or_emit(
+            ("mha-final", mlen, head_dim, mlen),
+            batch_size * full_blocks,
+            lambda: emit_final(0, mlen),
+        )
+        if has_tail:
+            replay_or_emit(
+                ("mha-init", mlen, head_dim, tail_rows),
+                batch_size,
+                lambda: emit_init(full_blocks, tail_rows),
+            )
+            replay_or_emit(
+                ("mha-final", mlen, head_dim, tail_rows),
+                batch_size,
+                lambda: emit_final(full_blocks, tail_rows),
+            )
+
+        def emit_pair(
+            *,
+            q_idx: int,
+            k_idx: int,
+            rows: int,
+            cols: int,
+            diagonal: bool,
+        ):
+            self.vram_sub_projection_T_to(
+                q_sample,
+                q_idx,
+                K,
+                k_idx,
+                S_block,
+                target_row_idx=0,
+                target_col_idx=0,
+            )
+            valid_mask = valid_col_masks.get(cols)
+            if valid_mask is not None:
+                self.vram_add(S_block, valid_mask, num_rows=rows)
+            if diagonal and causal_mask is not None:
+                self.vram_add(S_block, causal_mask)
+            self.online_softmax_block(
+                S_block,
+                scale,
+                rows=rows,
+                valid_cols=None if valid_mask is not None else cols,
+            )
+            self.compute_pv(S_block, V, 0, PV, head_dim, rows=rows)
+            self.scale_o_row(o_sample, q_idx, rows=rows)
+            self.vram_add(
+                o_sample,
+                PV,
+                dst_row_offset=q_idx * mlen,
+                num_rows=rows,
+            )
+
+        if causal_mask is not None:
+            replay_or_emit(
+                ("mha-pair", mlen, self.blen, head_dim, mlen, mlen, False),
+                batch_size * full_blocks * max(0, full_blocks - 1) // 2,
+                lambda: emit_pair(
+                    q_idx=0, k_idx=0, rows=mlen, cols=mlen, diagonal=False
+                ),
+            )
+            replay_or_emit(
+                ("mha-pair", mlen, self.blen, head_dim, mlen, mlen, True),
+                batch_size * full_blocks,
+                lambda: emit_pair(
+                    q_idx=0, k_idx=0, rows=mlen, cols=mlen, diagonal=True
+                ),
+            )
+            if has_tail:
+                replay_or_emit(
+                    ("mha-pair", mlen, self.blen, head_dim, tail_rows, mlen, False),
+                    batch_size * full_blocks,
+                    lambda: emit_pair(
+                        q_idx=full_blocks,
+                        k_idx=0,
+                        rows=tail_rows,
+                        cols=mlen,
+                        diagonal=False,
+                    ),
+                )
+                replay_or_emit(
+                    ("mha-pair", mlen, self.blen, head_dim, tail_rows, tail_rows, True),
+                    batch_size,
+                    lambda: emit_pair(
+                        q_idx=full_blocks,
+                        k_idx=full_blocks,
+                        rows=tail_rows,
+                        cols=tail_rows,
+                        diagonal=True,
+                    ),
+                )
+        else:
+            replay_or_emit(
+                ("mha-pair", mlen, self.blen, head_dim, mlen, mlen, False),
+                batch_size * full_blocks * full_blocks,
+                lambda: emit_pair(
+                    q_idx=0, k_idx=0, rows=mlen, cols=mlen, diagonal=False
+                ),
+            )
+            if has_tail:
+                replay_or_emit(
+                    ("mha-pair", mlen, self.blen, head_dim, mlen, tail_rows, False),
+                    batch_size * full_blocks,
+                    lambda: emit_pair(
+                        q_idx=0,
+                        k_idx=full_blocks,
+                        rows=mlen,
+                        cols=tail_rows,
+                        diagonal=False,
+                    ),
+                )
+                replay_or_emit(
+                    ("mha-pair", mlen, self.blen, head_dim, tail_rows, mlen, False),
+                    batch_size * full_blocks,
+                    lambda: emit_pair(
+                        q_idx=full_blocks,
+                        k_idx=0,
+                        rows=tail_rows,
+                        cols=mlen,
+                        diagonal=False,
+                    ),
+                )
+                replay_or_emit(
+                    ("mha-pair", mlen, self.blen, head_dim, tail_rows, tail_rows, False),
+                    batch_size,
+                    lambda: emit_pair(
+                        q_idx=full_blocks,
+                        k_idx=full_blocks,
+                        rows=tail_rows,
+                        cols=tail_rows,
+                        diagonal=False,
+                    ),
+                )
+
+        self._record_mha_summary_dma(
+            K=K,
+            V=V,
+            batch_size=batch_size,
+            num_blocks=num_blocks,
+            head_dim=head_dim,
+            k_row_blocks_per_batch=k_row_blocks_per_batch,
+            causal=causal_mask is not None,
+        )
+        for mask in valid_col_masks.values():
+            self.free_tensor(mask)
+        sink = getattr(self, "_symbolic_cost_sink", None)
+        if sink is not None:
+            sink.record_symbolic_lineage(
+                "mha-census-v1",
+                {
+                    "batch_size": batch_size,
+                    "num_blocks": num_blocks,
+                    "full_blocks": full_blocks,
+                    "tail_rows": tail_rows,
+                    "causal": causal_mask is not None,
+                },
+            )
+        return O
+
+    def _record_mha_summary_dma(
+        self,
+        *,
+        K: InputVar,
+        V: InputVar,
+        batch_size: int,
+        num_blocks: int,
+        head_dim: int,
+        k_row_blocks_per_batch: int,
+        causal: bool,
+    ) -> None:
+        """Record exact affine K/V HBM streams for the compressed MHA census."""
+
+        self._ensure_hbm_sub_matrix_registered(K)
+        self._ensure_hbm_sub_matrix_registered(V)
+        k_layout = self.get_hbm_layout(K.name)
+        v_layout = self.get_hbm_layout(V.name)
+        k_rows, k_cols = k_layout.physical_shape or k_layout.full_shape
+        v_rows, v_cols = v_layout.physical_shape or v_layout.full_shape
+        k_col_blocks = max(1, math.ceil(head_dim / self.mlen))
+        v_col_blocks = max(1, math.ceil(head_dim / self.mlen))
+        block_element_delta = self.mlen * k_cols
+        block_scale_delta = block_element_delta // 8
+
+        for batch_idx in range(batch_size):
+            base_block = batch_idx * k_row_blocks_per_batch
+            for q_idx in range(num_blocks):
+                visible = q_idx + 1 if causal else num_blocks
+                k_transfer = self._matrix_dma_transfer(
+                    name=K.name,
+                    layout=k_layout,
+                    row_idx=base_block,
+                    col_idx=0,
+                    precision=0,
+                    set_scale=True,
+                    hbm_element_bytes=1,
+                )
+                self.record_dma(
+                    k_transfer,
+                    multiplicity=visible * k_col_blocks,
+                    axes=(
+                        RepeatAxis.from_mapping(
+                            "visible_k_block",
+                            visible,
+                            {
+                                "element_base_bytes": block_element_delta,
+                                "scale_base_bytes": block_scale_delta,
+                            },
+                        ),
+                        RepeatAxis.from_mapping(
+                            "k_head_column",
+                            k_col_blocks,
+                            {
+                                "element_base_bytes": self.mlen,
+                                "scale_base_bytes": self.mlen // 8,
+                            },
+                        ),
+                    ),
+                )
+                v_offset = base_block * self.mlen * v_cols
+                self.record_dma(
+                    DmaTransfer(
+                        opcode="H_PREFETCH_M",
+                        direction="read",
+                        role=V.memory_role,
+                        element_base_bytes=v_layout.hbm_base_addr + v_offset,
+                        scale_base_bytes=(
+                            v_layout.hbm_base_addr
+                            + v_rows * v_cols
+                            + v_offset // 8
+                        ),
+                        dim=self.mlen,
+                        amount=1,
+                        stride_bytes=v_cols,
+                        rstride=1,
+                        precision="matrix_kv",
+                        memory_object=V.name,
+                    ),
+                    multiplicity=visible * v_col_blocks,
+                    axes=(
+                        RepeatAxis.from_mapping(
+                            "visible_v_block",
+                            visible,
+                            {
+                                "element_base_bytes": self.mlen * v_cols,
+                                "scale_base_bytes": self.mlen * v_cols // 8,
+                            },
+                        ),
+                        RepeatAxis.from_mapping(
+                            "v_head_column",
+                            v_col_blocks,
+                            {
+                                "element_base_bytes": self.mlen,
+                                "scale_base_bytes": self.mlen // 8,
+                            },
+                        ),
+                    ),
+                )
 
     def _flash_attention_gqa_fused(
         self,

--- a/aten/plena/program_matrix_ops.py
+++ b/aten/plena/program_matrix_ops.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import math
 
+from compiler.aten.plena.cost_kernels import (
+    bf16_stream_k_accum_cost_summary,
+    linear_projection_cost_summary,
+)
 from compiler.aten.plena.vars import InputVar, TensorVar, VRAMMatrixVar
 
 
@@ -350,6 +354,82 @@ class ProgramMatrixOpsMixin:
             physical_shape=(physical_rows, physical_out_features),
         )
 
+        if self.cost_summary_enabled:
+            chunks = list(_iter_k_chunks(num_k_tiles, max_k_tiles))
+            temp = self.alloc(f"{name}_temp", mlen, mlen) if len(chunks) > 1 else None
+            input_layout = self.get_vram_layout(input_var.name)
+            weight_layout = self.get_hbm_layout(weight_var.name)
+            output_layout = self.get_vram_layout(output.name)
+            weight_rows, weight_cols = (
+                weight_layout.physical_shape or weight_layout.full_shape
+            )
+            row_loop_counts = []
+            for row_idx in range(num_row_blocks):
+                block = input_layout.get_row_blocks(row_idx)[0]
+                valid_rows = block.valid_shape[0] if block.valid_shape else mlen
+                row_loop_counts.append(max(1, math.ceil(valid_rows / self.blen)))
+            hbm_offsets = [
+                [
+                    block.hbm_offset
+                    for block in weight_layout.get_col_blocks(col_idx)
+                ]
+                for col_idx in range(num_col_blocks)
+            ]
+            precision = _matrix_precision_code(matrix_precision)
+            dma_prototypes = [
+                self._matrix_dma_transfer(
+                    name=weight_var.name,
+                    layout=weight_layout,
+                    row_idx=0,
+                    col_idx=col_idx,
+                    precision=precision,
+                    set_scale=set_scale,
+                    hbm_element_bytes=hbm_element_bytes,
+                )
+                for col_idx in range(num_col_blocks)
+            ]
+            summary = linear_projection_cost_summary(
+                mlen=mlen,
+                blen=self.blen,
+                full_batch=input_layout.physical_shape[0],
+                hbm_base=weight_layout.hbm_base_addr,
+                hbm_rows=weight_rows,
+                hbm_cols=weight_cols,
+                input_base=input_layout.vram_base_addr,
+                input_physical_rows=input_layout.physical_shape[0],
+                output_base=output_layout.vram_base_addr,
+                output_physical_rows=output_layout.physical_shape[0],
+                temp_base=(
+                    self.get_vram_layout(temp.name).vram_base_addr
+                    if temp is not None
+                    else None
+                ),
+                num_row_blocks=num_row_blocks,
+                num_col_blocks=num_col_blocks,
+                chunks=chunks,
+                row_loop_counts=row_loop_counts,
+                hbm_offsets=hbm_offsets,
+                dma_prototypes=dma_prototypes,
+                include_hbm_base_setup=not getattr(
+                    self,
+                    "_suppress_summary_projection_hbm_base",
+                    False,
+                ),
+            )
+            self.emit_cost_opcode_counts(
+                summary.opcodes,
+                provenance="main-linear-projection-v1",
+            )
+            for stream in summary.dma_streams:
+                self.record_dma(
+                    stream.transfer,
+                    multiplicity=stream.multiplicity,
+                    axes=stream.axes,
+                )
+            if temp is not None:
+                self.free_tensor(temp)
+            return output
+
         def emit_projection(row_idx, col_idx, target, target_row_idx, target_col_idx, **k_split):
             self.vram_sub_projection_to(
                 input_var,
@@ -435,6 +515,75 @@ class ProgramMatrixOpsMixin:
             strict=False,
             physical_shape=(physical_rows, physical_out_features),
         )
+
+        if self.cost_summary_enabled and num_k_tiles > max_tiles:
+            self._ensure_vram_sub_matrix_registered(input_var)
+            self._ensure_hbm_sub_matrix_registered(weight_var)
+            self._ensure_vram_sub_matrix_registered(output)
+            input_layout = self.get_vram_layout(input_var.name)
+            weight_layout = self.get_hbm_layout(weight_var.name)
+            chunks = list(_iter_k_chunks(num_k_tiles, max_tiles))
+            row_loop_counts: list[int] = []
+            input_vram_bases: list[list[int]] = []
+            output_tile_bases: list[list[int]] = []
+            for row_idx in range(num_row_blocks):
+                blocks = input_layout.get_row_blocks(row_idx)
+                valid_rows = blocks[0].valid_shape[0] if blocks[0].valid_shape else mlen
+                row_loop_counts.append(
+                    min(mlen // self.blen, max(1, math.ceil(valid_rows / self.blen)))
+                )
+                input_vram_bases.append([block.vram_addr for block in blocks])
+                output_tile_bases.append(
+                    [
+                        self.get_vram_tile_addr(output.name, row_idx, col_idx)
+                        for col_idx in range(num_col_blocks)
+                    ]
+                )
+            hbm_offsets = [
+                [
+                    weight_layout.get_sub_block(k_idx, col_idx).hbm_offset
+                    for k_idx in range(num_k_tiles)
+                ]
+                for col_idx in range(num_col_blocks)
+            ]
+            dma_prototypes = [
+                self._matrix_dma_transfer(
+                    name=weight_var.name,
+                    layout=weight_layout,
+                    row_idx=0,
+                    col_idx=col_idx,
+                    precision=_matrix_precision_code("keyvalue"),
+                    set_scale=False,
+                    hbm_element_bytes=2,
+                )
+                for col_idx in range(num_col_blocks)
+            ]
+            summary = bf16_stream_k_accum_cost_summary(
+                mlen=mlen,
+                blen=self.blen,
+                hbm_base=weight_layout.hbm_base_addr,
+                hbm_cols=weight_layout.physical_shape[1],
+                full_batch=input_layout.physical_shape[0],
+                output_physical_rows=output.physical_shape[0],
+                input_vram_bases=input_vram_bases,
+                output_tile_bases=output_tile_bases,
+                row_loop_counts=row_loop_counts,
+                chunks=chunks,
+                hbm_offsets=hbm_offsets,
+                dma_prototypes=dma_prototypes,
+                hbm_element_bytes=2,
+            )
+            self.emit_cost_opcode_counts(
+                summary.opcodes,
+                provenance="main-bf16-stream-k-accum-v1",
+            )
+            for stream in summary.dma_streams:
+                self.record_dma(
+                    stream.transfer,
+                    multiplicity=stream.multiplicity,
+                    axes=stream.axes,
+                )
+            return output
 
         if num_k_tiles <= max_tiles:
             for col_idx in range(num_col_blocks):

--- a/aten/plena/program_routed_moe.py
+++ b/aten/plena/program_routed_moe.py
@@ -6,6 +6,11 @@ import math
 from collections.abc import Sequence
 
 from compiler.aten.isa_builder import IsaBuilder, addr as areg, fp, gp
+from compiler.aten.plena.cost_kernels import (
+    routed_row_copy_cost_summary,
+    standard_swiglu_cost_summary,
+    true_zero_rows_cost_summary,
+)
 from compiler.aten.plena.vars import FPVar, InputVar, VRAMMatrixVar
 
 GptOssFPConstants = tuple[FPVar, FPVar, FPVar, FPVar, FPVar]
@@ -1124,6 +1129,76 @@ class ProgramRoutedMoeMixin:
 
         return gathered
 
+    def gpt_oss_gather_token_rows_from_vram_summary_v0(
+        self,
+        x: VRAMMatrixVar,
+        *,
+        route_start: int,
+        route_count: int,
+        token_count: int,
+        hidden: int,
+        zero_row: FPVar | None = None,
+        name: str = "gpt_oss_gathered_x_vram",
+    ) -> VRAMMatrixVar:
+        """Census an affine routed gather without materializing route objects."""
+        if not self.cost_summary_enabled:
+            raise RuntimeError("summary routed gather requires summary cost tracing")
+        self._ensure_vram_sub_matrix_registered(x)
+        if hidden % self.mlen != 0:
+            raise ValueError(f"VRAM gather hidden={hidden} must be divisible by MLEN={self.mlen}")
+        if hidden > x.shape[1]:
+            raise ValueError(f"VRAM gather hidden={hidden} exceeds x width={x.shape[1]}")
+        if route_count <= 0 or token_count <= 0:
+            raise ValueError("route_count and token_count must be positive")
+        if token_count > x.physical_shape[0]:
+            raise ValueError(
+                f"VRAM gather token_count={token_count} exceeds x physical rows={x.physical_shape[0]}"
+            )
+
+        logical_rows = route_count * self.blen
+        physical_rows = max(self.blen, math.ceil(logical_rows / self.blen) * self.blen)
+        gathered = self.alloc(
+            name,
+            rows=logical_rows,
+            cols=hidden,
+            strict=False,
+            physical_shape=(physical_rows, hidden),
+        )
+        fp_zero_row = zero_row or self.fp_var(f"{name}_zero_row", size=self.mlen)
+        zero_summary = true_zero_rows_cost_summary(
+            mlen=self.mlen,
+            matrix_base=self._vram_matrix_row_addr(gathered, 0, 0),
+            matrix_physical_rows=gathered.physical_shape[0],
+            hidden=hidden,
+            fp_zero_base=fp_zero_row.address,
+            row_start=0,
+            row_step=1,
+            row_count=physical_rows,
+        )
+        self.emit_cost_opcode_counts(
+            zero_summary.opcodes,
+            provenance="main-routed-true-zero-v0",
+        )
+        gather_summary = routed_row_copy_cost_summary(
+            opcode="V_ADD_VV",
+            mlen=self.mlen,
+            hidden=hidden,
+            route_start=route_start,
+            route_count=route_count,
+            token_count=token_count,
+            slot_rows=self.blen,
+            dst_base=self._vram_matrix_row_addr(gathered, 0, 0),
+            dst_physical_rows=gathered.physical_shape[0],
+            src_base=self._vram_matrix_row_addr(x, 0, 0),
+            src_physical_rows=x.physical_shape[0],
+            token_is_destination=False,
+        )
+        self.emit_cost_opcode_counts(
+            gather_summary.opcodes,
+            provenance="main-routed-vram-gather-v0",
+        )
+        return gathered
+
     def gpt_oss_true_zero_vram_rows_v0(
         self,
         matrix: VRAMMatrixVar,
@@ -1170,6 +1245,45 @@ class ProgramRoutedMoeMixin:
         finally:
             self._reg.free_gp([gp_fp, gp_dst, gp_loop])
 
+    def gpt_oss_true_zero_vram_rows_summary_v0(
+        self,
+        matrix: VRAMMatrixVar,
+        *,
+        row_start: int,
+        row_step: int,
+        row_count: int,
+        hidden: int,
+        zero_row: FPVar | None = None,
+        name: str = "gpt_oss_zero_rows",
+    ) -> None:
+        """Census an affine true-zero row run without expanding row indices."""
+        if not self.cost_summary_enabled:
+            raise RuntimeError("summary true-zero requires summary cost tracing")
+        if row_count <= 0:
+            return
+        if row_start < 0 or row_step <= 0:
+            raise ValueError("summary true-zero requires a nonnegative start and positive step")
+        last_row = row_start + (row_count - 1) * row_step
+        if last_row >= matrix.physical_shape[0]:
+            raise ValueError(
+                f"zero row {last_row} exceeds physical rows={matrix.physical_shape[0]}"
+            )
+        fp_zero_row = zero_row or self.fp_var(f"{name}_zero_row", size=self.mlen)
+        summary = true_zero_rows_cost_summary(
+            mlen=self.mlen,
+            matrix_base=self._vram_matrix_row_addr(matrix, 0, 0),
+            matrix_physical_rows=matrix.physical_shape[0],
+            hidden=hidden,
+            fp_zero_base=fp_zero_row.address,
+            row_start=row_start,
+            row_step=row_step,
+            row_count=row_count,
+        )
+        self.emit_cost_opcode_counts(
+            summary.opcodes,
+            provenance="main-routed-true-zero-v0",
+        )
+
     def gpt_oss_scatter_add_active_rows_v0(
         self,
         dst: VRAMMatrixVar,
@@ -1213,6 +1327,51 @@ class ProgramRoutedMoeMixin:
             self._emit(asm)
         finally:
             self._reg.free_gp([gp_dst, gp_src])
+
+    def gpt_oss_scatter_add_active_rows_summary_v0(
+        self,
+        dst: VRAMMatrixVar,
+        src: VRAMMatrixVar,
+        *,
+        route_start: int,
+        route_count: int,
+        token_count: int,
+        hidden: int,
+        name: str = "gpt_oss_scatter_add",
+    ) -> None:
+        """Census affine scatter-add rows without route or active-row lists."""
+        del name
+        if not self.cost_summary_enabled:
+            raise RuntimeError("summary routed scatter requires summary cost tracing")
+        if route_count <= 0 or token_count <= 0:
+            raise ValueError("route_count and token_count must be positive")
+        if token_count > dst.physical_shape[0]:
+            raise ValueError(
+                f"scatter token_count={token_count} exceeds dst physical rows={dst.physical_shape[0]}"
+            )
+        required_src_rows = (route_count - 1) * self.blen + 1
+        if required_src_rows > src.physical_shape[0]:
+            raise ValueError(
+                f"scatter requires {required_src_rows} source rows, got {src.physical_shape[0]}"
+            )
+        summary = routed_row_copy_cost_summary(
+            opcode="V_ADD_VV",
+            mlen=self.mlen,
+            hidden=hidden,
+            route_start=route_start,
+            route_count=route_count,
+            token_count=token_count,
+            slot_rows=self.blen,
+            dst_base=self._vram_matrix_row_addr(dst, 0, 0),
+            dst_physical_rows=dst.physical_shape[0],
+            src_base=self._vram_matrix_row_addr(src, 0, 0),
+            src_physical_rows=src.physical_shape[0],
+            token_is_destination=True,
+        )
+        self.emit_cost_opcode_counts(
+            summary.opcodes,
+            provenance="main-routed-vram-scatter-v0",
+        )
 
     def gpt_oss_clamp_gated_activation_v0(
         self,
@@ -1281,7 +1440,6 @@ class ProgramRoutedMoeMixin:
         """
         self._validate_standard_swiglu_constants(constants, rows)
         _, _unused_pos, _unused_neg, one, neg_one = constants
-        active_rows = list(range(rows))
         physical_rows = max(self.mlen, math.ceil(rows / self.mlen) * self.mlen)
         num_col_blocks = math.ceil(intermediate / self.mlen)
         sigmoid = self.alloc(
@@ -1292,6 +1450,28 @@ class ProgramRoutedMoeMixin:
             strict=False,
         )
 
+        if self.cost_summary_enabled:
+            summary = standard_swiglu_cost_summary(
+                mlen=self.mlen,
+                sigmoid_base=self._vram_matrix_row_addr(sigmoid, 0, 0),
+                sigmoid_physical_rows=sigmoid.physical_shape[0],
+                intermediate=intermediate,
+                rows=rows,
+                one_fp_base=one.address,
+                neg_one_fp_base=neg_one.address,
+            )
+            self.emit_cost_opcode_counts(
+                summary.opcodes,
+                provenance="main-standard-swiglu-v0",
+            )
+            self.vram_add(sigmoid, gate, num_rows=rows)
+            self.vram_mul(gate, sigmoid, num_rows=rows)
+            self.vram_mul(up, gate, num_rows=rows)
+            self.free_tensor(sigmoid)
+            self.free_tensor(gate)
+            return up
+
+        active_rows = list(range(rows))
         self.vram_fill_zero(sigmoid, rows=active_rows)
         self.vram_add(sigmoid, gate, num_rows=rows)
 
@@ -1302,6 +1482,8 @@ class ProgramRoutedMoeMixin:
             self.tile_row_reci(sigmoid, rows=active_rows, tile_col_idx=col_block)
         self.vram_mul(gate, sigmoid, num_rows=rows)
         self.vram_mul(up, gate, num_rows=rows)
+        self.free_tensor(sigmoid)
+        self.free_tensor(gate)
         return up
 
     def gpt_oss_expert_v0(

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from compiler.asm_templates import ffn_asm, preload_addr_reg_asm, reset_reg_asm
+from compiler.aten.plena.cost_kernels import ffn_unrolled_cost_summary
 from compiler.aten.plena.vars import FPVar, InputVar, TensorVar, VRAMMatrixVar
 
 
@@ -146,6 +147,7 @@ class ProgramTensorMixin:
         precision: int = 0,
         hbm_element_bytes: int = 1,
         real_data_ratio: float | None = None,
+        memory_role: str | None = None,
     ) -> InputVar:
         """
         Write tensor from VRAM back to HBM.
@@ -168,6 +170,7 @@ class ProgramTensorMixin:
             h, w = tensor_var.physical_shape
             hbm_size = self.hbm_tensor_size(h * w)
 
+        resolved_role = memory_role or ("activation" if precision == 0 else "kv")
         super().store_to_hbm(
             tensor_name=tensor_var.name,  # internal name for symbol table lookup
             hbm_addr=hbm_addr,
@@ -177,7 +180,7 @@ class ProgramTensorMixin:
             precision=precision,
             hbm_element_bytes=hbm_element_bytes,
             hbm_real_data_ratio=real_data_ratio,
-            memory_role="activation" if precision == 0 else "kv",
+            memory_role=resolved_role,
         )
 
         var = InputVar(
@@ -188,7 +191,7 @@ class ProgramTensorMixin:
             hbm_size,
             display_name=display_name,
             physical_shape=tensor_var.physical_shape,
-            memory_role="activation" if precision == 0 else "kv",
+            memory_role=resolved_role,
         )
         self._inputs[internal_name] = var
         return var
@@ -444,26 +447,80 @@ class ProgramTensorMixin:
             addr_reg_val=[w_gate.hbm_addr, w_up.hbm_addr, w_down.hbm_addr],
         )
         isa_code += reset_reg_asm(alive_registers=[1, 2, 3])
-        isa_code += ffn_asm(
+        self.emit(isa_code)
+        gate_layout = self.get_hbm_layout(w_gate.name)
+        up_layout = self.get_hbm_layout(w_up.name)
+        down_layout = self.get_hbm_layout(w_down.name)
+        summary = ffn_unrolled_cost_summary(
             mlen=mlen,
             vlen=mlen,
             blen=blen,
-            batch=batch_size,
-            seq_len=1,
+            batch_rows=batch_size,
             hidden_size=hidden_size,
             intermediate_size=inter_dim,
-            alive_registers=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-            gate_weight_hbm_offset_reg=1,
-            up_weight_hbm_offset_reg=2,
-            down_weight_hbm_offset_reg=3,
-            const_one_fp_address=5,
-            activation_base_address=activation_base_address,
-            use_loop_instructions=use_loop_instructions,
+            activation_base=activation_base_address,
+            workspace_base=workspace_base_address,
             matrix_sram_size=self.mram_capacity_elems,
-            workspace_base_address=workspace_base_address,
+            gate_weight_dma=self._matrix_dma_transfer(
+                name=w_gate.name,
+                layout=gate_layout,
+                row_idx=0,
+                col_idx=0,
+                precision=0,
+                set_scale=True,
+                hbm_element_bytes=1,
+            ),
+            up_weight_dma=self._matrix_dma_transfer(
+                name=w_up.name,
+                layout=up_layout,
+                row_idx=0,
+                col_idx=0,
+                precision=0,
+                set_scale=True,
+                hbm_element_bytes=1,
+            ),
+            down_weight_dma=self._matrix_dma_transfer(
+                name=w_down.name,
+                layout=down_layout,
+                row_idx=0,
+                col_idx=0,
+                precision=0,
+                set_scale=True,
+                hbm_element_bytes=1,
+            ),
         )
-
-        self.emit(isa_code)
+        if self.cost_summary_enabled:
+            self.emit_cost_opcode_counts(
+                summary.opcodes,
+                provenance="main-ffn-unrolled-v1",
+            )
+        else:
+            self.emit(
+                ffn_asm(
+                    mlen=mlen,
+                    vlen=mlen,
+                    blen=blen,
+                    batch=batch_size,
+                    seq_len=1,
+                    hidden_size=hidden_size,
+                    intermediate_size=inter_dim,
+                    alive_registers=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                    gate_weight_hbm_offset_reg=1,
+                    up_weight_hbm_offset_reg=2,
+                    down_weight_hbm_offset_reg=3,
+                    const_one_fp_address=5,
+                    activation_base_address=activation_base_address,
+                    use_loop_instructions=use_loop_instructions,
+                    matrix_sram_size=self.mram_capacity_elems,
+                    workspace_base_address=workspace_base_address,
+                )
+            )
+        for stream in summary.dma_streams:
+            self.record_dma(
+                stream.transfer,
+                multiplicity=stream.multiplicity,
+                axes=stream.axes,
+            )
         self.free_tensor(workspace)
         return input_var
 

--- a/aten/plena/program_tensors.py
+++ b/aten/plena/program_tensors.py
@@ -19,6 +19,7 @@ class ProgramTensorMixin:
         prestaged_vram_addr: int | None = None,
         physical_shape: tuple[int, int] | None = None,
         real_data_ratio: float | None = None,
+        memory_role: str = "activation",
     ) -> InputVar:
         """
         Declare an input tensor (in HBM).
@@ -54,6 +55,7 @@ class ProgramTensorMixin:
             hbm_size,
             prestaged_vram_addr=prestaged_vram_addr,
             physical_shape=physical_shape,
+            memory_role=memory_role,
         )
         self._inputs[name] = var
         super().add_hbm_object(
@@ -119,6 +121,7 @@ class ProgramTensorMixin:
                 vram_object_name=internal_name,
                 vlen=self.mlen,
                 preload_len=self.hbm_v_prefetch_amount,
+                memory_role=input_var.memory_role,
             )
 
         var = VRAMMatrixVar(
@@ -174,6 +177,7 @@ class ProgramTensorMixin:
             precision=precision,
             hbm_element_bytes=hbm_element_bytes,
             hbm_real_data_ratio=real_data_ratio,
+            memory_role="activation" if precision == 0 else "kv",
         )
 
         var = InputVar(
@@ -184,6 +188,7 @@ class ProgramTensorMixin:
             hbm_size,
             display_name=display_name,
             physical_shape=tensor_var.physical_shape,
+            memory_role="activation" if precision == 0 else "kv",
         )
         self._inputs[internal_name] = var
         return var

--- a/aten/plena/vars.py
+++ b/aten/plena/vars.py
@@ -69,11 +69,15 @@ class InputVar(TensorVar):
         display_name: str | None = None,
         prestaged_vram_addr: int | None = None,
         physical_shape: tuple[int, int] | None = None,
+        memory_role: str = "activation",
     ):
         super().__init__(program, name, "input", shape, display_name=display_name, physical_shape=physical_shape)
         self.hbm_addr = hbm_addr
         self.hbm_size = hbm_size
         self.prestaged_vram_addr = prestaged_vram_addr
+        if not memory_role:
+            raise ValueError("InputVar.memory_role must be non-empty")
+        self.memory_role = memory_role
 
 
 class FPVar:

--- a/aten/plena_frontend.py
+++ b/aten/plena_frontend.py
@@ -799,8 +799,16 @@ def _emit_kv_stores(
                 semantic=f"K projection for KV head {kv_h} after RoPE",
             )
 
-        K_stored = prog.store(K_h, name=f"K_stored_{layer_idx}_h{kv_h}")
-        V_stored = prog.store(V_h, name=f"V_stored_{layer_idx}_h{kv_h}")
+        K_stored = prog.store(
+            K_h,
+            name=f"K_stored_{layer_idx}_h{kv_h}",
+            memory_role="kv",
+        )
+        V_stored = prog.store(
+            V_h,
+            name=f"V_stored_{layer_idx}_h{kv_h}",
+            memory_role="kv",
+        )
         kv_stored.append((K_stored, V_stored))
 
         prog.free_tensor(K_h)

--- a/aten/program_sink.py
+++ b/aten/program_sink.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from hashlib import sha256
 import json
 from typing import Any, Protocol
@@ -24,6 +24,12 @@ from compiler.aten.isa_builder import (
 
 
 TRACE_SCHEMA_VERSION = "plena-final-schedule-v1"
+COST_TRACE_GRANULARITY_DETAILED = "detailed"
+COST_TRACE_GRANULARITY_SUMMARY = "affine-block-summary-v1"
+COST_TRACE_GRANULARITIES = (
+    COST_TRACE_GRANULARITY_DETAILED,
+    COST_TRACE_GRANULARITY_SUMMARY,
+)
 
 
 class ProgramSink(Protocol):
@@ -101,6 +107,14 @@ class CostTrace:
         }
 
 
+@dataclass(frozen=True)
+class CostTraceFragment:
+    """One compiler-emitted kernel body retained for algebraic replay."""
+
+    instructions: tuple[TraceInstruction, ...]
+    dma_events: tuple[TraceDma, ...]
+
+
 @dataclass
 class AsmSink:
     """Reference sink used to prove IR rendering remains byte stable."""
@@ -120,6 +134,7 @@ class SymbolicCostSink:
 
     compiler_hash: str = "unknown"
     default_stage: str | None = None
+    granularity: str = COST_TRACE_GRANULARITY_DETAILED
     _stage_stack: list[str] = field(default_factory=list)
     _multiplier_stack: list[int] = field(default_factory=lambda: [1])
     _axis_stack: list[RepeatAxis] = field(default_factory=list)
@@ -128,6 +143,22 @@ class SymbolicCostSink:
     _schedule_digest: Any = field(default_factory=sha256)
     _raw_instruction_count: int = 0
     _symbolic_repeat_count: int = 0
+    _suppress_dma_depth: int = 0
+    _templates: dict[tuple[Any, ...], CostTraceFragment] = field(default_factory=dict)
+    _capture_stack: list[
+        tuple[tuple[Any, ...], dict[tuple[Any, ...], int], int]
+    ] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.granularity not in COST_TRACE_GRANULARITIES:
+            raise ValueError(
+                f"unsupported cost-trace granularity {self.granularity!r}; "
+                f"expected one of {COST_TRACE_GRANULARITIES}"
+            )
+
+    @property
+    def summary_enabled(self) -> bool:
+        return self.granularity == COST_TRACE_GRANULARITY_SUMMARY
 
     @property
     def stage(self) -> str:
@@ -167,6 +198,28 @@ class SymbolicCostSink:
             sram=sram,
             multiplicity=self.multiplier,
         )
+        self._add_instruction(leaf)
+        self._raw_instruction_count += 1
+        self._schedule_digest.update(instruction.render().encode())
+        self._schedule_digest.update(b"\n")
+        if instruction.dma is not None:
+            self.emit_dma(instruction.dma)
+
+    def _add_instruction(self, leaf: TraceInstruction, multiplier: int = 1) -> None:
+        if multiplier < 0:
+            raise ValueError("instruction multiplier must be nonnegative")
+        if multiplier == 0 or leaf.multiplicity == 0:
+            return
+        if multiplier != 1:
+            leaf = TraceInstruction(
+                stage=leaf.stage,
+                opcode=leaf.opcode,
+                operands=leaf.operands,
+                variant=leaf.variant,
+                active=leaf.active,
+                sram=leaf.sram,
+                multiplicity=leaf.multiplicity * multiplier,
+            )
         key = leaf.key()
         old = self._instructions.get(key)
         if old is None:
@@ -181,11 +234,59 @@ class SymbolicCostSink:
                 sram=old.sram,
                 multiplicity=old.multiplicity + leaf.multiplicity,
             )
-        self._raw_instruction_count += 1
-        self._schedule_digest.update(instruction.render().encode())
-        self._schedule_digest.update(b"\n")
-        if instruction.dma is not None:
-            self.emit_dma(instruction.dma)
+
+    def add_opcode_counts(
+        self,
+        counts: Counter[str] | dict[str, int],
+        *,
+        provenance: str,
+    ) -> None:
+        """Add a compiler-owned symbolic schedule census.
+
+        This hook is reserved for legacy templates whose production renderer
+        still Python-unrolls a deterministic affine loop.  The census lives in
+        the compiler adapter and is parity-tested against the rendered final
+        schedule; timing consumers never carry a second opcode formula.
+        """
+        if not self.summary_enabled:
+            raise RuntimeError("abstract opcode counts are only valid in summary mode")
+        for opcode, count in counts.items():
+            if count < 0:
+                raise ValueError(f"negative {opcode} count")
+            if count == 0:
+                continue
+            if not opcode.startswith(("M_", "V_", "S_", "C_", "H_")):
+                raise ValueError(f"unknown final-schedule opcode {opcode!r}")
+            self._add_instruction(
+                TraceInstruction(
+                    stage=self.stage,
+                    opcode=opcode,
+                    operands=(),
+                    variant=(("symbolic_provenance", provenance),),
+                    active=None,
+                    sram=(),
+                    multiplicity=int(count) * self.multiplier,
+                )
+            )
+        self._schedule_digest.update(
+            json.dumps(
+                {"provenance": provenance, "counts": dict(sorted(counts.items()))},
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        )
+
+    def record_symbolic_lineage(self, provenance: str, payload: Any) -> None:
+        """Bind an algebraic schedule census to the trace identity."""
+        if not self.summary_enabled:
+            raise RuntimeError("symbolic lineage is only valid in summary mode")
+        self._schedule_digest.update(
+            json.dumps(
+                {"provenance": provenance, "payload": payload},
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        )
 
     def emit_dma(self, transfer: DmaTransfer) -> None:
         self.record_dma(transfer)
@@ -197,6 +298,8 @@ class SymbolicCostSink:
         multiplicity: int = 1,
         axes: tuple[RepeatAxis, ...] = (),
     ) -> None:
+        if self._suppress_dma_depth:
+            return
         if transfer.opcode not in {"H_PREFETCH_M", "H_PREFETCH_V", "H_STORE_V"}:
             raise ValueError(f"unsupported DMA opcode {transfer.opcode!r}")
         if multiplicity < 0:
@@ -209,6 +312,90 @@ class SymbolicCostSink:
                 repeat_axes=tuple(self._axis_stack) + axes + transfer.axes,
             )
         )
+
+    def begin_dma_suppression(self) -> None:
+        self._suppress_dma_depth += 1
+
+    def end_dma_suppression(self) -> None:
+        if self._suppress_dma_depth <= 0:
+            raise ValueError("unbalanced DMA suppression")
+        self._suppress_dma_depth -= 1
+
+    def begin_template(self, key: tuple[Any, ...]) -> None:
+        if not self.summary_enabled:
+            raise RuntimeError("summary templates require summary granularity")
+        if self._capture_stack:
+            raise RuntimeError("nested summary-template capture is unsupported")
+        if key in self._templates:
+            raise ValueError(f"summary template {key!r} already exists")
+        snapshot = {item_key: item.multiplicity for item_key, item in self._instructions.items()}
+        self._capture_stack.append((key, snapshot, len(self._dmas)))
+
+    def end_template(self, key: tuple[Any, ...]) -> None:
+        if not self._capture_stack or self._capture_stack[-1][0] != key:
+            raise ValueError(f"unbalanced summary template {key!r}")
+        _, before, dma_start = self._capture_stack.pop()
+        instructions: list[TraceInstruction] = []
+        for item_key, item in self._instructions.items():
+            delta = item.multiplicity - before.get(item_key, 0)
+            if delta:
+                instructions.append(
+                    TraceInstruction(
+                        stage=item.stage,
+                        opcode=item.opcode,
+                        operands=item.operands,
+                        variant=item.variant,
+                        active=item.active,
+                        sram=item.sram,
+                        multiplicity=delta,
+                    )
+                )
+        self._templates[key] = CostTraceFragment(
+            instructions=tuple(instructions),
+            dma_events=tuple(self._dmas[dma_start:]),
+        )
+
+    def replay_template(
+        self,
+        key: tuple[Any, ...],
+        *,
+        count: int = 1,
+        axes: tuple[RepeatAxis, ...] = (),
+        dma_address_delta_bytes: int = 0,
+    ) -> bool:
+        fragment = self._templates.get(key)
+        if fragment is None:
+            return False
+        if count < 0:
+            raise ValueError("summary-template replay count must be nonnegative")
+        for item in fragment.instructions:
+            self._add_instruction(item, count * self.multiplier)
+        for event in fragment.dma_events:
+            transfer = event.transfer
+            if dma_address_delta_bytes:
+                transfer = replace(
+                    transfer,
+                    element_base_bytes=(
+                        transfer.element_base_bytes + dma_address_delta_bytes
+                    ),
+                    scale_base_bytes=(
+                        None
+                        if transfer.scale_base_bytes is None
+                        else transfer.scale_base_bytes + dma_address_delta_bytes
+                    ),
+                )
+            self._dmas.append(
+                TraceDma(
+                    stage=event.stage,
+                    transfer=transfer,
+                    multiplicity=event.multiplicity * count * self.multiplier,
+                    repeat_axes=tuple(self._axis_stack) + axes + event.repeat_axes,
+                )
+            )
+        self._schedule_digest.update(
+            repr(("replay", key, count, axes, dma_address_delta_bytes)).encode()
+        )
+        return True
 
     def begin_repeat(self, count: int, axis: RepeatAxis | None, kind: str) -> None:
         if count < 0:
@@ -231,15 +418,49 @@ class SymbolicCostSink:
         _walk(schedule, self)
 
     def finish(self, **metadata: Any) -> CostTrace:
-        if self._stage_stack or len(self._multiplier_stack) != 1 or self._axis_stack:
+        if (
+            self._stage_stack
+            or len(self._multiplier_stack) != 1
+            or self._axis_stack
+            or self._capture_stack
+            or self._suppress_dma_depth
+        ):
             raise ValueError("cannot finish an unbalanced final schedule")
         merged_dma = _merge_dma_events(self._dmas)
+        hbm_opcodes = {
+            opcode: count
+            for opcode, count in self.dynamic_opcode_counts().items()
+            if opcode.startswith("H_")
+        }
+        dma_opcodes: Counter[str] = Counter()
+        for event in merged_dma:
+            dma_opcodes[event.transfer.opcode] += event.multiplicity
+        uncovered = {
+            opcode: (count, dma_opcodes.get(opcode, 0))
+            for opcode, count in hbm_opcodes.items()
+            if count != dma_opcodes.get(opcode, 0)
+        }
+        if uncovered:
+            detail = ", ".join(
+                f"{opcode}: instructions={counts[0]}, DMA={counts[1]}"
+                for opcode, counts in sorted(uncovered.items())
+            )
+            raise ValueError(f"incomplete final-schedule DMA coverage: {detail}")
         trace_metadata = {
             "trace_fidelity": "exact_final_schedule",
-            "ordered_schedule_available": True,
+            "cost_trace_granularity": self.granularity,
+            "ordered_schedule_available": not self.summary_enabled,
             "materialized_dynamic_instructions": 0,
             "symbolic_repeat_nodes": self._symbolic_repeat_count,
             "materialized_schedule_leaves": self._raw_instruction_count,
+            "summary_template_count": len(self._templates),
+            "dma_opcode_coverage": {
+                opcode: {
+                    "instruction_count": count,
+                    "described_count": dma_opcodes.get(opcode, 0),
+                }
+                for opcode, count in sorted(hbm_opcodes.items())
+            },
             **metadata,
         }
         return CostTrace(
@@ -250,6 +471,12 @@ class SymbolicCostSink:
             dma_events=tuple(merged_dma),
             metadata=trace_metadata,
         )
+
+    def dynamic_opcode_counts(self) -> Counter[str]:
+        result: Counter[str] = Counter()
+        for item in self._instructions.values():
+            result[item.opcode] += item.multiplicity
+        return result
 
 
 def _walk(sequence: Sequence, sink: ProgramSink) -> None:
@@ -308,6 +535,10 @@ def _merge_dma_events(events: list[TraceDma]) -> list[TraceDma]:
 __all__ = [
     "AsmSink",
     "CostTrace",
+    "CostTraceFragment",
+    "COST_TRACE_GRANULARITIES",
+    "COST_TRACE_GRANULARITY_DETAILED",
+    "COST_TRACE_GRANULARITY_SUMMARY",
     "ProgramSink",
     "SymbolicCostSink",
     "TRACE_SCHEMA_VERSION",

--- a/aten/program_sink.py
+++ b/aten/program_sink.py
@@ -146,7 +146,13 @@ class SymbolicCostSink:
     _suppress_dma_depth: int = 0
     _templates: dict[tuple[Any, ...], CostTraceFragment] = field(default_factory=dict)
     _capture_stack: list[
-        tuple[tuple[Any, ...], dict[tuple[Any, ...], int], int]
+        tuple[
+            tuple[Any, ...],
+            dict[tuple[Any, ...], int],
+            int,
+            int,
+            tuple[RepeatAxis, ...],
+        ]
     ] = field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -328,17 +334,32 @@ class SymbolicCostSink:
             raise RuntimeError("nested summary-template capture is unsupported")
         if key in self._templates:
             raise ValueError(f"summary template {key!r} already exists")
+        if self.multiplier == 0:
+            raise ValueError("cannot capture a summary template in a zero-count repeat")
         snapshot = {item_key: item.multiplicity for item_key, item in self._instructions.items()}
-        self._capture_stack.append((key, snapshot, len(self._dmas)))
+        self._capture_stack.append(
+            (
+                key,
+                snapshot,
+                len(self._dmas),
+                self.multiplier,
+                tuple(self._axis_stack),
+            )
+        )
 
     def end_template(self, key: tuple[Any, ...]) -> None:
         if not self._capture_stack or self._capture_stack[-1][0] != key:
             raise ValueError(f"unbalanced summary template {key!r}")
-        _, before, dma_start = self._capture_stack.pop()
+        _, before, dma_start, capture_multiplier, capture_axes = self._capture_stack.pop()
         instructions: list[TraceInstruction] = []
         for item_key, item in self._instructions.items():
             delta = item.multiplicity - before.get(item_key, 0)
             if delta:
+                if delta % capture_multiplier:
+                    raise ValueError(
+                        f"summary template {key!r} instruction multiplicity {delta} "
+                        f"is not divisible by enclosing repeat {capture_multiplier}"
+                    )
                 instructions.append(
                     TraceInstruction(
                         stage=item.stage,
@@ -347,12 +368,32 @@ class SymbolicCostSink:
                         variant=item.variant,
                         active=item.active,
                         sram=item.sram,
-                        multiplicity=delta,
+                        multiplicity=delta // capture_multiplier,
                     )
                 )
+        dma_events: list[TraceDma] = []
+        for event in self._dmas[dma_start:]:
+            if event.multiplicity % capture_multiplier:
+                raise ValueError(
+                    f"summary template {key!r} DMA multiplicity {event.multiplicity} "
+                    f"is not divisible by enclosing repeat {capture_multiplier}"
+                )
+            if event.repeat_axes[: len(capture_axes)] != capture_axes:
+                raise ValueError(
+                    f"summary template {key!r} DMA axes do not preserve the "
+                    "enclosing repeat prefix"
+                )
+            dma_events.append(
+                TraceDma(
+                    stage=event.stage,
+                    transfer=event.transfer,
+                    multiplicity=event.multiplicity // capture_multiplier,
+                    repeat_axes=event.repeat_axes[len(capture_axes) :],
+                )
+            )
         self._templates[key] = CostTraceFragment(
             instructions=tuple(instructions),
-            dma_events=tuple(self._dmas[dma_start:]),
+            dma_events=tuple(dma_events),
         )
 
     def replay_template(

--- a/aten/program_sink.py
+++ b/aten/program_sink.py
@@ -77,7 +77,10 @@ class CostTrace:
 
     @property
     def dynamic_opcode_counts(self) -> Counter[str]:
-        return Counter({item.opcode: item.multiplicity for item in self.instructions})
+        result: Counter[str] = Counter()
+        for item in self.instructions:
+            result[item.opcode] += item.multiplicity
+        return result
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -185,14 +188,25 @@ class SymbolicCostSink:
             self.emit_dma(instruction.dma)
 
     def emit_dma(self, transfer: DmaTransfer) -> None:
+        self.record_dma(transfer)
+
+    def record_dma(
+        self,
+        transfer: DmaTransfer,
+        *,
+        multiplicity: int = 1,
+        axes: tuple[RepeatAxis, ...] = (),
+    ) -> None:
         if transfer.opcode not in {"H_PREFETCH_M", "H_PREFETCH_V", "H_STORE_V"}:
             raise ValueError(f"unsupported DMA opcode {transfer.opcode!r}")
+        if multiplicity < 0:
+            raise ValueError("DMA multiplicity must be nonnegative")
         self._dmas.append(
             TraceDma(
                 stage=self.stage,
                 transfer=transfer,
-                multiplicity=self.multiplier,
-                repeat_axes=tuple(self._axis_stack) + transfer.axes,
+                multiplicity=self.multiplier * multiplicity,
+                repeat_axes=tuple(self._axis_stack) + axes + transfer.axes,
             )
         )
 

--- a/aten/program_sink.py
+++ b/aten/program_sink.py
@@ -1,0 +1,302 @@
+"""Consumers for the compiler's immutable final-schedule IR."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from hashlib import sha256
+import json
+from typing import Any, Protocol
+
+from compiler.aten.isa_builder import (
+    Comment,
+    CompileTimeRepeat,
+    DmaTransfer,
+    HardwareLoop,
+    Instr,
+    RepeatAxis,
+    Sequence,
+    Stage,
+    parse_legacy_asm,
+    render_arg,
+    render_items,
+)
+
+
+TRACE_SCHEMA_VERSION = "plena-final-schedule-v1"
+
+
+class ProgramSink(Protocol):
+    """Minimal backend contract for final compiler schedules."""
+
+    def begin_stage(self, stage_path: str) -> None: ...
+    def end_stage(self, stage_path: str) -> None: ...
+    def emit_instruction(self, instruction: Instr) -> None: ...
+    def emit_dma(self, transfer: DmaTransfer) -> None: ...
+    def begin_repeat(self, count: int, axis: RepeatAxis | None, kind: str) -> None: ...
+    def end_repeat(self, count: int, axis: RepeatAxis | None, kind: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class TraceInstruction:
+    stage: str
+    opcode: str
+    operands: tuple[str, ...]
+    variant: tuple[tuple[str, str], ...]
+    active: dict[str, int | None] | None
+    sram: tuple[dict[str, Any], ...]
+    multiplicity: int
+
+    def key(self) -> tuple[Any, ...]:
+        return (
+            self.stage,
+            self.opcode,
+            self.operands,
+            self.variant,
+            tuple(sorted((self.active or {}).items())),
+            tuple(tuple(sorted(entry.items())) for entry in self.sram),
+        )
+
+
+@dataclass(frozen=True)
+class TraceDma:
+    stage: str
+    transfer: DmaTransfer
+    multiplicity: int
+    repeat_axes: tuple[RepeatAxis, ...]
+
+
+@dataclass(frozen=True)
+class CostTrace:
+    schema_version: str
+    isa_hash: str
+    compiler_hash: str
+    instructions: tuple[TraceInstruction, ...]
+    dma_events: tuple[TraceDma, ...]
+    metadata: dict[str, Any]
+
+    @property
+    def dynamic_opcode_counts(self) -> Counter[str]:
+        return Counter({item.opcode: item.multiplicity for item in self.instructions})
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "isa_hash": self.isa_hash,
+            "compiler_hash": self.compiler_hash,
+            "instructions": [asdict(item) for item in self.instructions],
+            "dma_events": [
+                {
+                    "stage": item.stage,
+                    "transfer": asdict(item.transfer),
+                    "multiplicity": item.multiplicity,
+                    "repeat_axes": [asdict(axis) for axis in item.repeat_axes],
+                }
+                for item in self.dma_events
+            ],
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class AsmSink:
+    """Reference sink used to prove IR rendering remains byte stable."""
+
+    lines: list[str] = field(default_factory=list)
+
+    def consume(self, schedule: Sequence) -> None:
+        self.lines.extend(render_items(schedule.items))
+
+    def render(self) -> str:
+        return "\n".join(self.lines) + ("\n" if self.lines else "")
+
+
+@dataclass
+class SymbolicCostSink:
+    """Exact multiplicity collector that never expands symbolic repeats."""
+
+    compiler_hash: str = "unknown"
+    default_stage: str | None = None
+    _stage_stack: list[str] = field(default_factory=list)
+    _multiplier_stack: list[int] = field(default_factory=lambda: [1])
+    _axis_stack: list[RepeatAxis] = field(default_factory=list)
+    _instructions: dict[tuple[Any, ...], TraceInstruction] = field(default_factory=dict)
+    _dmas: list[TraceDma] = field(default_factory=list)
+    _schedule_digest: Any = field(default_factory=sha256)
+    _raw_instruction_count: int = 0
+    _symbolic_repeat_count: int = 0
+
+    @property
+    def stage(self) -> str:
+        if self._stage_stack:
+            return "/".join(self._stage_stack)
+        if self.default_stage:
+            return self.default_stage
+        raise ValueError("final schedule instruction has no stage ownership")
+
+    @property
+    def multiplier(self) -> int:
+        return self._multiplier_stack[-1]
+
+    def begin_stage(self, stage_path: str) -> None:
+        if not stage_path:
+            raise ValueError("stage_path must be non-empty")
+        self._stage_stack.append(stage_path)
+
+    def end_stage(self, stage_path: str) -> None:
+        if not self._stage_stack or self._stage_stack[-1] != stage_path:
+            raise ValueError(f"unbalanced stage {stage_path!r}")
+        self._stage_stack.pop()
+
+    def emit_instruction(self, instruction: Instr) -> None:
+        if not instruction.opcode.startswith(("M_", "V_", "S_", "C_", "H_")):
+            raise ValueError(f"unknown final-schedule opcode {instruction.opcode!r}")
+        stage = self.stage
+        operands = tuple(render_arg(arg) for arg in instruction.args)
+        active = None if instruction.active is None else asdict(instruction.active)
+        sram = tuple(asdict(entry) for entry in instruction.sram)
+        leaf = TraceInstruction(
+            stage=stage,
+            opcode=instruction.opcode,
+            operands=operands,
+            variant=instruction.variant,
+            active=active,
+            sram=sram,
+            multiplicity=self.multiplier,
+        )
+        key = leaf.key()
+        old = self._instructions.get(key)
+        if old is None:
+            self._instructions[key] = leaf
+        else:
+            self._instructions[key] = TraceInstruction(
+                stage=old.stage,
+                opcode=old.opcode,
+                operands=old.operands,
+                variant=old.variant,
+                active=old.active,
+                sram=old.sram,
+                multiplicity=old.multiplicity + leaf.multiplicity,
+            )
+        self._raw_instruction_count += 1
+        self._schedule_digest.update(instruction.render().encode())
+        self._schedule_digest.update(b"\n")
+        if instruction.dma is not None:
+            self.emit_dma(instruction.dma)
+
+    def emit_dma(self, transfer: DmaTransfer) -> None:
+        if transfer.opcode not in {"H_PREFETCH_M", "H_PREFETCH_V", "H_STORE_V"}:
+            raise ValueError(f"unsupported DMA opcode {transfer.opcode!r}")
+        self._dmas.append(
+            TraceDma(
+                stage=self.stage,
+                transfer=transfer,
+                multiplicity=self.multiplier,
+                repeat_axes=tuple(self._axis_stack) + transfer.axes,
+            )
+        )
+
+    def begin_repeat(self, count: int, axis: RepeatAxis | None, kind: str) -> None:
+        if count < 0:
+            raise ValueError(f"repeat count must be nonnegative, got {count}")
+        self._multiplier_stack.append(self.multiplier * count)
+        if axis is not None:
+            self._axis_stack.append(axis)
+        self._symbolic_repeat_count += 1
+
+    def end_repeat(self, count: int, axis: RepeatAxis | None, kind: str) -> None:
+        if axis is not None:
+            if not self._axis_stack or self._axis_stack[-1] != axis:
+                raise ValueError("unbalanced affine repeat axis")
+            self._axis_stack.pop()
+        if len(self._multiplier_stack) == 1:
+            raise ValueError("unbalanced repeat")
+        self._multiplier_stack.pop()
+
+    def consume(self, schedule: Sequence) -> None:
+        _walk(schedule, self)
+
+    def finish(self, **metadata: Any) -> CostTrace:
+        if self._stage_stack or len(self._multiplier_stack) != 1 or self._axis_stack:
+            raise ValueError("cannot finish an unbalanced final schedule")
+        merged_dma = _merge_dma_events(self._dmas)
+        trace_metadata = {
+            "trace_fidelity": "exact_final_schedule",
+            "ordered_schedule_available": True,
+            "materialized_dynamic_instructions": 0,
+            "symbolic_repeat_nodes": self._symbolic_repeat_count,
+            "materialized_schedule_leaves": self._raw_instruction_count,
+            **metadata,
+        }
+        return CostTrace(
+            schema_version=TRACE_SCHEMA_VERSION,
+            isa_hash=self._schedule_digest.hexdigest(),
+            compiler_hash=self.compiler_hash,
+            instructions=tuple(sorted(self._instructions.values(), key=lambda item: item.key())),
+            dma_events=tuple(merged_dma),
+            metadata=trace_metadata,
+        )
+
+
+def _walk(sequence: Sequence, sink: ProgramSink) -> None:
+    for item in sequence.items:
+        if isinstance(item, str):
+            _walk(parse_legacy_asm(item), sink)
+        elif isinstance(item, Comment):
+            continue
+        elif isinstance(item, Instr):
+            sink.emit_instruction(item)
+        elif isinstance(item, Sequence):
+            _walk(item, sink)
+        elif isinstance(item, Stage):
+            sink.begin_stage(item.path)
+            _walk(item.body, sink)
+            sink.end_stage(item.path)
+        elif isinstance(item, CompileTimeRepeat):
+            sink.begin_repeat(item.count, item.axis, "compile-time")
+            _walk(item.body, sink)
+            sink.end_repeat(item.count, item.axis, "compile-time")
+        elif isinstance(item, HardwareLoop):
+            # The loop setup executes once; the body and C_LOOP_END execute for
+            # every effective iteration in the current emulator semantics.
+            sink.emit_instruction(Instr("C_LOOP_START", (item.loop_register, item.count)))
+            dynamic_count = item.effective_count if item.effective_count is not None else item.count
+            sink.begin_repeat(dynamic_count, item.axis, "hardware")
+            _walk(item.body, sink)
+            sink.emit_instruction(Instr("C_LOOP_END", (item.loop_register,)))
+            sink.end_repeat(dynamic_count, item.axis, "hardware")
+        else:
+            raise TypeError(f"unsupported final schedule node {type(item).__name__}")
+
+
+def _merge_dma_events(events: list[TraceDma]) -> list[TraceDma]:
+    merged: dict[str, TraceDma] = {}
+    for event in events:
+        payload = {
+            "stage": event.stage,
+            "transfer": asdict(event.transfer),
+            "repeat_axes": [asdict(axis) for axis in event.repeat_axes],
+        }
+        key = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        old = merged.get(key)
+        if old is None:
+            merged[key] = event
+        else:
+            merged[key] = TraceDma(
+                stage=old.stage,
+                transfer=old.transfer,
+                multiplicity=old.multiplicity + event.multiplicity,
+                repeat_axes=old.repeat_axes,
+            )
+    return [merged[key] for key in sorted(merged)]
+
+
+__all__ = [
+    "AsmSink",
+    "CostTrace",
+    "ProgramSink",
+    "SymbolicCostSink",
+    "TRACE_SCHEMA_VERSION",
+    "TraceDma",
+    "TraceInstruction",
+]

--- a/aten/tests/test_cost_frontend.py
+++ b/aten/tests/test_cost_frontend.py
@@ -32,6 +32,7 @@ def test_dense_shape_frontend_uses_real_compiler_schedule():
         CompilerHardwareSpec(mlen=64, blen=4),
         seq_len=16,
         batch_size=1,
+        num_layers=1,
         include_assembly=True,
     )
     counts = result.trace.dynamic_opcode_counts
@@ -98,12 +99,17 @@ def test_production_routes_must_use_summary_backend():
 def test_dense_summary_is_opcode_and_dma_exact(seq_len):
     hardware = CompilerHardwareSpec(mlen=64, blen=4, mram_tile_capacity=2)
     detailed = compile_dense_decoder_trace(
-        _dense_model(), hardware, seq_len=seq_len, cost_trace_granularity="detailed"
+        _dense_model(),
+        hardware,
+        seq_len=seq_len,
+        num_layers=1,
+        cost_trace_granularity="detailed",
     )
     summary = compile_dense_decoder_trace(
         _dense_model(),
         hardware,
         seq_len=seq_len,
+        num_layers=1,
         cost_trace_granularity=COST_TRACE_GRANULARITY_SUMMARY,
     )
 
@@ -111,6 +117,49 @@ def test_dense_summary_is_opcode_and_dma_exact(seq_len):
     assert _dma_occurrences(summary) == _dma_occurrences(detailed)
     assert summary.trace.metadata["materialized_dynamic_instructions"] == 0
     assert summary.trace.metadata["ordered_schedule_available"] is False
+
+
+def test_dense_summary_materializes_model_layer_repeat():
+    hardware = CompilerHardwareSpec(mlen=64, blen=4, mram_tile_capacity=2)
+    one = compile_dense_decoder_trace(
+        _dense_model(),
+        hardware,
+        seq_len=16,
+        num_layers=1,
+        cost_trace_granularity=COST_TRACE_GRANULARITY_SUMMARY,
+    )
+    three = compile_dense_decoder_trace(
+        _dense_model(),
+        hardware,
+        seq_len=16,
+        num_layers=3,
+        cost_trace_granularity=COST_TRACE_GRANULARITY_SUMMARY,
+    )
+
+    def stage_counts(result, prefix):
+        counts = {}
+        for item in result.trace.instructions:
+            if item.stage.startswith(prefix):
+                counts[item.opcode] = counts.get(item.opcode, 0) + item.multiplicity
+        return counts
+
+    assert stage_counts(three, "decoder/layer") == {
+        opcode: 3 * count
+        for opcode, count in stage_counts(one, "decoder/layer").items()
+    }
+    assert stage_counts(three, "global/setup") == stage_counts(one, "global/setup")
+    assert three.trace.metadata["layer_scaling_required"] is False
+
+
+def test_dense_detailed_rejects_implicit_multilayer_expansion():
+    with pytest.raises(ValueError, match="use summary mode"):
+        compile_dense_decoder_trace(
+            _dense_model(),
+            CompilerHardwareSpec(mlen=64, blen=4),
+            seq_len=16,
+            num_layers=2,
+            cost_trace_granularity="detailed",
+        )
 
 
 def test_routed_moe_summary_matches_detailed_without_route_objects():

--- a/aten/tests/test_cost_frontend.py
+++ b/aten/tests/test_cost_frontend.py
@@ -1,0 +1,89 @@
+import pytest
+
+from compiler.aten.cost_frontend import (
+    CompilerHardwareSpec,
+    DecoderModelSpec,
+    RoutingHistogram,
+    compile_dense_decoder_trace,
+    compile_routed_moe_trace,
+)
+
+
+def _dense_model():
+    return DecoderModelSpec(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=64,
+        num_hidden_layers=2,
+        model_type="llama",
+    )
+
+
+def test_dense_shape_frontend_uses_real_compiler_schedule():
+    result = compile_dense_decoder_trace(
+        _dense_model(),
+        CompilerHardwareSpec(mlen=64, blen=4),
+        seq_len=16,
+        batch_size=1,
+        include_assembly=True,
+    )
+    counts = result.trace.dynamic_opcode_counts
+    assert counts["M_MM"] > 0
+    assert counts["V_RED_SUM"] > 0
+    assert counts["H_PREFETCH_M"] > 0
+    assert result.trace.dma_events
+    assert all(event.stage for event in result.trace.dma_events)
+    assert result.assembly is not None
+
+
+def test_routing_histogram_is_required_and_conservative():
+    with pytest.raises(ValueError, match="expected"):
+        RoutingHistogram((1, 1), token_count=2, top_k=2)
+
+
+def test_tiny_routed_moe_frontend_has_router_expert_and_combine_stages():
+    model = DecoderModelSpec(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=64,
+        model_type="qwen3_moe",
+        num_experts=32,
+        experts_per_token=4,
+        moe_intermediate_size=64,
+    )
+    routing = RoutingHistogram.balanced(token_count=1, top_k=4, num_experts=32)
+    result = compile_routed_moe_trace(
+        model,
+        CompilerHardwareSpec(mlen=64, blen=4),
+        routing,
+    )
+    stages = {instruction.stage for instruction in result.trace.instructions}
+    assert "decoder/moe/router" in stages
+    assert "decoder/moe/expert" in stages
+    assert "decoder/moe/combine" in stages
+    assert result.trace.dynamic_opcode_counts["V_TOPK"] == 1
+
+
+def test_production_routes_must_use_summary_backend():
+    model = DecoderModelSpec(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=64,
+        model_type="gpt_oss",
+        num_experts=2,
+        experts_per_token=1,
+        moe_intermediate_size=64,
+    )
+    routing = RoutingHistogram((5000, 0), token_count=5000, top_k=1)
+    with pytest.raises(ValueError, match="summary mode"):
+        compile_routed_moe_trace(
+            model,
+            CompilerHardwareSpec(mlen=64, blen=4),
+            routing,
+        )

--- a/aten/tests/test_cost_frontend.py
+++ b/aten/tests/test_cost_frontend.py
@@ -7,6 +7,11 @@ from compiler.aten.cost_frontend import (
     compile_dense_decoder_trace,
     compile_routed_moe_trace,
 )
+from compiler.aten.program_sink import COST_TRACE_GRANULARITY_SUMMARY
+
+
+def _dma_occurrences(result):
+    return sum(event.multiplicity for event in result.trace.dma_events)
 
 
 def _dense_model():
@@ -87,3 +92,81 @@ def test_production_routes_must_use_summary_backend():
             CompilerHardwareSpec(mlen=64, blen=4),
             routing,
         )
+
+
+@pytest.mark.parametrize("seq_len", [16, 96])
+def test_dense_summary_is_opcode_and_dma_exact(seq_len):
+    hardware = CompilerHardwareSpec(mlen=64, blen=4, mram_tile_capacity=2)
+    detailed = compile_dense_decoder_trace(
+        _dense_model(), hardware, seq_len=seq_len, cost_trace_granularity="detailed"
+    )
+    summary = compile_dense_decoder_trace(
+        _dense_model(),
+        hardware,
+        seq_len=seq_len,
+        cost_trace_granularity=COST_TRACE_GRANULARITY_SUMMARY,
+    )
+
+    assert summary.trace.dynamic_opcode_counts == detailed.trace.dynamic_opcode_counts
+    assert _dma_occurrences(summary) == _dma_occurrences(detailed)
+    assert summary.trace.metadata["materialized_dynamic_instructions"] == 0
+    assert summary.trace.metadata["ordered_schedule_available"] is False
+
+
+def test_routed_moe_summary_matches_detailed_without_route_objects():
+    model = DecoderModelSpec(
+        hidden_size=128,
+        intermediate_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=32,
+        model_type="qwen3_moe",
+        num_experts=32,
+        experts_per_token=4,
+        moe_intermediate_size=64,
+    )
+    hardware = CompilerHardwareSpec(mlen=32, blen=4, mram_tile_capacity=2)
+    routing = RoutingHistogram.balanced(token_count=5, top_k=4, num_experts=32)
+    detailed = compile_routed_moe_trace(model, hardware, routing)
+    summary = compile_routed_moe_trace(
+        model,
+        hardware,
+        routing,
+        cost_trace_granularity=COST_TRACE_GRANULARITY_SUMMARY,
+    )
+
+    assert summary.trace.dynamic_opcode_counts == detailed.trace.dynamic_opcode_counts
+    assert _dma_occurrences(summary) == _dma_occurrences(detailed)
+    assert summary.trace.metadata["route_object_count"] == 0
+    assert summary.trace.metadata["expert_template_count"] > 0
+
+
+def test_routed_moe_summary_chunks_to_main_fpram_capacity():
+    model = DecoderModelSpec(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=64,
+        model_type="qwen3_moe",
+        num_experts=32,
+        experts_per_token=4,
+        moe_intermediate_size=64,
+    )
+    routing = RoutingHistogram.skewed(
+        token_count=121,
+        top_k=4,
+        num_experts=32,
+        hot_fraction=0.5,
+    )
+    summary = compile_routed_moe_trace(
+        model,
+        CompilerHardwareSpec(mlen=64, blen=4),
+        routing,
+        cost_trace_granularity=COST_TRACE_GRANULARITY_SUMMARY,
+    )
+
+    assert summary.trace.metadata["route_object_count"] == 0
+    assert summary.trace.metadata["expert_chunk_count"] > model.num_experts
+    assert summary.trace.metadata["route_storage_mode"] == "streamed-histogram-scratch"
+    assert summary.trace.metadata["max_routes_per_chunk"] == 120

--- a/aten/tests/test_program_sink.py
+++ b/aten/tests/test_program_sink.py
@@ -57,6 +57,26 @@ def test_symbolic_sink_counts_hardware_loops_without_expansion():
     assert trace.metadata["materialized_schedule_leaves"] == 3
 
 
+def test_legacy_loop_text_is_refolded_before_cost_collection():
+    schedule = IsaBuilder().stage(
+        "decoder/legacy",
+        IsaBuilder().raw(
+            "C_LOOP_START gp6, 7\n"
+            "V_ADD_VV gp1, gp2, gp3, 0\n"
+            "C_LOOP_END gp6\n"
+        ),
+    )
+    sink = SymbolicCostSink()
+    # final_sequence is normally called by IsaEmitMixin; exercise that path by
+    # emitting the raw body as a standalone final schedule.
+    from compiler.aten.isa_builder import final_sequence
+
+    sink.consume(final_sequence(schedule))
+    assert sink.finish().dynamic_opcode_counts == Counter(
+        {"C_LOOP_START": 1, "V_ADD_VV": 7, "C_LOOP_END": 7}
+    )
+
+
 def test_dma_metadata_fails_closed_without_a_stage():
     dma = DmaTransfer(
         opcode="H_PREFETCH_M",

--- a/aten/tests/test_program_sink.py
+++ b/aten/tests/test_program_sink.py
@@ -99,3 +99,14 @@ def test_unknown_opcode_fails_closed():
     sink = SymbolicCostSink()
     with pytest.raises(ValueError, match="unknown final-schedule opcode"):
         sink.consume(schedule.finalized())
+
+
+def test_hbm_opcode_without_dma_geometry_fails_closed():
+    schedule = IsaBuilder().stage(
+        "decoder/test",
+        IsaBuilder().instr("H_PREFETCH_M", gp(1), gp(2), "a0", 1, 0),
+    )
+    sink = SymbolicCostSink()
+    sink.consume(schedule.finalized())
+    with pytest.raises(ValueError, match="incomplete final-schedule DMA coverage"):
+        sink.finish()

--- a/aten/tests/test_program_sink.py
+++ b/aten/tests/test_program_sink.py
@@ -5,6 +5,7 @@ import pytest
 from compiler.aten.isa_builder import (
     ActiveDimensions,
     DmaTransfer,
+    Instr,
     IsaBuilder,
     RepeatAxis,
     SramActivity,
@@ -110,3 +111,34 @@ def test_hbm_opcode_without_dma_geometry_fails_closed():
     sink.consume(schedule.finalized())
     with pytest.raises(ValueError, match="incomplete final-schedule DMA coverage"):
         sink.finish()
+
+
+def test_summary_template_replay_normalizes_enclosing_repeat():
+    dma = DmaTransfer(
+        opcode="H_PREFETCH_M",
+        direction="read",
+        role="weight",
+        element_base_bytes=0,
+        scale_base_bytes=4096,
+        dim=64,
+        amount=4,
+        stride_bytes=4096,
+    )
+    layer_axis = RepeatAxis.from_mapping("layer", 3, {"hbm": 8192})
+    sink = SymbolicCostSink(granularity="affine-block-summary-v1")
+    sink.begin_stage("decoder/layer")
+    sink.begin_repeat(3, layer_axis, "model-layer")
+    sink.begin_template(("projection",))
+    sink.emit_instruction(Instr("M_MM"))
+    sink.emit_instruction(Instr("H_PREFETCH_M", dma=dma))
+    sink.end_template(("projection",))
+    assert sink.replay_template(("projection",), count=4)
+    sink.end_repeat(3, layer_axis, "model-layer")
+    sink.end_stage("decoder/layer")
+
+    trace = sink.finish()
+    assert trace.dynamic_opcode_counts == Counter(
+        {"M_MM": 15, "H_PREFETCH_M": 15}
+    )
+    assert sum(event.multiplicity for event in trace.dma_events) == 15
+    assert all(event.repeat_axes == (layer_axis,) for event in trace.dma_events)

--- a/aten/tests/test_program_sink.py
+++ b/aten/tests/test_program_sink.py
@@ -1,0 +1,81 @@
+from collections import Counter
+
+import pytest
+
+from compiler.aten.isa_builder import (
+    ActiveDimensions,
+    DmaTransfer,
+    IsaBuilder,
+    RepeatAxis,
+    SramActivity,
+    gp,
+)
+from compiler.aten.program_sink import AsmSink, SymbolicCostSink
+
+
+def test_asm_sink_matches_builder_render_byte_for_byte():
+    body = IsaBuilder().instr("V_ADD_VV", gp(1), gp(2), gp(3), 0)
+    builder = (
+        IsaBuilder()
+        .comment("fixture")
+        .stage("decoder/attention", IsaBuilder().hardware_loop(gp(7), 3, body))
+    )
+
+    sink = AsmSink()
+    sink.consume(builder.finalized())
+
+    assert sink.render() == builder.render()
+
+
+def test_symbolic_sink_counts_hardware_loops_without_expansion():
+    body = IsaBuilder().instr(
+        "V_MUL_VV",
+        gp(1),
+        gp(2),
+        gp(3),
+        0,
+        active=ActiveDimensions(lanes=32, total_lanes=64),
+        sram=(SramActivity("vector", "read", accesses=2),),
+    )
+    schedule = IsaBuilder().stage(
+        "decoder/ffn",
+        IsaBuilder().hardware_loop(
+            gp(6),
+            1_000_000,
+            body,
+            axis=RepeatAxis.from_mapping("row", 1_000_000, {"vram": 64}),
+        ),
+    )
+    sink = SymbolicCostSink(compiler_hash="fixture")
+    sink.consume(schedule.finalized())
+    trace = sink.finish()
+
+    assert trace.dynamic_opcode_counts == Counter(
+        {"C_LOOP_START": 1, "V_MUL_VV": 1_000_000, "C_LOOP_END": 1_000_000}
+    )
+    assert trace.metadata["materialized_dynamic_instructions"] == 0
+    assert trace.metadata["materialized_schedule_leaves"] == 3
+
+
+def test_dma_metadata_fails_closed_without_a_stage():
+    dma = DmaTransfer(
+        opcode="H_PREFETCH_M",
+        direction="read",
+        role="weight",
+        element_base_bytes=0,
+        scale_base_bytes=4096,
+        dim=64,
+        amount=4,
+        stride_bytes=4096,
+    )
+    schedule = IsaBuilder().instr("H_PREFETCH_M", gp(1), gp(2), "a0", 1, 0, dma=dma)
+    sink = SymbolicCostSink()
+    with pytest.raises(ValueError, match="no stage ownership"):
+        sink.consume(schedule.finalized())
+
+
+def test_unknown_opcode_fails_closed():
+    schedule = IsaBuilder().stage("decoder/test", IsaBuilder().instr("X_MAGIC"))
+    sink = SymbolicCostSink()
+    with pytest.raises(ValueError, match="unknown final-schedule opcode"):
+        sink.consume(schedule.finalized())


### PR DESCRIPTION
Adds a compiler-assisted symbolic CostTrace generated from the final lowered schedule.

## Main changes
- Shared assembly and symbolic cost sinks
- Exact dynamic opcode and DMA accounting
- Structured repeat and affine-repeat representation
- Dense and routed-MoE decoder support
- Algebraic trace compression without expanding dynamic instructions

## Validation
- Detailed and compressed traces have identical opcode and DMA totals
- Dense and routed-MoE focused tests pass
- Unknown opcodes, variants, DMA roles, and routing inputs fail closed

## Companion PR
The corresponding Simulator analytical latency PR is opened separately and points to this branch commit.