### PR TITLE
Legalise over-wide immediates so geometries at MLEN 512 compile

### DIFF
--- a/asm_templates/_imm.py
+++ b/asm_templates/_imm.py
@@ -12,7 +12,13 @@ the single source of truth.
 
 from __future__ import annotations
 
+import re
+
 IMM2_BOUND = 1 << 18  # S_ADDI_INT supports values 0..2^18-1
+
+_ADDI_PATTERN = re.compile(
+    r"^\s*S_ADDI_INT\s+gp(?P<dest>\d+)\s*,\s*gp(?P<source>\d+)\s*,\s*(?P<imm>\d+)\s*$"
+)
 
 
 def load_large_int(reg: int, value: int) -> list[str]:
@@ -32,6 +38,9 @@ def load_large_int(reg: int, value: int) -> list[str]:
     return lines
 
 
+CHUNK_LIMIT = 256  # chunked fallback ceiling; larger expansions fail loudly
+
+
 def add_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int | None = None) -> list[str]:
     """Return ASM lines for `gp{dest_reg} = gp{src_reg} + value`.
 
@@ -42,9 +51,12 @@ def add_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int | None 
     must not alias src_reg, because loading the immediate would clobber the
     source value before the add.
 
-    When `temp_reg` is omitted, larger values are emitted as a sequence of
-    bounded S_ADDI_INT chunks. This fallback is less compact but is safe in a
-    compiler-wide legalization pass because it requires no scratch register.
+    Without a temp register, a non-aliasing destination serves as its own
+    temporary: the immediate is materialised into dest_reg and added to
+    src_reg, since dest_reg is overwritten either way. Only the aliasing case
+    (dest_reg == src_reg) falls back to bounded S_ADDI_INT chunks; that
+    expansion is capped at CHUNK_LIMIT instructions so a pathological
+    immediate fails loudly instead of flooding the program.
     """
     if value < 0:
         raise ValueError(f"large immediate helpers only support non-negative values, got {value}")
@@ -56,10 +68,22 @@ def add_large_int(dest_reg: int, src_reg: int, value: int, temp_reg: int | None 
         lines.append(f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{temp_reg}")
         return lines
 
-    lines: list[str] = []
+    if dest_reg != src_reg:
+        lines = load_large_int(dest_reg, value)
+        lines.append(f"S_ADD_INT gp{dest_reg}, gp{src_reg}, gp{dest_reg}")
+        return lines
+
+    chunk = IMM2_BOUND - 1
+    chunk_count = -(-value // chunk)
+    if chunk_count > CHUNK_LIMIT:
+        raise ValueError(
+            f"chunked immediate add of {value} to gp{src_reg} needs "
+            f"{chunk_count} instructions (limit {CHUNK_LIMIT}); provide a "
+            "temp register or a non-aliasing destination"
+        )
+    lines = []
     remaining = value
     source = src_reg
-    chunk = IMM2_BOUND - 1
     while remaining:
         step = min(remaining, chunk)
         lines.append(f"S_ADDI_INT gp{dest_reg}, gp{source}, {step}")
@@ -86,3 +110,41 @@ def add_large_int_str(dest_reg: int, src_reg: int, value: int, temp_reg: int | N
 def addi_large_int_str(dest_reg: int, src_reg: int, value: int, temp_reg: int) -> str:
     """String variant of addi_large_int."""
     return add_large_int_str(dest_reg, src_reg, value, temp_reg=temp_reg)
+
+
+def legalize_immediates(assembly: str) -> str:
+    """Rewrite every `S_ADDI_INT` whose immediate exceeds the encoding field.
+
+    The templates build addresses and strides from raw text, and several of
+    those strides are `MLEN * MLEN`, which reaches exactly `2**18` at MLEN=512
+    and overflows the 18-bit immediate. Legalising the emitted text covers every
+    template at once, including ones that do not yet route their arithmetic
+    through the helpers above, so a geometry cannot fail on an encoding limit
+    that has a mechanical fix.
+
+    `gp0` sources become a wide load; a non-aliasing destination becomes a
+    wide load into the destination plus one add; only an aliasing
+    destination falls back to the chunked relative add. All three forms need
+    no scratch register and so are safe to apply after register allocation.
+    """
+    output: list[str] = []
+    for line in assembly.splitlines():
+        match = _ADDI_PATTERN.match(line)
+        if match is None:
+            output.append(line)
+            continue
+        dest, source, value = (
+            int(match.group("dest")),
+            int(match.group("source")),
+            int(match.group("imm")),
+        )
+        if value < IMM2_BOUND:
+            output.append(line)
+            continue
+        replacement = (
+            load_large_int(dest, value)
+            if source == 0
+            else add_large_int(dest, source, value)
+        )
+        output.extend(replacement)
+    return "\n".join(output) + ("\n" if assembly.endswith("\n") else "")

--- a/asm_templates/tests/test_large_immediate.py
+++ b/asm_templates/tests/test_large_immediate.py
@@ -89,14 +89,36 @@ class TestLoadLargeInt(unittest.TestCase):
         self.assertIn("S_ADDI_INT gp7, gp7, 992", asm)
         self.assertIn("S_ADD_INT gp5, gp3, gp7", asm)
 
-    def test_large_add_without_temp_chunks(self):
-        """Compiler-wide fallback must not need a scratch register."""
+    def test_large_add_without_temp_uses_destination(self):
+        """A non-aliasing destination serves as its own temp register."""
         result = _add_large_int(5, 3, 300000, temp_reg=None)
         asm = "\n".join(result)
-        self.assertIn("S_ADDI_INT gp5, gp3, 262143", asm)
-        self.assertIn("S_ADDI_INT gp5, gp5, 37857", asm)
+        self.assertIn("S_LUI_INT gp5, 73", asm)
+        self.assertIn("S_ADDI_INT gp5, gp5, 992", asm)
+        self.assertIn("S_ADD_INT gp5, gp3, gp5", asm)
         self.assertNotIn("S_ADDI_INT gp5, gp3, 300000", asm)
         _check_all_addi_immediates(self, asm, "add_large_int(no temp)")
+
+    def test_large_add_aliasing_destination_chunks(self):
+        """dest == src without a temp must still not need a scratch register."""
+        result = _add_large_int(5, 5, 300000, temp_reg=None)
+        asm = "\n".join(result)
+        self.assertIn("S_ADDI_INT gp5, gp5, 262143", asm)
+        self.assertIn("S_ADDI_INT gp5, gp5, 37857", asm)
+        self.assertNotIn("S_LUI_INT", asm)
+        _check_all_addi_immediates(self, asm, "add_large_int(aliasing)")
+
+    def test_large_add_aliasing_chunk_limit(self):
+        """A pathological aliasing immediate fails loudly instead of flooding."""
+        from asm_templates._imm import CHUNK_LIMIT, IMM2_BOUND
+
+        over_limit = (IMM2_BOUND - 1) * CHUNK_LIMIT + 1
+        with self.assertRaises(ValueError):
+            _add_large_int(5, 5, over_limit, temp_reg=None)
+        # exactly at the limit still succeeds
+        at_limit = (IMM2_BOUND - 1) * CHUNK_LIMIT
+        result = _add_large_int(5, 5, at_limit, temp_reg=None)
+        self.assertEqual(len(result), CHUNK_LIMIT)
 
 
 class TestProjectionAsmLargeMatrix(unittest.TestCase):
@@ -270,7 +292,7 @@ class TestFfnAsmLargeMatrix(unittest.TestCase):
         """use_loop_instructions=True (production path) must handle large matrices."""
         ffn_asm = self._import_ffn_asm()
         args = dict(self.BASE_ARGS)
-        args["alive_registers"] = list(range(10))  # loop version needs 10
+        args["alive_registers"] = list(range(1, 12))  # loop version needs 11
         try:
             asm = ffn_asm(hidden_size=2048, intermediate_size=8192, use_loop_instructions=True, **args)
         except AssertionError as e:
@@ -282,7 +304,7 @@ class TestFfnAsmLargeMatrix(unittest.TestCase):
         """Production path with smollm2 scale (hidden=128, inter=256) all immediates bounded."""
         ffn_asm = self._import_ffn_asm()
         args = dict(self.BASE_ARGS)
-        args["alive_registers"] = list(range(10))
+        args["alive_registers"] = list(range(1, 12))
         asm = ffn_asm(hidden_size=128, intermediate_size=256, use_loop_instructions=True, **args)
         _check_all_addi_immediates(self, asm, "ffn_asm(loop,128,256)")
 
@@ -290,7 +312,7 @@ class TestFfnAsmLargeMatrix(unittest.TestCase):
         """Production loop path must place FFN temps at the explicit workspace base."""
         ffn_asm = self._import_ffn_asm()
         args = dict(self.BASE_ARGS)
-        args["alive_registers"] = list(range(10))
+        args["alive_registers"] = list(range(1, 12))
         workspace_base = 1_000_000
         rows = args["batch"] * args["seq_len"]
         gate_base = workspace_base + rows * 256
@@ -303,10 +325,13 @@ class TestFfnAsmLargeMatrix(unittest.TestCase):
             **args,
         )
 
-        self.assertIn(f"S_LUI_INT gp3, {workspace_base >> 12}", asm)
-        self.assertIn(f"S_ADDI_INT gp3, gp3, {workspace_base & 0xFFF}", asm)
-        self.assertIn(f"S_LUI_INT gp5, {gate_base >> 12}", asm)
-        self.assertIn(f"S_ADDI_INT gp5, gp5, {gate_base & 0xFFF}", asm)
+        # The template holds the up/gate result bases in alive_registers[3] and [5].
+        up_reg = args["alive_registers"][3]
+        gate_reg = args["alive_registers"][5]
+        self.assertIn(f"S_LUI_INT gp{up_reg}, {workspace_base >> 12}", asm)
+        self.assertIn(f"S_ADDI_INT gp{up_reg}, gp{up_reg}, {workspace_base & 0xFFF}", asm)
+        self.assertIn(f"S_LUI_INT gp{gate_reg}, {gate_base >> 12}", asm)
+        self.assertIn(f"S_ADDI_INT gp{gate_reg}, gp{gate_reg}, {gate_base & 0xFFF}", asm)
         _check_all_addi_immediates(self, asm, "ffn_asm(loop,workspace)")
 
 

--- a/aten/plena/compiler.py
+++ b/aten/plena/compiler.py
@@ -13,6 +13,7 @@ from compiler.aten.plena.program_routed_moe import ProgramRoutedMoeMixin
 from compiler.aten.plena.program_matrix_ops import ProgramMatrixOpsMixin
 from compiler.aten.plena.program_tensors import ProgramTensorMixin
 from compiler.aten.plena.vars import FPVar, InputVar, TensorVar
+from compiler.asm_templates._imm import legalize_immediates
 from compiler.utils.load_config import load_toml_config
 
 
@@ -140,7 +141,7 @@ class PlenaCompiler(
 
     def compile(self) -> str:
         """Get generated ISA code string."""
-        return super().get_code()
+        return legalize_immediates(super().get_code())
 
     @property
     def _compiler(self) -> PlenaCompiler:


### PR DESCRIPTION
## Bug: Over-wide immediates block compilation at MLEN 512

`S_ADDI_INT` encodes an 18-bit immediate, and `mlen * mlen` is exactly \( 2^{18} \) at `MLEN` 512. Around 30 emitter sites across the ffn, projection, gemv, and batched matmul templates pass that value as a raw immediate rather than going through the `_imm` helpers, so the assembler correctly refuses the program, and no geometry at or above `MLEN` 512 can be compiled.

## Fix

Adds a pass over emitted assembly that rewrites over-wide immediates through `S_LUI_INT`:

- A `gp0` source becomes a wide load.
- A non-aliasing destination becomes a wide load into the destination plus one add.
- Only an aliasing destination falls back to a chunked relative add.

None of the three cases needs a scratch register, so the pass is safe to run after register allocation.

The chunked fallback is capped so a pathological immediate fails with a clear error rather than emitting an unbounded instruction sequence.